### PR TITLE
Add PartialDateTime class

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -63,6 +63,7 @@ kotlin {
             // Kotlin stuff
             implementation(libs.serialization.core)
             implementation(libs.serialization.json)
+            implementation(libs.kotlinx.datetime)
 
             // Compose
             implementation(compose.runtime)

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTime.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTime.kt
@@ -1,0 +1,468 @@
+package io.github.couchtracker.db.user.datastruct.partialtime
+
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Local
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Local.Date
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Local.DateTime
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Local.Year
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Local.YearMonth
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Zoned
+import kotlinx.datetime.FixedOffsetTimeZone
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.asTimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.format
+import kotlinx.datetime.format.DateTimeComponents
+import kotlinx.datetime.format.DateTimeFormat
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.format.alternativeParsing
+import kotlinx.datetime.format.char
+import kotlinx.datetime.format.format
+import kotlinx.datetime.toInstant
+
+/**
+ * Represents a date/time value that might not have all the components present.
+ *
+ * This class is needed to store a watch date of a movie/episode, as the user might not know/remember all details of when something was
+ * watched.
+ *
+ * **Not all combinations of missing data are supported**. In ascending order of precision, when a component is unknown, all components
+ * after it must be as well. Time is considered a single indivisible component.
+ *
+ * This is done to have a cleaner UI, as supporting true partial data like "July 15 of unknown year, at unknown hour at the 45-minute mark"
+ * would make the UI needlessly more cumbersome for little benefit, as users are likely to remember all components up to a certain point
+ * anyway.
+ *
+ * Supported types are:
+ * - [Local.Year] just a year, e.g. 2024
+ * - [Local.YearMonth] year and month, e.g. July 2024
+ * - [Local.Date] date, e.g. July 12th, 2024
+ * - [Local.DateTime] date and time, e.g. July 12th, 2024 at 21:00:00
+ * - [Zoned] composes any [Local] value with a [TimeZone]
+ *
+ * Since sorting [PartialDateTime]s is a difficult task, implementing [Comparable] is not possible: the sorting algorithm needs to consider
+ * multiple factors, deciding whether A <=> B is undecidable in isolation. See [PartialDateTime.sort] for more info.
+ * However, both [Local] and [Zoned] implement [Comparable].
+ */
+sealed class PartialDateTime {
+
+    /**
+     * Returns the local part of this instance. For [Local] instance, this is the same object on which this is called
+     */
+    abstract val local: Local
+
+    /**
+     * Serializes this object to a string.
+     *
+     * @see PartialDateTime.parse for parsing the string back to a [PartialDateTime]
+     */
+    abstract fun serialize(): String
+
+    /**
+     * Returns in which [PartialDateTimeGroup] the partial date time belongs to. There is also an extension function on the nullable type
+     * that returns [PartialDateTimeGroup.Unknown] in that case.
+     */
+    abstract fun group(): PartialDateTimeGroup
+
+    /**
+     * Interface for companion object that each subclass should implement that defines a [parse] method.
+     */
+    interface ICompanion<out P : PartialDateTime> {
+
+        /**
+         * Parses the given [input] into a [P].
+         * @throws IllegalArgumentException if the input is invalid
+         */
+        fun parse(input: String): P
+    }
+
+    /**
+     * Specialization of [ICompanion] that handles parsing with a given [DateTimeFormat] of [DateTimeComponents].
+     */
+    @Suppress("VariableNaming")
+    abstract class ICompanionWithFormat<out P : PartialDateTime> : ICompanion<P> {
+        abstract val FORMAT: DateTimeFormat<DateTimeComponents>
+
+        /**
+         * Creates a [P] from the given [components].
+         * @throws IllegalArgumentException if a required component is present or is not valid
+         */
+        abstract fun fromComponents(components: DateTimeComponents): P
+
+        override fun parse(input: String): P = fromComponents(FORMAT.parse(input))
+    }
+
+    /**
+     * Specialization of [ICompanion] that handles parsing with a given list of parser functions.
+     *
+     * The result of first parser that doesn't throw [IllegalArgumentException] is propagated to the caller.
+     */
+    @Suppress("VariableNaming")
+    abstract class ICompanionWithParsers<out P : PartialDateTime> : ICompanion<P> {
+        abstract val PARSERS: List<(String) -> P>
+
+        override fun parse(input: String): P {
+            val exceptions = mutableListOf<IllegalArgumentException>()
+            for (parser in PARSERS) {
+                try {
+                    return parser(input)
+                } catch (e: IllegalArgumentException) {
+                    exceptions.add(e)
+                }
+            }
+            val messages = exceptions.mapNotNull { it.message }.joinToString(", ")
+            throw IllegalArgumentException("Invalid input: $input. Couldn't be parsed by any format: $messages")
+        }
+    }
+
+    /**
+     * Represents a date/time that has no time zone information.
+     *
+     * Implements [Comparable]. Unknown information is considered always < than more precise values.
+     *
+     * For example: `2024` < `2024-01` < `2024-01-01` < `2024-01-01T00:00:00`
+     *
+     * @see PartialDateTime
+     */
+    sealed class Local : PartialDateTime(), Comparable<Local> {
+
+        override val local get() = this
+
+        /**
+         * Converts this to an [Instant] using the provided time zone [zone].
+         * Partial information is filled in with a default value.
+         */
+        abstract fun toInstant(zone: TimeZone): Instant
+
+        /**
+         * Represents a whole year, e.g. 2024
+         */
+        data class Year(val year: Int) : Local() {
+            override fun group() = PartialDateTimeGroup.Year(this)
+            override fun serialize() = FORMAT.format {
+                year = this@Year.year
+            }
+
+            override fun toInstant(zone: TimeZone) = LocalDate(year, Month.JANUARY, dayOfMonth = 1).atStartOfDayIn(zone)
+
+            companion object : ICompanionWithFormat<Year>() {
+                override val FORMAT = DateTimeComponents.Format { year(Padding.ZERO) }
+
+                override fun fromComponents(components: DateTimeComponents) = Year(year = requireNotNull(components.year))
+            }
+        }
+
+        /**
+         * Represents a month in a given year, e.g. July 2024
+         */
+        data class YearMonth(val year: Int, val month: Month) : Local() {
+            override fun group() = PartialDateTimeGroup.YearMonth(this)
+            override fun serialize() = FORMAT.format {
+                year = this@YearMonth.year
+                month = this@YearMonth.month
+            }
+
+            override fun toInstant(zone: TimeZone) = LocalDate(year, month, dayOfMonth = 1).atStartOfDayIn(zone)
+
+            companion object : ICompanionWithFormat<YearMonth>() {
+                override val FORMAT = DateTimeComponents.Format {
+                    year(Padding.ZERO)
+                    char('-')
+                    monthNumber(Padding.ZERO)
+                }
+
+                override fun fromComponents(components: DateTimeComponents) = YearMonth(
+                    year = requireNotNull(components.year),
+                    month = requireNotNull(components.month),
+                )
+            }
+        }
+
+        /**
+         * Represents a full date with no time component, e.g. 15th of July 2024
+         */
+        data class Date(val date: LocalDate) : Local() {
+            override fun group() = PartialDateTimeGroup.YearMonth(YearMonth(date.year, date.month))
+            override fun serialize() = FORMAT.format { setDate(date) }
+
+            override fun toInstant(zone: TimeZone) = date.atStartOfDayIn(zone)
+
+            companion object : ICompanionWithFormat<Date>() {
+                override val FORMAT = DateTimeComponents.Format { date(LocalDate.Formats.ISO) }
+
+                override fun fromComponents(components: DateTimeComponents) = Date(components.toLocalDate())
+            }
+        }
+
+        /**
+         * Represents a full date and time, e.g. 15:00 15th of July 2024
+         */
+        data class DateTime(val dateTime: LocalDateTime) : Local() {
+            override fun group() = PartialDateTimeGroup.YearMonth(YearMonth(dateTime.year, dateTime.month))
+            override fun serialize() = FORMAT.format { setDateTime(dateTime) }
+
+            override fun toInstant(zone: TimeZone) = dateTime.toInstant(zone)
+
+            companion object : ICompanionWithFormat<DateTime>() {
+                override val FORMAT = DateTimeComponents.Format { dateTime(LocalDateTime.Formats.ISO) }
+
+                override fun fromComponents(components: DateTimeComponents) = DateTime(components.toLocalDateTime())
+            }
+        }
+
+        /**
+         * Returns a [Zoned] with this instance as its local part and [timeZone] for the timezone.
+         */
+        fun atZone(timeZone: TimeZone) = Zoned(local = this, zone = timeZone)
+
+        override fun compareTo(other: Local) = LOCAL_COMPARATOR.compare(this, other)
+
+        companion object : ICompanionWithParsers<Local>() {
+            override val PARSERS by lazy { listOf(Year::parse, YearMonth::parse, Date::parse, DateTime::parse) }
+
+            private val FROM_COMPONENTS: List<(DateTimeComponents) -> Local> by lazy {
+                listOf(
+                    DateTime::fromComponents,
+                    Date::fromComponents,
+                    YearMonth::fromComponents,
+                    Year::fromComponents,
+                )
+            }
+
+            fun fromComponents(components: DateTimeComponents): Local {
+                return FROM_COMPONENTS.firstNotNullOf { fromComponents ->
+                    try {
+                        fromComponents(components)
+                    } catch (ignored: IllegalArgumentException) {
+                        null
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Enriches a [Local] time with a [TimeZone]. This way any local time can have a timezone attached.
+     *
+     * This is useful as in most cases users will know which time zone they have watched a movie in, but might not remember the full details
+     * like the day or the time.
+     *
+     * Implements [Comparable] with the following rules:
+     * 1. The local year and month are always sorted first, without taking the timezone into consideration, with the same rules as [Local];
+     * 2. After that, [toInstant] is used to compare instances;
+     * 3. When instants are the same, less precise objects are put first, in the same vein as [Local].
+     *
+     * Example: `2024-18:00` < `2024-01-10:00` < `2024-01-01T00:00:00+05:00` < `2024-01-01+00:00`
+     */
+    data class Zoned(
+        override val local: Local,
+        val zone: TimeZone,
+    ) : PartialDateTime(), Comparable<Zoned> {
+
+        override fun group() = local.group()
+
+        override fun serialize(): String {
+            val zonePart = when (zone) {
+                is FixedOffsetTimeZone -> zone.offset.format(OFFSET_FORMAT)
+                else -> IANA_FORMAT.format { timeZoneId = zone.id }
+            }
+            return local.serialize() + zonePart
+        }
+
+        /**
+         * Converts this instance's [local] to an [Instant] using [zone] as a time zone
+         *
+         * @see Local.toInstant
+         */
+        fun toInstant() = local.toInstant(zone)
+
+        override fun compareTo(other: Zoned) = ZONED_COMPARATOR.compare(this, other)
+
+        companion object : ICompanion<Zoned> {
+
+            private val OFFSET_FORMAT = UtcOffset.Formats.ISO
+            private val IANA_FORMAT = DateTimeComponents.Format {
+                char('[')
+                timeZoneId()
+                char(']')
+            }
+
+            // Can be used for parsing only
+            private val PARSE_FORMAT = DateTimeComponents.Format {
+                // Any type of Local value
+                alternativeParsing(
+                    { dateTimeComponents(Date.FORMAT) },
+                    { dateTimeComponents(YearMonth.FORMAT) },
+                    { dateTimeComponents(Year.FORMAT) },
+                ) { dateTimeComponents(DateTime.FORMAT) }
+
+                // Either offset or IANA timezone ID
+                alternativeParsing({ offset(OFFSET_FORMAT) }) {
+                    dateTimeComponents(IANA_FORMAT)
+                }
+            }
+
+            override fun parse(input: String): Zoned {
+                val components = PARSE_FORMAT.parse(input)
+                return fromComponents(components)
+            }
+
+            fun fromComponents(components: DateTimeComponents): Zoned {
+                val local = Local.fromComponents(components)
+                val timeZone = when (val timeZoneId = components.timeZoneId) {
+                    null -> components.toUtcOffset().asTimeZone()
+                    else -> TimeZone.of(timeZoneId)
+                }
+                return Zoned(local, timeZone)
+            }
+        }
+    }
+
+    companion object : ICompanionWithParsers<PartialDateTime>() {
+
+        override val PARSERS: List<(String) -> PartialDateTime> by lazy { Local.PARSERS + listOf(Zoned::parse) }
+
+        /**
+         * Sorts [PartialDateTime] only by their local year and month.
+         */
+        private val LOCAL_YEAR_MONTH_COMPARATOR: Comparator<PartialDateTime> = compareBy<PartialDateTime> {
+            when (val local = it.local) {
+                is Year -> local.year
+                is YearMonth -> local.year
+                is Date -> local.date.year
+                is DateTime -> local.dateTime.year
+            }
+        }.thenBy {
+            when (val local = it.local) {
+                is Year -> 0
+                is YearMonth -> local.month.value
+                is Date -> local.date.month.value
+                is DateTime -> local.dateTime.month.value
+            }
+        }
+
+        /**
+         * Sorts [PartialDateTime] only by their local part. At parity of local part, [Zoned] values are put last.
+         */
+        private val LOCAL_COMPARATOR: Comparator<PartialDateTime> = LOCAL_YEAR_MONTH_COMPARATOR.thenBy {
+            when (val local = it.local) {
+                is Year, is YearMonth -> Int.MIN_VALUE
+                is Date -> local.date.toEpochDays()
+                is DateTime -> local.dateTime.date.toEpochDays()
+            }
+        }.thenBy {
+            when (val local = it.local) {
+                is Year, is YearMonth, is Date -> Instant.DISTANT_PAST
+                is DateTime -> local.dateTime.toInstant(UtcOffset.ZERO)
+            }
+        }.thenBy {
+            when (it) {
+                is Local -> 0
+                is Zoned -> 1
+            }
+        }
+
+        private val ZONED_COMPARATOR: Comparator<Zoned> = compareBy<Zoned, Local>(LOCAL_YEAR_MONTH_COMPARATOR) { it.local }
+            .thenBy {
+                when (it.local) {
+                    is Year, is YearMonth -> 0
+                    is Date, is DateTime -> 1
+                }
+            }
+            .thenBy { it.toInstant() }
+            .thenBy {
+                when (it.local) {
+                    is Year -> 0
+                    is YearMonth -> 1
+                    is Date -> 2
+                    is DateTime -> 3
+                }
+            }
+
+        /**
+         * Sorts the given [items] based on their [PartialDateTime], retrieved with the [getPartialDateTime] lambda.
+         * Upon identical [PartialDateTime], [additionalComparator] is used on the items [T].
+         *
+         * The algorithm works like this:
+         * - First it splits [Local] and [Zoned] values into two different lists, and sorts the according to their comparator;
+         * - Then, the two lists are merged together, sorted according to their local part only.
+         *
+         * This ensures that the [Local] and [Zoned] are always sorted among themselves.
+         *
+         * @see PartialDateTime.sortAndGroup
+         */
+        fun <T> sort(
+            items: Iterable<T>,
+            getPartialDateTime: T.() -> PartialDateTime,
+            additionalComparator: Comparator<T> = compareBy { 0 },
+        ): List<T> {
+            data class ItemWithDate(val item: T, val date: PartialDateTime)
+
+            val itemsWithDates = items.map { ItemWithDate(item = it, date = it.getPartialDateTime()) }
+
+            val (locals, zoned) = itemsWithDates.partition { it.date is Local }
+
+            val sortedLocals = locals
+                .sortedWith(compareBy<ItemWithDate, Local>(LOCAL_COMPARATOR) { it.date as Local }.thenBy(additionalComparator) { it.item })
+                .toCollection(ArrayDeque(locals.size))
+
+            val sortedZoned = zoned
+                .sortedWith(compareBy<ItemWithDate, Zoned>(ZONED_COMPARATOR) { it.date as Zoned }.thenBy(additionalComparator) { it.item })
+                .toCollection(ArrayDeque(zoned.size))
+
+            return buildList {
+                fun pushLocal() = add(sortedLocals.removeFirst().item)
+                fun pushZoned() = add(sortedZoned.removeFirst().item)
+
+                while (sortedLocals.isNotEmpty() || sortedZoned.isNotEmpty()) {
+                    if (sortedLocals.isNotEmpty() && sortedZoned.isNotEmpty()) {
+                        if (LOCAL_COMPARATOR.compare(sortedLocals.first().date, sortedZoned.first().date) < 0) {
+                            pushLocal()
+                        } else {
+                            pushZoned()
+                        }
+                    } else if (sortedLocals.isNotEmpty()) {
+                        pushLocal()
+                    } else {
+                        pushZoned()
+                    }
+                }
+            }
+        }
+
+        /**
+         * Sorts the given [items], by their [PartialDateTime] and groups them according to the [PartialDateTime]'s [PartialDateTime.group].
+         *
+         * @param items the items to sort
+         * @param getPartialDateTime lambda that receives a [T] and must return the [PartialDateTime] associated for the given element
+         * @param additionalComparator in the case the [PartialDateTime]s of two items are identical, the given comparator is applied
+         * @see PartialDateTime.sort
+         */
+        fun <T> sortAndGroup(
+            items: Iterable<T>,
+            getPartialDateTime: T.() -> PartialDateTime,
+            additionalComparator: Comparator<T> = compareBy { 0 },
+        ): Map<PartialDateTimeGroup, List<T>> {
+            return sort(items, getPartialDateTime, additionalComparator).groupBy { it.getPartialDateTime().group() }
+        }
+    }
+}
+
+/**
+ * Identical to [PartialDateTime.group], but can also return [PartialDateTimeGroup.Unknown] when [this] is `null`.
+ */
+fun PartialDateTime?.group(): PartialDateTimeGroup = when (this) {
+    null -> PartialDateTimeGroup.Unknown
+    else -> this.group()
+}
+
+/**
+ * Sorts the given list of [PartialDateTime]. See [PartialDateTime.sort].
+ */
+fun List<PartialDateTime>.sort(): List<PartialDateTime> {
+    return PartialDateTime.sort(items = this, getPartialDateTime = { this })
+}

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeGroup.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeGroup.kt
@@ -1,0 +1,51 @@
+package io.github.couchtracker.db.user.datastruct.partialtime
+
+/**
+ * When showing a list of objects with an associated [PartialDateTime], they should be split into groups in order to provide a clear UI to
+ * the user.
+ *
+ * Furthermore, splitting the object into distincts groups is a key factor into how they are sorted.
+ *
+ * @see PartialDateTime.Local.Year
+ * @see PartialDateTime.Local.YearMonth
+ */
+sealed class PartialDateTimeGroup : Comparable<PartialDateTimeGroup> {
+
+    /**
+     * Used only for those [PartialDateTime]s where only the only local part known is the year
+     */
+    data class Year(val value: PartialDateTime.Local.Year) : PartialDateTimeGroup()
+
+    /**
+     * Used only for all [PartialDateTime]s that don't fit into [Year] or [Unknown] groups.
+     */
+    data class YearMonth(val value: PartialDateTime.Local.YearMonth) : PartialDateTimeGroup()
+
+    /**
+     * Used when the [PartialDateTime] of an object is unknown.
+     */
+    data object Unknown : PartialDateTimeGroup()
+
+    override fun compareTo(other: PartialDateTimeGroup) = COMPARATOR.compare(this, other)
+
+    companion object {
+        private val COMPARATOR: Comparator<PartialDateTimeGroup> = compareBy<PartialDateTimeGroup> {
+            // All unknowns go first
+            when (it) {
+                Unknown -> 0
+                else -> 1
+            }
+        }.thenBy {
+            when (it) {
+                Unknown -> 0
+                is Year -> it.value.year
+                is YearMonth -> it.value.year
+            }
+        }.thenBy {
+            when (it) {
+                Unknown, is Year -> 0
+                is YearMonth -> it.value.month.value // January is 1, December is 12
+            }
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/couchtracker/SortTestUtils.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/couchtracker/SortTestUtils.kt
@@ -1,0 +1,28 @@
+package io.github.couchtracker
+
+import io.kotest.core.spec.style.scopes.FunSpecContainerScope
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.comparables.shouldBeLessThan
+
+object SortTestUtils {
+    fun <T : Comparable<T>> runComparablesTest(items: Iterable<T>) {
+        val list = items.toList()
+
+        // Check that every item in the list has the expected compareTo() result with every other item in the list (including itself)
+        for ((ia, a) in list.withIndex()) {
+            for (b in list.subList(fromIndex = ia + 1, toIndex = list.size)) {
+                a shouldBeLessThan b
+                b shouldBeGreaterThan a
+            }
+            a shouldBeEqualComparingTo a
+        }
+    }
+}
+
+suspend fun <T : Comparable<T>> FunSpecContainerScope.testComparables(name: String, vararg items: T) {
+    test(name) {
+        SortTestUtils.runComparablesTest(items.toList())
+    }
+}
+

--- a/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeGroupSortTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeGroupSortTest.kt
@@ -1,0 +1,30 @@
+package io.github.couchtracker.db.user.datastruct.partialtime
+
+import io.github.couchtracker.testComparables
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.datetime.Month
+
+class PartialDateTimeGroupSortTest : FunSpec(
+    {
+        context("compareBy()") {
+            testComparables(
+                name = "Base test",
+                // Unknown must be before anything else
+                PartialDateTimeGroup.Unknown,
+
+                // Year must be before YearMonth
+                PartialDateTimeGroup.Year(PartialDateTime.Local.Year(2023)),
+
+                // Months must be sorted
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2023, Month.JANUARY)),
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2023, Month.JUNE)),
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2023, Month.DECEMBER)),
+
+                PartialDateTimeGroup.Year(PartialDateTime.Local.Year(2024)),
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2024, Month.FEBRUARY)),
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2024, Month.MARCH)),
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2024, Month.OCTOBER)),
+            )
+        }
+    },
+)

