### PR TITLE
Movie screen improvements

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/App.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/App.kt
@@ -1,20 +1,33 @@
 package io.github.couchtracker
 
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import io.github.couchtracker.ui.AnimationDefaults
 import io.github.couchtracker.ui.screens.main.MainScreen
 import io.github.couchtracker.ui.screens.movieScreen
 import org.koin.compose.KoinContext
+import kotlin.math.roundToInt
 
 val LocalNavController = staticCompositionLocalOf<NavController> { error("no default nav controller") }
+
+private const val ANIMATION_SLIDE = 0.25f
+private val FADE_ANIMATION_SPEC = tween<Float>(AnimationDefaults.ANIMATION_DURATION_MS)
 
 @Composable
 fun App() {
@@ -23,7 +36,26 @@ fun App() {
         MaterialTheme(colorScheme = darkColorScheme()) {
             CompositionLocalProvider(LocalNavController provides navController) {
                 Surface(color = MaterialTheme.colorScheme.background) {
-                    NavHost(navController = navController, startDestination = "main") {
+                    NavHost(
+                        navController = navController,
+                        startDestination = "main",
+                        enterTransition = {
+                            val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = LinearOutSlowInEasing)
+                            slideInVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
+                                fadeIn(FADE_ANIMATION_SPEC)
+                        },
+                        exitTransition = {
+                            fadeOut(FADE_ANIMATION_SPEC)
+                        },
+                        popEnterTransition = {
+                            fadeIn(FADE_ANIMATION_SPEC)
+                        },
+                        popExitTransition = {
+                            val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = FastOutLinearInEasing)
+                            slideOutVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
+                                fadeOut(FADE_ANIMATION_SPEC)
+                        },
+                    ) {
                         composable("main") {
                             MainScreen()
                         }

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/AnimationDefaults.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/AnimationDefaults.kt
@@ -1,0 +1,5 @@
+package io.github.couchtracker.ui
+
+object AnimationDefaults {
+    const val ANIMATION_DURATION_MS = 350
+}

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
@@ -58,10 +58,9 @@ fun <T : Any> LoadableScreen(
     // Animating the appearance of the Loading state
     val state = remember {
         MutableTransitionState(
-            initialState = if (data is Loadable.Loading) {
-                null
-            } else {
-                data
+            initialState = when (data) {
+                is Loadable.Loading -> null
+                else -> data
             },
         )
     }

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
@@ -1,0 +1,122 @@
+@file:OptIn(ExperimentalTransitionApi::class)
+
+package io.github.couchtracker.ui.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.ExperimentalTransitionApi
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import couch_tracker_app.composeapp.generated.resources.Res
+import couch_tracker_app.composeapp.generated.resources.retry_action
+import io.github.couchtracker.utils.Loadable
+import io.github.couchtracker.utils.str
+
+private const val ANIMATION_DURATION_MS = 300
+private val DEFAULT_INDICATOR_SIZE = 64.dp
+
+/**
+ * A Composable to use at the root of the screen, when the content can also be loading or in error.
+ * This Composable is optimised to minimise the visual impact of the loading state, as it often
+ * appears.
+ * In particular, the loading screen:
+ *  - has no background
+ *  - animates its appearance (even if it's the initial state)
+ *  - it shows up with a delay
+ */
+@Composable
+fun <T : Any> LoadableScreen(
+    data: Loadable<T>,
+    onLoading: @Composable () -> Unit = { DefaultLoadingScreen() },
+    onError: @Composable (message: String) -> Unit = { DefaultErrorScreen(it) },
+    onLoaded: @Composable (value: T) -> Unit,
+) {
+    // Animating the appearance of the Loading state
+    val state = remember {
+        MutableTransitionState(
+            initialState = if (data is Loadable.Loading) {
+                null
+            } else {
+                data
+            },
+        )
+    }
+    state.targetState = data
+
+    val transition = rememberTransition(state)
+    transition.AnimatedContent(
+        Modifier,
+        contentKey = { it?.javaClass },
+        transitionSpec = {
+            val fadeInDelay = if (targetState is Loadable.Loading) {
+                ANIMATION_DURATION_MS / 2
+            } else {
+                0
+            }
+            fadeIn(tween(ANIMATION_DURATION_MS, delayMillis = fadeInDelay)) togetherWith
+                fadeOut(tween(ANIMATION_DURATION_MS))
+        },
+    ) { content ->
+        when (content) {
+            null -> Spacer(Modifier.fillMaxSize())
+            Loadable.Loading -> onLoading()
+            is Loadable.Error -> onError(content.message)
+            is Loadable.Loaded -> onLoaded(content.value)
+        }
+    }
+}
+
+@Composable
+fun DefaultLoadingScreen() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator(
+            Modifier.size(DEFAULT_INDICATOR_SIZE),
+            strokeWidth = 6.dp,
+        )
+    }
+}
+
+@Composable
+fun DefaultErrorScreen(errorMessage: String, retry: (() -> Unit)? = null) {
+    Surface {
+        Column(
+            Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(Icons.Filled.Error, contentDescription = null, modifier = Modifier.size(DEFAULT_INDICATOR_SIZE))
+            Spacer(Modifier.height(16.dp))
+            Text(errorMessage, textAlign = TextAlign.Center)
+            if (retry != null) {
+                Spacer(Modifier.height(16.dp))
+                Button(retry) {
+                    Text(Res.string.retry_action.str())
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
@@ -30,9 +30,9 @@ import io.github.couchtracker.ui.generateColorScheme
 import io.github.couchtracker.utils.str
 import org.jetbrains.compose.resources.StringResource
 
-private val HOME_COLOR_SCHEME = Color.hsv(240f, 1f, 0.5f).generateColorScheme()
-private val SHOW_COLOR_SCHEME = Color.hsv(0f, 1f, 0.5f).generateColorScheme()
-private val MOVIE_COLOR_SCHEME = Color.hsv(180f, 1f, 0.5f).generateColorScheme()
+val HOME_COLOR_SCHEME = Color.hsv(240f, 1f, 0.5f).generateColorScheme()
+val SHOW_COLOR_SCHEME = Color.hsv(0f, 1f, 0.5f).generateColorScheme()
+val MOVIE_COLOR_SCHEME = Color.hsv(180f, 1f, 0.5f).generateColorScheme()
 
 @Composable
 fun MainScreen() {

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Animation.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Animation.kt
@@ -1,0 +1,3 @@
+package io.github.couchtracker.utils
+
+const val DEFAULT_ANIMATION_DURATION_MS = 350

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Animation.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Animation.kt
@@ -1,3 +1,0 @@
-package io.github.couchtracker.utils
-
-const val DEFAULT_ANIMATION_DURATION_MS = 350

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Loadable.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Loadable.kt
@@ -1,0 +1,7 @@
+package io.github.couchtracker.utils
+
+sealed interface Loadable<out T> {
+    data object Loading : Loadable<Nothing>
+    data class Error(val message: String) : Loadable<Nothing>
+    data class Loaded<T>(val value: T) : Loadable<T>
+}

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="back_action">Indietro</string>
+    <string name="retry_action">Riprova</string>
 
     <string name="main_section_home">Home</string>
     <string name="main_section_shows">Serie</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="back_action">Back</string>
+    <string name="retry_action">Retry</string>
 
     <string name="main_section_home">Home</string>
     <string name="main_section_shows">Shows</string>


### PR DESCRIPTION
The goal of this PR is to add animations when opening the movie screen.

The main challenges are:
- Performances. I chose an animation that doesn't "move" the content too fast, so stutters are less noticeable. I also moved more work on background threads
- Loading state. For a few frames, while the movie loads, both the content _and_ the color scheme is not ready. I reworked the loading state so it has a transparent background, and the progress bar shows with a delay. This makes the loading seamless and almost invisible when opening a movie that is already cached locally
