### PR TITLE
Fix Android test dependencies being in main dependencies

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -54,8 +54,10 @@ kotlin {
             implementation(libs.navigation.compose)
             implementation(libs.palette)
             implementation(libs.koin.androidx.compose)
-
-            // There is no androidUnitTest target
+        }
+        // androidUnitTest is not directly available, as it's missing from `KotlinMultiplatformSourceSetConventions`'s interface
+        // see https://youtrack.jetbrains.com/issue/KT-63772
+        sourceSets.getByName("androidUnitTest").dependencies {
             implementation(libs.kotest.runner.junit5)
             implementation(libs.mockk.android)
             implementation(libs.sqldelight.jvm)


### PR DESCRIPTION
This also fixes the app not compiling after the recent change when we added `libs.sqldelight.jvm`
