### PR TITLE
Rename ShowCollection to ShowInCollection

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/db/user/FullUserData.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/db/user/FullUserData.kt
@@ -11,7 +11,7 @@ import kotlin.time.measureTimedValue
 private const val LOG_TAG = "FullUserData"
 
 data class FullUserData(
-    val showCollection: List<ShowCollection>,
+    val showCollection: List<ShowInCollection>,
 ) {
 
     companion object {
@@ -20,7 +20,7 @@ data class FullUserData(
             Log.d(LOG_TAG, "Starting loading full user data")
             val (data, time) = measureTimedValue {
                 FullUserData(
-                    showCollection = db.showCollectionQueries.selectShowCollection().asFlow().mapToList(coroutineContext).first(),
+                    showCollection = db.showInCollectionQueries.selectShowCollection().asFlow().mapToList(coroutineContext).first(),
                 )
             }
             Log.d(LOG_TAG, "Loading full user data took $time")

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/db/user/UserDb.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/db/user/UserDb.kt
@@ -119,7 +119,7 @@ sealed class UserDb : KoinComponent {
         return driver.use {
             val db = UserData(
                 driver = driver,
-                ShowCollectionAdapter = ShowCollection.Adapter(
+                ShowInCollectionAdapter = ShowInCollection.Adapter(
                     showIdAdapter = ExternalShowId.columnAdapter(),
                     addDateAdapter = InstantColumnAdapter,
                 ),

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/UserPane.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/components/UserPane.kt
@@ -87,7 +87,7 @@ fun UserPane() {
                 coroutineScope.launch {
                     lastActionStatus = userInfo.write { db ->
                         @Suppress("MagicNumber")
-                        db.showCollectionQueries.insertShow(TmdbShowId(Random.nextInt(0, 999_999)).toExternalId())
+                        db.showInCollectionQueries.insertShow(TmdbShowId(Random.nextInt(0, 999_999)).toExternalId())
                     }
                 }
             },
@@ -103,7 +103,7 @@ fun UserPane() {
                     if (item != null) {
                         coroutineScope.launch {
                             lastActionStatus = userInfo.write { db ->
-                                db.showCollectionQueries.deleteShow(item.showId)
+                                db.showInCollectionQueries.deleteShow(item.showId)
                             }
                         }
                     }

--- a/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/ShowInCollection.sq
+++ b/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/ShowInCollection.sq
@@ -4,17 +4,17 @@ import kotlinx.datetime.Instant;
 /**
  * Saves the list of shows in the user's collection.
  */
-CREATE TABLE ShowCollection (
+CREATE TABLE ShowInCollection (
   showId TEXT AS ExternalShowId PRIMARY KEY NOT NULL,
   manualSortIndex INTEGER NOT NULL,
   addDate TEXT AS Instant NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 
 selectShowCollection:
-SELECT * FROM ShowCollection;
+SELECT * FROM ShowInCollection;
 
 insertShow:
-INSERT INTO ShowCollection(showId, manualSortIndex) VALUES (?, (SELECT COALESCE(MAX(manualSortIndex) + 1, 0) FROM ShowCollection));
+INSERT INTO ShowInCollection(showId, manualSortIndex) VALUES (?, (SELECT COALESCE(MAX(manualSortIndex) + 1, 0) FROM ShowInCollection));
 
 deleteShow:
-DELETE FROM ShowCollection WHERE showId=?;
+DELETE FROM ShowInCollection WHERE showId=?;


### PR DESCRIPTION
SQLDelight generates the class name from the table name. As the class name should represent a single item, the name `ShowCollection` is wrong.

`ShowInCollection` better represents a single item.