--- a/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeSerializationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeSerializationTest.kt
@@ -1,0 +1,204 @@
+package io.github.couchtracker.db.user.datastruct.partialtime
+
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Local
+import io.github.couchtracker.db.user.datastruct.partialtime.PartialDateTime.Zoned
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.WithDataTestName
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.FixedOffsetTimeZone
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+
+private val LOCAL_TEST_CASES = listOf(
+    ValidTestCase(
+        testName = "Year",
+        serialized = "2024",
+        value = Local.Year(2024),
+    ),
+    ValidTestCase(
+        testName = "Year and Month",
+        serialized = "2024-07",
+        value = Local.YearMonth(2024, Month.JULY),
+    ),
+    ValidTestCase(
+        testName = "Date",
+        serialized = "2024-07-01",
+        value = Local.Date(LocalDate(2024, Month.JULY, dayOfMonth = 1)),
+    ),
+    ValidTestCase(
+        testName = "Date and time at hour mark",
+        serialized = "2024-07-01T08:00:00",
+        otherAcceptedParsableFormats = listOf("2024-07-01T08:00"),
+        value = Local.DateTime(LocalDateTime(2024, Month.JULY, dayOfMonth = 1, hour = 8, minute = 0)),
+    ),
+    ValidTestCase(
+        testName = "Date and time with minutes and seconds",
+        serialized = "2024-07-01T22:12:34",
+        value = Local.DateTime(LocalDateTime(2024, Month.JULY, dayOfMonth = 1, hour = 22, minute = 12, second = 34)),
+    ),
+)
+
+private val ZONED_TEST_CASES = LOCAL_TEST_CASES.flatMap { tc ->
+    val local = tc.value as Local
+    listOf(
+        tc.copy(
+            testName = "${tc.testName} with timezone ID",
+            serialized = "${tc.serialized}[Europe/Rome]",
+            otherAcceptedParsableFormats = tc.otherAcceptedParsableFormats.map { "$it[Europe/Rome]" },
+            value = Zoned(local, TimeZone.of("Europe/Rome")),
+        ),
+        tc.copy(
+            testName = "${tc.testName} with negative timezone offset",
+            serialized = "${tc.serialized}-05:45",
+            otherAcceptedParsableFormats = tc.otherAcceptedParsableFormats.map { "$it-05:45" },
+            value = Zoned(local, FixedOffsetTimeZone(UtcOffset(hours = -5, minutes = -45))),
+        ),
+        tc.copy(
+            testName = "${tc.testName} with positive timezone offset with seconds",
+            serialized = "${tc.serialized}+10:00:05",
+            otherAcceptedParsableFormats = tc.otherAcceptedParsableFormats.map { "$it+10:00:05" },
+            value = Zoned(local, FixedOffsetTimeZone(UtcOffset(hours = 10, minutes = 0, seconds = 5))),
+        ),
+        tc.copy(
+            testName = "${tc.testName} with Z offset",
+            serialized = "${tc.serialized}Z",
+            otherAcceptedParsableFormats = tc.otherAcceptedParsableFormats.map { "${it}Z" },
+            value = Zoned(local, FixedOffsetTimeZone(UtcOffset.ZERO)),
+        ),
+    )
+}
+
+private data class ValidTestCase(
+    val serialized: String,
+    val otherAcceptedParsableFormats: List<String> = emptyList(),
+    val value: PartialDateTime,
+    val testName: String,
+) : WithDataTestName {
+    override fun dataTestName() = "$testName ($serialized)"
+}
+
+private data class InvalidTestCase(
+    val value: String,
+    val testName: String,
+) : WithDataTestName {
+    override fun dataTestName() = "$testName ($value)"
+}
+
+class PartialDateTimeSerializationTest : FunSpec(
+    {
+        val validTestCases = LOCAL_TEST_CASES + ZONED_TEST_CASES
+
+        context("serialize()") {
+            withData(validTestCases) { tc ->
+                tc.value.serialize() shouldBe tc.serialized
+            }
+        }
+
+        context("parse()") {
+            context("works for valid cases") {
+                withData(validTestCases) { tc ->
+                    withData(
+                        (listOf(tc.serialized) + tc.otherAcceptedParsableFormats).withIndex().associate { (i, format) ->
+                            (if (i == 0) "main" else "additional") + " format ($format)" to format
+                        },
+                    ) {
+                        PartialDateTime.parse(it) shouldBe tc.value
+                    }
+                }
+            }
+        }
+        context("fails for invalid formats") {
+            withData(
+                InvalidTestCase(
+                    testName = "empty string",
+                    value = "",
+                ),
+                InvalidTestCase(
+                    testName = "blank string",
+                    value = "   ",
+                ),
+                InvalidTestCase(
+                    testName = "truncated date",
+                    value = "2024-",
+                ),
+                InvalidTestCase(
+                    testName = "non trimmed year",
+                    value = " 2024 ",
+                ),
+                InvalidTestCase(
+                    testName = "non padded month",
+                    value = "2024-1-01",
+                ),
+                InvalidTestCase(
+                    testName = "non padded day",
+                    value = "2024-01-1",
+                ),
+                InvalidTestCase(
+                    testName = "truncated time",
+                    value = "2024-01-01T15",
+                ),
+                InvalidTestCase(
+                    testName = "space for date/time separator",
+                    value = "2024-01-01 08:00:00",
+                ),
+                InvalidTestCase(
+                    testName = "non padded hour",
+                    value = "2024-01-01T8:00:00",
+                ),
+                InvalidTestCase(
+                    testName = "non padded minute",
+                    value = "2024-01-01T08:0:00",
+                ),
+                InvalidTestCase(
+                    testName = "non padded second",
+                    value = "2024-01-01T08:00:0",
+                ),
+                InvalidTestCase(
+                    testName = "non padded hour offset",
+                    value = "2024-01-01T08:00:00+1:00",
+                ),
+                InvalidTestCase(
+                    testName = "non padded minute offset",
+                    value = "2024-01-01T08:00:00+01:0",
+                ),
+                InvalidTestCase(
+                    testName = "non padded second offset",
+                    value = "2024-01-01T08:00:00+01:00:0",
+                ),
+                InvalidTestCase(
+                    testName = "hour/min offset with no colon",
+                    value = "2024-01-01T08:00:00+0100",
+                ),
+                InvalidTestCase(
+                    testName = "hour/min/sec offset with no colon",
+                    value = "2024-01-01T08:00:00+010000",
+                ),
+                InvalidTestCase(
+                    testName = "hour only offset",
+                    value = "2024-01-01T10:00:00+00",
+                ),
+                InvalidTestCase(
+                    testName = "offset too big",
+                    value = "2024-01-01T10:00:00+20:00",
+                ),
+                InvalidTestCase(
+                    testName = "offset too small",
+                    value = "2024-01-01T10:00:00-20:00",
+                ),
+                InvalidTestCase(
+                    testName = "non existent timezone ID",
+                    value = "2024-01-01T10:00:00[Atlantis/City]",
+                ),
+            ) { (value) ->
+                shouldThrow<IllegalArgumentException> {
+                    PartialDateTime.parse(value)
+                }
+            }
+        }
+    },
+)

