### PR TITLE
Enable release build optimisations

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -134,7 +134,12 @@ android {
     }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+
             signingConfig = signingConfigs.getByName("debug") // TODO remove this
         }
     }
@@ -181,7 +186,7 @@ sqldelight {
 
 tasks.register<SqlDelightTmdbCacheDefinitionsGenerator>("generateSqldelightTmdbCacheDefinitions")
 
-tasks.whenTaskAdded {
+tasks.configureEach {
     if (this.name == "generateCommonMainTmdbCacheInterface") {
         dependsOn += "generateSqldelightTmdbCacheDefinitions"
     }

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -1,0 +1,4 @@
+-dontwarn javax.swing.*
+-dontwarn com.intellij.icons.*
+-dontwarn org.slf4j.impl.*
+-dontwarn reactor.blockhound.**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,10 @@ androidx-espresso-core = "3.6.0"
 androidx-material = "1.12.0"
 androidx-lifecycle = "2.8.2"
 androidx-test-junit = "1.2.1"
-compose = "1.6.8"
+# Version 1.6.x has some minor binary incompatiblties with androidx-lifecycle 2.8.x.
+# Using 1.7.x allows us to use libraries that are perfectly compatible, which allows to enable build optimisations.
+# See issue https://issuetracker.google.com/issues/336842920
+compose = "1.7.0-beta03"
 compose-plugin = "1.6.11"
 junit = "4.13.2"
 kotlin = "2.0.0"


### PR DESCRIPTION
This has significant positive impact in runtime performance, and allows us to see how the app will behave when released.

### Implementation details

I encountered two bugs:
1.  A binary incompatibility with two library, which will be fixed in the next compose-ui release. To mitigate, I'm using the latest beta version of the next release.
    See https://issuetracker.google.com/issues/336842920
2. `whenTaskAdded` breaks the build with a random error. I had to change it to `configureEach`. Fortunately it works the same for our use-case. 
    See https://issuetracker.google.com/issues/277166577

### References:
 - Performance guide: https://developer.android.com/develop/ui/compose/performance#config
 - How to enable optimizations: https://developer.android.com/build/shrink-code#enable