### PR TITLE
Add WatchedItemDimension and related tables

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/db/common/AndroidSqliteDriverFactory.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/db/common/AndroidSqliteDriverFactory.kt
@@ -31,6 +31,10 @@ class AndroidSqliteDriverFactory(
                     // It will delete the file and later in the process a new empty DB will be created, which is not what we want
                     throw DBCorruptedException()
                 }
+
+                override fun onOpen(db: SupportSQLiteDatabase) {
+                    db.setForeignKeyConstraintsEnabled(true)
+                }
             },
         )
     }

--- a/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItem.sq
+++ b/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItem.sq
@@ -14,7 +14,13 @@ CREATE TABLE WatchedItem (
    */
   addedAt TEXT AS Instant NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
 
-  watchedAt TEXT AS PartialDateTime
+  /**
+   * The date/time this item has *started* being watched.
+   *
+   * This is different than what some other apps do. For instance, Trakt has a `watchedAt` field, which is the date/time
+   * when a user has *finished* watching something.
+   */
+  watchAt TEXT AS PartialDateTime
 );
 
 selectAll:

--- a/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemChoice.sq
+++ b/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemChoice.sq
@@ -1,0 +1,13 @@
+/**
+ * Many-to-many relationship between `WatchedItem`s and `WatchedItemDimensionChoice`s.
+ */
+CREATE TABLE WatchedItemChoice(
+  watchedItemId INTEGER NOT NULL,
+  choice INTEGER NOT NULL,
+  PRIMARY KEY(watchedItemId, choice),
+  FOREIGN KEY(watchedItemId) REFERENCES WatchedItem(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY(choice) REFERENCES WatchedItemDimensionChoice(id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+selectAll:
+SELECT * FROM WatchedItemChoice;

--- a/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemDimension.sq
+++ b/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemDimension.sq
@@ -1,0 +1,51 @@
+import io.github.couchtracker.db.user.model.icon.DbIcon;
+import io.github.couchtracker.db.user.model.text.DbText;
+import io.github.couchtracker.db.user.model.watchedItem.WatchedItemDimensionType;
+import io.github.couchtracker.db.user.model.watchedItem.WatchedItemType;
+import kotlin.collections.Set;
+
+/**
+ * Represents each type of data that can be stored in conjunction with a watched movie or episode.
+ */
+CREATE TABLE WatchedItemDimension(
+  id INTEGER PRIMARY KEY NOT NULL,
+  name TEXT AS DbText NOT NULL,
+  appliesTo TEXT AS Set<WatchedItemType> NOT NULL,
+  type TEXT AS WatchedItemDimensionType NOT NULL,
+  manualSortIndex INTEGER NOT NULL
+);
+
+/**
+ * Many-to-many relationship between WatchedItemDimension and WatchedItemDimensionChoice.
+ *
+ * If, for a specific dimension:
+ * - There are no rows: it means that the dimension is always visible
+ * - There is a single row: it means that the dimension is visible only if that choice is selected
+ * - There are multiple rows. it means that the dimension is visible if any of the choices are selected
+ *
+ * Note: it doesn't ever make sense to have a row in which the choice belongs to the dimension it is enabling. Any row
+ * with such values shall be ignored and have no effect.
+ */
+CREATE TABLE WatchedItemDimensionEnableIf(
+  dimension INTEGER NOT NULL,
+  choice INTEGER NOT NULL,
+
+  PRIMARY KEY(dimension, choice),
+  FOREIGN KEY(dimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY(choice) REFERENCES WatchedItemDimensionChoice(id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+
+selectAll:
+SELECT *
+FROM WatchedItemDimension
+ORDER BY manualSortIndex;
+
+selectAllEnableIf:
+SELECT *
+FROM WatchedItemDimensionEnableIf;
+
+insert:
+INSERT INTO WatchedItemDimension(name, appliesTo, type, manualSortIndex)
+VALUES (?, ?, ?, (SELECT COALESCE(:manualSortIndex, MAX(manualSortIndex) + 1, 0) FROM WatchedItemDimension))
+RETURNING id;

--- a/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemDimensionChoice.sq
+++ b/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemDimensionChoice.sq
@@ -1,0 +1,25 @@
+import io.github.couchtracker.db.user.model.icon.DbIcon;
+import io.github.couchtracker.db.user.model.text.DbText;
+
+/**
+ * Represents a choice for a `WatchedItemDimension` with a type of `choice`.
+ *
+ * If an item in this table references a `WatchedItemDimension` which is not of type `choice`, it is simply ignored.
+ */
+CREATE TABLE WatchedItemDimensionChoice(
+  id INTEGER PRIMARY KEY NOT NULL,
+  dimension INTEGER NOT NULL,
+  name TEXT AS DbText NOT NULL,
+  icon TEXT AS DbIcon NOT NULL,
+  manualSortIndex INTEGER NOT NULL,
+
+  FOREIGN KEY(dimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+selectAll:
+SELECT * FROM WatchedItemDimensionChoice;
+
+insert:
+INSERT INTO WatchedItemDimensionChoice(dimension, name, icon, manualSortIndex)
+VALUES (?, ?, ?, (SELECT COALESCE(MAX(manualSortIndex) + 1, 0) FROM WatchedItemDimensionChoice))
+RETURNING id;

--- a/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemFreeText.sq
+++ b/composeApp/src/androidMain/sqldelight/user/io/github/couchtracker/db/user/WatchedItemFreeText.sq
@@ -1,0 +1,14 @@
+/**
+ * Contains the values for the dimensions of type free text for a single `WatchedItem`.
+ */
+CREATE TABLE WatchedItemFreeText(
+  watchedItemId INTEGER NOT NULL,
+  watchedItemDimension INTEGER NOT NULL,
+  text TEXT NOT NULL,
+  PRIMARY KEY(watchedItemId, watchedItemDimension),
+  FOREIGN KEY(watchedItemId) REFERENCES WatchedItem(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY(watchedItemDimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+selectAll:
+SELECT * FROM WatchedItemFreeText;

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/UserDbCommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/UserDbCommonModule.kt
@@ -1,9 +1,16 @@
 package io.github.couchtracker.db.user
 
+import app.cash.sqldelight.EnumColumnAdapter
+import io.github.couchtracker.db.common.adapters.DbIconColumnAdapter
+import io.github.couchtracker.db.common.adapters.DbTextColumnAdapter
 import io.github.couchtracker.db.common.adapters.InstantColumnAdapter
 import io.github.couchtracker.db.common.adapters.PartialDateTimeColumnAdapter
 import io.github.couchtracker.db.common.adapters.WatchableExternalIdColumnAdapter
 import io.github.couchtracker.db.common.adapters.columnAdapter
+import io.github.couchtracker.db.common.adapters.jsonAdapter
+import io.github.couchtracker.db.common.adapters.jsonSet
+import io.github.couchtracker.db.user.model.watchedItem.WatchedItemDimensionType
+import io.github.couchtracker.db.user.model.watchedItem.WatchedItemType
 import io.github.couchtracker.db.user.show.ExternalShowId
 import org.koin.dsl.module
 
@@ -19,6 +26,15 @@ val UserDbCommonModule = module {
                 itemIdAdapter = WatchableExternalIdColumnAdapter,
                 addedAtAdapter = InstantColumnAdapter,
                 watchAtAdapter = PartialDateTimeColumnAdapter,
+            ),
+            WatchedItemDimensionAdapter = WatchedItemDimension.Adapter(
+                appliesToAdapter = EnumColumnAdapter<WatchedItemType>().jsonSet(),
+                nameAdapter = DbTextColumnAdapter,
+                typeAdapter = jsonAdapter<WatchedItemDimensionType>(),
+            ),
+            WatchedItemDimensionChoiceAdapter = WatchedItemDimensionChoice.Adapter(
+                nameAdapter = DbTextColumnAdapter,
+                iconAdapter = DbIconColumnAdapter,
             ),
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/UserDbCommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/UserDbCommonModule.kt
@@ -18,7 +18,7 @@ val UserDbCommonModule = module {
             WatchedItemAdapter = WatchedItem.Adapter(
                 itemIdAdapter = WatchableExternalIdColumnAdapter,
                 addedAtAdapter = InstantColumnAdapter,
-                watchedAtAdapter = PartialDateTimeColumnAdapter,
+                watchAtAdapter = PartialDateTimeColumnAdapter,
             ),
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/model/watchedItem/WatchedItemDimensionType.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/db/user/model/watchedItem/WatchedItemDimensionType.kt
@@ -1,0 +1,29 @@
+package io.github.couchtracker.db.user.model.watchedItem
+
+import io.github.couchtracker.db.user.WatchedItemDimension
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The type of selection that can be made for a [WatchedItemDimension].
+ */
+@Serializable
+sealed interface WatchedItemDimensionType {
+
+    @Serializable
+    @SerialName("choice")
+    data class Choice(val maxSelections: Int?) : WatchedItemDimensionType {
+        init {
+            require(maxSelections == null || maxSelections > 0) { "maxSelections cannot be negative" }
+        }
+
+        companion object {
+            val SINGLE = Choice(maxSelections = 1)
+            val UNBOUNDED = Choice(maxSelections = null)
+        }
+    }
+
+    @Serializable
+    @SerialName("freeText")
+    data object FreeText : WatchedItemDimensionType
+}


### PR DESCRIPTION
For now only the `choice` and `freeText` types are supported.

Dimensions can be enabled conditionally based on the selection status of another dimension choice.

Sample db with some data:
[couch-tracker.db.zip](https://github.com/user-attachments/files/17216742/couch-tracker.zip)