--- a/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeSortTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeSortTest.kt
@@ -1,0 +1,215 @@
+package io.github.couchtracker.db.user.datastruct.partialtime
+
+import io.github.couchtracker.testComparables
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Month
+
+class PartialDateTimeSortTest : FunSpec(
+    {
+        context("compareBy()") {
+            context("Local") {
+                testComparables(
+                    name = "Local years are sorted by year",
+                    PartialDateTime.Local.parse("2024"),
+                    PartialDateTime.Local.parse("2025"),
+                    PartialDateTime.Local.parse("2026"),
+                )
+                testComparables(
+                    name = "Local year months are sorted by year and month",
+                    PartialDateTime.Local.parse("2024-01"),
+                    PartialDateTime.Local.parse("2024-02"),
+                    PartialDateTime.Local.parse("2025"),
+                )
+                testComparables(
+                    name = "Local dates are sorted by date",
+                    PartialDateTime.Local.parse("2024-01-01"),
+                    PartialDateTime.Local.parse("2024-01-02"),
+                    PartialDateTime.Local.parse("2024-02-01"),
+                    PartialDateTime.Local.parse("2025-01-01"),
+                )
+                testComparables(
+                    name = "Local times are sorted by date and time",
+                    PartialDateTime.Local.parse("2024-01-01T00:00:00"),
+                    PartialDateTime.Local.parse("2024-01-01T00:00:01"),
+                    PartialDateTime.Local.parse("2024-01-01T00:01:00"),
+                    PartialDateTime.Local.parse("2024-01-01T01:00:00"),
+                    PartialDateTime.Local.parse("2024-01-02T00:00:00"),
+                    PartialDateTime.Local.parse("2024-02-02T00:00:00"),
+                    PartialDateTime.Local.parse("2025-02-02T00:00:00"),
+                )
+                testComparables(
+                    name = "Local values for the same instant are sorted according to precision",
+                    PartialDateTime.Local.parse("2024"),
+                    PartialDateTime.Local.parse("2024-01"),
+                    PartialDateTime.Local.parse("2024-01-01"),
+                    PartialDateTime.Local.parse("2024-01-01T00:00:00"),
+                )
+            }
+
+            context("Zoned") {
+                testComparables(
+                    name = "Zoned years are sorted according to year and timezone",
+                    PartialDateTime.Zoned.parse("2024+10:00"),
+                    PartialDateTime.Zoned.parse("2024+00:00"),
+                    PartialDateTime.Zoned.parse("2024-10:00"),
+                    PartialDateTime.Zoned.parse("2025+18:00"),
+                )
+
+                testComparables(
+                    name = "Zoned year months are sorted according to year, month and timezone",
+                    PartialDateTime.Zoned.parse("2024-01+10:00"),
+                    PartialDateTime.Zoned.parse("2024-01+00:00"),
+                    PartialDateTime.Zoned.parse("2024-01-10:00"),
+                    PartialDateTime.Zoned.parse("2024-02+18:00"),
+                    PartialDateTime.Zoned.parse("2025-02+18:00"),
+                )
+
+                testComparables(
+                    name = "Zoned dates are sorted sorted based on their instants, even if their local parts would be swapped",
+                    PartialDateTime.Zoned.parse("2024-01-01+10:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01+00:00"),
+                    PartialDateTime.Zoned.parse("2024-01-02+18:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01-10:00"),
+                    PartialDateTime.Zoned.parse("2024-02-01+18:00"),
+                    PartialDateTime.Zoned.parse("2025-01-01+18:00"),
+                )
+
+                testComparables(
+                    name = "Zoned values are sorted based on their instants, even if their local part would be swapped",
+                    PartialDateTime.Zoned.parse("2024-01-01T12:00:00+05:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01T10:00:00+00:00"),
+
+                    PartialDateTime.Zoned.parse("2024-02-02T12:00:00[Europe/Dublin]"), // +00:00
+                    PartialDateTime.Zoned.parse("2024-02-02T10:00:00[Pacific/Honolulu]"), // -10:00
+                )
+
+                testComparables(
+                    name = "Zoned values for same instant and same timezone are sorted according to precision",
+                    PartialDateTime.Zoned.parse("2024+05:00"),
+                    PartialDateTime.Zoned.parse("2024-01+05:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01+05:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01T00:00:00+05:00"),
+                )
+
+                // This test is interesting: the toInstant() of these values would sort them in a different order, but since they have
+                // low precision, we choose to sort them based on their local part and precision
+                testComparables(
+                    name = "Zoned values up to YearMonth are sorted according to precision, even if their instants would be swapped",
+                    PartialDateTime.Zoned.parse("2024-18:00"),
+                    PartialDateTime.Zoned.parse("2024-01-10:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01+00:00"),
+
+                    PartialDateTime.Zoned.parse("2025-18:00"),
+                    PartialDateTime.Zoned.parse("2025-01-10:00"),
+                    PartialDateTime.Zoned.parse("2025-01-01+00:00"),
+                )
+
+                testComparables(
+                    name = "Zone dates and date times are sorted according to instant, not according to precisions",
+                    PartialDateTime.Zoned.parse("2024-01-01T00:00:00+05:00"),
+                    PartialDateTime.Zoned.parse("2024-01-01+00:00"),
+                )
+
+                // DST changes should make differences in how values are sorted, making the two timezones possibly "flip" at different dates
+                testComparables(
+                    name = "Zoned values are sorted also based on DST observance",
+                    // America/Phoenix DOESN'T observe DST, and is always at -07:00
+                    // America/Boise DOES: SDT −07:00, DST −06:00
+
+                    // when out of DST, they are at the same offset (-07:00)
+                    PartialDateTime.Zoned.parse("2024-03-09T10:00:00[America/Phoenix]"),
+                    PartialDateTime.Zoned.parse("2024-03-09T10:30:00[America/Boise]"),
+
+                    // DST change for 2024 in US is Match 10th
+
+                    // when in DST, America/Boise goes to -06:00
+                    PartialDateTime.Zoned.parse("2024-03-10T10:30:00[America/Boise]"),
+                    PartialDateTime.Zoned.parse("2024-03-10T10:00:00[America/Phoenix]"),
+                )
+            }
+        }
+
+        context("sort()") {
+            withData(
+                mapOf(
+                    // In the case of mixed Local and Zoned date times, the Local goes first
+                    "Local values always go first than Zoned values" to listOf(
+                        PartialDateTime.parse("2024-01-01"),
+                        PartialDateTime.parse("2024-01-01+18:00"),
+
+                        PartialDateTime.parse("2024-01-01T10:00:00"),
+                        PartialDateTime.parse("2024-01-01T12:00:00+18:00"),
+                    ),
+
+                    // This example, other than testing all possible types together, also has a peculiar edge case:
+                    // `2023-12-31T23:59:59-18:00` and `2024-01-01T00:00-18:00` are only one second apart, yet they appear at very different positions
+                    // This is because they are in different local years, and sorting gives priority to the local part most of the time
+                    "All types example" to listOf(
+                        PartialDateTime.parse("2023-12-31T23:59:59-18:00"),
+
+                        PartialDateTime.parse("2024"),
+                        PartialDateTime.parse("2024+10:00"),
+                        PartialDateTime.parse("2024-10:00"),
+
+                        PartialDateTime.parse("2024-01"),
+                        PartialDateTime.parse("2024-01+10:00"),
+                        PartialDateTime.parse("2024-01-10:00"),
+
+                        PartialDateTime.parse("2024-01-01"),
+                        PartialDateTime.parse("2024-01-01T00:00"),
+
+                        PartialDateTime.parse("2024-01-01T00:00+18:00"),
+                        PartialDateTime.parse("2024-01-01+10:00"),
+                        PartialDateTime.parse("2024-01-01-10:00"),
+                        PartialDateTime.parse("2024-01-01T00:00-18:00"),
+
+                        PartialDateTime.parse("2024-01-01T00:02"),
+
+                        PartialDateTime.parse("2024-01-05T00:00"),
+                        PartialDateTime.parse("2024-01-05T00:00+18:00"),
+                        PartialDateTime.parse("2024-01-05T00:00-18:00"),
+
+                        PartialDateTime.parse("2024-02-01"),
+                        PartialDateTime.parse("2024-02-01[Asia/Shanghai]"),
+                        PartialDateTime.parse("2024-02-01T00:00"),
+                        PartialDateTime.parse("2024-02-01T00:00[Europe/Rome]"),
+                        PartialDateTime.parse("2024-02-01[America/New_York]"),
+                        PartialDateTime.parse("2024-02-01T00:00[Pacific/Honolulu]"),
+
+                    ),
+                ),
+            ) { items ->
+                items.shuffled().sort() shouldBe items
+            }
+        }
+
+        test("groupAndSort()") {
+            data class TestItem(
+                val name: String,
+                val date: PartialDateTime,
+            )
+
+            val a = TestItem(name = "aaa", date = PartialDateTime.parse("2023-12-31T23:59:59-18:00"))
+            val b = TestItem(name = "bbb", date = PartialDateTime.parse("2024"))
+            val c = TestItem(name = "ccc", date = PartialDateTime.parse("2024-01"))
+            val d = TestItem(name = "ddd", date = PartialDateTime.parse("2024-01-01"))
+            val e = TestItem(name = "eee", date = PartialDateTime.parse("2024-01-01T12:34:56Z"))
+            val f = TestItem(name = "fff", date = PartialDateTime.parse("2024-01-01T12:34:56Z"))
+
+            val result = PartialDateTime.sortAndGroup(
+                items = listOf(a, b, c, d, e, f).shuffled(),
+                getPartialDateTime = { date },
+                additionalComparator = compareBy { it.name },
+            )
+
+            result shouldBe mapOf(
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2023, Month.DECEMBER)) to listOf(a),
+                PartialDateTimeGroup.Year(PartialDateTime.Local.Year(2024)) to listOf(b),
+                PartialDateTimeGroup.YearMonth(PartialDateTime.Local.YearMonth(2024, Month.JANUARY)) to listOf(c, d, e, f),
+            )
+        }
+    },
+)
+

