### PR TITLE
Movie grid

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/App.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/App.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import io.github.couchtracker.ui.AnimationDefaults
 import io.github.couchtracker.ui.screens.main.MainScreen
+import io.github.couchtracker.ui.screens.movieScreen
 import org.koin.compose.KoinContext
 import kotlin.math.roundToInt
 
@@ -59,6 +60,7 @@ fun App() {
                             composable("main") {
                                 MainScreen()
                             }
+                            movieScreen()
                         }
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/MovieGrid.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/MovieGrid.kt
@@ -1,0 +1,37 @@
+package io.github.couchtracker.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.couchtracker.LocalNavController
+import io.github.couchtracker.ui.screens.navigateToMovie
+
+@Composable
+fun MovieGrid(
+    movies: List<MoviePortraitModel>,
+) {
+    val navController = LocalNavController.current
+    LazyVerticalGrid(
+        modifier = Modifier.fillMaxSize(),
+        columns = GridCells.Adaptive(minSize = MoviePortraitModel.SUGGESTED_WIDTH),
+        contentPadding = PaddingValues(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        items(movies) { movie ->
+            MoviePortrait(
+                Modifier.fillMaxWidth(),
+                movie,
+            ) {
+                navController.navigateToMovie(movie.movie)
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -36,7 +36,7 @@ val MOVIE_COLOR_SCHEME = Color.hsv(180f, 1f, 0.5f).generateColorScheme()
 
 @Composable
 fun MainScreen() {
-    var currentSection by remember { mutableStateOf(Section.HOME) }
+    var currentSection by rememberSaveable { mutableStateOf(Section.HOME) }
     val insetTop = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top)
     MaterialTheme(colorScheme = currentSection.mainColor) {
         Scaffold(

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
@@ -4,12 +4,21 @@ package io.github.couchtracker.ui.screens.main
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import app.moviebase.tmdb.Tmdb3
+import app.moviebase.tmdb.model.TmdbDiscover
+import app.moviebase.tmdb.model.TmdbDiscoverMovieSortBy
+import app.moviebase.tmdb.model.TmdbTimeWindow
 import couch_tracker_app.composeapp.generated.resources.Res
 import couch_tracker_app.composeapp.generated.resources.aurora_borealis
 import couch_tracker_app.composeapp.generated.resources.tab_movie_calendar
@@ -17,13 +26,30 @@ import couch_tracker_app.composeapp.generated.resources.tab_movie_explore
 import couch_tracker_app.composeapp.generated.resources.tab_movie_followed
 import couch_tracker_app.composeapp.generated.resources.tab_movie_timeline
 import couch_tracker_app.composeapp.generated.resources.tab_movie_up_next
+import io.github.couchtracker.tmdb.TmdbException
+import io.github.couchtracker.tmdb.TmdbLanguage
+import io.github.couchtracker.tmdb.tmdbDownload
+import io.github.couchtracker.ui.components.DefaultErrorScreen
+import io.github.couchtracker.ui.components.LoadableScreen
+import io.github.couchtracker.ui.components.MovieGrid
+import io.github.couchtracker.ui.components.MoviePortraitModel
+import io.github.couchtracker.ui.components.toMoviePortraitModels
+import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.str
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 
+// TODO: do better
+private val LANGUAGE = TmdbLanguage.ENGLISH
+
 @Composable
 fun MoviesSection(innerPadding: PaddingValues) {
+    val context = LocalContext.current
     val pagerState = rememberPagerState(initialPage = MovieTab.EXPLORE.ordinal) { MovieTab.entries.size }
+    val movieMaxW = with(LocalDensity.current) {
+        (MoviePortraitModel.SUGGESTED_WIDTH * 2).roundToPx()
+    }
 
     MainSection(
         innerPadding = innerPadding,
@@ -31,15 +57,86 @@ fun MoviesSection(innerPadding: PaddingValues) {
         backgroundImage = painterResource(Res.drawable.aurora_borealis),
         tabText = { page -> Text(text = MovieTab.entries[page].displayName.str()) },
         page = { page ->
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                item { Text("page $page") }
-                @Suppress("MagicNumber")
-                items(100) {
-                    Text("item $it")
+            MovieListComposable { tmdb3 ->
+                val pageResult = when (MovieTab.entries[page]) {
+                    MovieTab.TIMELINE ->
+                        tmdb3.movies.popular(page = 1, LANGUAGE.apiParameter)
+
+                    MovieTab.EXPLORE ->
+                        tmdb3.trending.getTrendingMovies(TmdbTimeWindow.DAY, page = 1, LANGUAGE.apiParameter)
+
+                    MovieTab.FOLLOWED ->
+                        tmdb3.discover.discoverMovie(
+                            page = 1,
+                            language = LANGUAGE.apiParameter,
+                            region = null,
+                            TmdbDiscover.Movie(
+                                sortBy = TmdbDiscoverMovieSortBy.POPULARITY,
+                            ),
+                        )
+
+                    MovieTab.UP_NEXT ->
+                        tmdb3.discover.discoverMovie(
+                            page = 1,
+                            language = LANGUAGE.apiParameter,
+                            region = null,
+                            TmdbDiscover.Movie(
+                                sortBy = TmdbDiscoverMovieSortBy.VOTE_AVERAGE,
+                            ),
+                        )
+
+                    MovieTab.CALENDAR ->
+                        tmdb3.discover.discoverMovie(
+                            page = 1,
+                            language = LANGUAGE.apiParameter,
+                            region = null,
+                            TmdbDiscover.Movie(
+                                sortBy = TmdbDiscoverMovieSortBy.RELEASE_DATE,
+                            ),
+                        )
                 }
+                pageResult
+                    .results
+                    .toMoviePortraitModels(context, LANGUAGE, movieMaxW)
             }
         },
     )
+}
+
+// TODO: state isn't saved here. Movies are getting downloaded at every page swipe/screen change
+@Composable
+private fun MovieListComposable(
+    downloadFunction: suspend (Tmdb3) -> List<MoviePortraitModel>,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    var state by remember { mutableStateOf<Loadable<List<MoviePortraitModel>>>(Loadable.Loading) }
+
+    suspend fun download() {
+        state = Loadable.Loading
+        try {
+            val movies = tmdbDownload { tmdb3 ->
+                downloadFunction(tmdb3)
+            }
+            state = Loadable.Loaded(movies)
+        } catch (e: TmdbException) {
+            // TODO: translate
+            state = Loadable.Error(e.message ?: "Error")
+        }
+    }
+    LaunchedEffect(Unit) {
+        download()
+    }
+
+    LoadableScreen(
+        state,
+        onError = { message ->
+            DefaultErrorScreen(message) {
+                coroutineScope.launch { download() }
+            }
+        },
+    ) { movies ->
+        MovieGrid(movies)
+    }
 }
 
 private enum class MovieTab(


### PR DESCRIPTION
Still a lot to do, but a first step.

The interesting addition is that now the model for the movie portrait composable can be also created directly from the result of the "explore" TMDB APIs, so there's no need to download movies individually.

![image](https://github.com/couch-tracker/couch-tracker-app/assets/802019/74a1e923-0634-47df-bfac-e71020ad4743)