--- a/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/couchtracker/db/user/datastruct/partialtime/PartialDateTimeTest.kt
@@ -1,0 +1,106 @@
+package io.github.couchtracker.db.user.datastruct.partialtime
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.FixedOffsetTimeZone
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.UtcOffset
+
+class PartialDateTimeTest : FunSpec(
+    {
+        context("Local") {
+            context("atZone()") {
+                withData(
+                    nameFn = { it.serialize() },
+                    PartialDateTime.parse("2024"),
+                    PartialDateTime.parse("2024-07"),
+                    PartialDateTime.parse("2024-07-01"),
+                    PartialDateTime.parse("2024-07-01T22:12:34"),
+                ) { local ->
+                    local as PartialDateTime.Local
+
+                    withData(
+                        nameFn = { it.toString() },
+                        TimeZone.UTC,
+                        TimeZone.of("Europe/Dublin"),
+                        TimeZone.of("America/New_York"),
+                        TimeZone.of("Australia/Sydney"),
+                        TimeZone.of("Australia/Sydney"),
+                        FixedOffsetTimeZone(UtcOffset(hours = -10)),
+                        FixedOffsetTimeZone(UtcOffset(hours = +10)),
+                    ) { timeZone ->
+                        val zoned = local.atZone(timeZone)
+
+                        zoned.local shouldBe local
+                        zoned.zone shouldBe timeZone
+                    }
+                }
+            }
+            context("toInstant()") {
+                val grouped = buildInstantTestCases().groupBy { it.local }
+                withData(nameFn = { it.key.serialize() }, grouped.entries) { (_, cases) ->
+                    withData(nameFn = { "at timezone ${it.timeZone}" }, cases) { (local, timeZone, expected) ->
+                        local.toInstant(timeZone) shouldBe expected
+                    }
+                }
+            }
+        }
+        context("Zoned") {
+            context("toInstant()") {
+                val tests = buildInstantTestCases().map { it.local.atZone(it.timeZone) to it.expected }
+                withData(nameFn = { it.first.serialize() }, tests) { (zoned, expected) ->
+                    zoned.toInstant() shouldBe expected
+                }
+            }
+        }
+    },
+)
+
+private data class ToInstantTestCase(
+    val local: PartialDateTime.Local,
+    val timeZone: TimeZone,
+    val expected: Instant,
+)
+
+private fun buildInstantTestCases(): List<ToInstantTestCase> {
+    val localValues = listOf(
+        PartialDateTime.parse("2024"),
+        PartialDateTime.parse("2024-01"),
+        PartialDateTime.parse("2024-01-01"),
+        PartialDateTime.parse("2024-01-01T00:00:00"),
+    )
+    val baseTestCases = localValues.flatMap {
+        listOf(
+            ToInstantTestCase(
+                local = it as PartialDateTime.Local,
+                timeZone = FixedOffsetTimeZone(UtcOffset(hours = +10)),
+                expected = Instant.parse("2023-12-31T14:00:00Z"),
+            ),
+            ToInstantTestCase(
+                local = it,
+                timeZone = TimeZone.of("Europe/Rome"),
+                expected = Instant.parse("2023-12-31T23:00:00Z"),
+            ),
+            ToInstantTestCase(
+                local = it,
+                timeZone = TimeZone.UTC,
+                expected = Instant.parse("2024-01-01T00:00:00Z"),
+            ),
+            ToInstantTestCase(
+                local = it,
+                timeZone = FixedOffsetTimeZone(UtcOffset(hours = -10)),
+                expected = Instant.parse("2024-01-01T10:00:00Z"),
+            ),
+        )
+    }
+    return baseTestCases + listOf(
+        // This also validates that on a timezone with DST we get the correct instant
+        ToInstantTestCase(
+            local = PartialDateTime.parse("2024-07-01T12:34:56") as PartialDateTime.Local,
+            timeZone = TimeZone.of("Europe/Rome"),
+            expected = Instant.parse("2024-07-01T10:34:56Z"),
+        ),
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ compose = "1.7.0-beta03"
 compose-plugin = "1.6.11"
 junit = "4.13.2"
 kotlin = "2.0.0"
+kotlinx-datetime = "0.6.0"
 detekt = "1.23.6"
 sqldelight = "2.0.2"
 kotest = "5.9.1"
@@ -61,6 +62,7 @@ koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin-bo
 koin-core = { group = "io.insert-koin", name = "koin-core" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
 requery-android = { module = "com.github.requery:sqlite-android", version.ref = "requeryAndroid" }
 tmdb-api = { module = "app.moviebase:tmdb-api", version.ref = "tmdb-api" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
Adds a class that represents a date/time value that might not have all the components present.

It's needed to store a watch date of a movie/episode, as the user might not know/remember all details of when something was watched.

Not all combinations of missing data are supported. In ascending order of precision, when a component is unknown, all components after it must be as well. Time is considered a single indivisible component.

Suppoorted types are:
- Local.Year: just a year, e.g. 2024
- Local.YearMonth: year and month, e.g. July 2024
- Local.Date: date, e.g. July 12th, 2024
- Local.DateTime: date and time, e.g. July 12th, 2024 at 21:00:00
- Zoned: composes any Local value with a time zone