### PR TITLE
Add API to localize a PartialDateTime

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/intl/Utils.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/intl/Utils.kt
@@ -1,0 +1,21 @@
+package io.github.couchtracker.intl
+
+import android.icu.text.ListFormatter
+import android.text.format.DateFormat
+import androidx.compose.ui.text.intl.Locale
+import io.github.couchtracker.intl.datetime.Skeleton
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toJavaInstant
+import kotlinx.datetime.toJavaZoneId
+import java.time.format.DateTimeFormatter
+
+actual fun formatAndList(items: List<String>): String {
+    return ListFormatter.getInstance().format(items)
+}
+
+actual fun formatDateTimeSkeleton(instant: Instant, timeZone: TimeZone, skeleton: Skeleton, locale: Locale): String {
+    val pattern = DateFormat.getBestDateTimePattern(locale.platformLocale, skeleton.value)
+    val temporal = instant.toJavaInstant().atZone(timeZone.toJavaZoneId())
+    return DateTimeFormatter.ofPattern(pattern, locale.platformLocale).format(temporal)
+}

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
@@ -72,13 +72,13 @@ import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.db.user.movie.ExternalMovieId
 import io.github.couchtracker.db.user.movie.TmdbExternalMovieId
 import io.github.couchtracker.db.user.movie.UnknownExternalMovieId
+import io.github.couchtracker.intl.formatAndList
 import io.github.couchtracker.tmdb.TmdbLanguage
 import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.ui.components.BackgroundTopAppBar
 import io.github.couchtracker.ui.components.DefaultErrorScreen
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.utils.Loadable
-import io.github.couchtracker.utils.formatAndList
 import io.github.couchtracker.utils.str
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject

--- a/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Intl.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/couchtracker/utils/Intl.kt
@@ -1,7 +1,0 @@
-package io.github.couchtracker.utils
-
-import android.icu.text.ListFormatter
-
-actual fun formatAndList(items: List<String>): String {
-    return ListFormatter.getInstance().format(items)
-}

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/Localized.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/Localized.kt
@@ -1,0 +1,19 @@
+package io.github.couchtracker.intl
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.intl.Locale
+import io.github.couchtracker.utils.Text
+
+/**
+ * Abstract class which holds an [item] of type [T] that can be localized by calling the [localize] method.
+ */
+abstract class Localized<out T>(val item: T) : Text {
+
+    /**
+     * Returns the localized string representing [item] with the given [locale], or the default one if not provided.
+     */
+    abstract fun localize(locale: Locale = Locale.current): String
+
+    @Composable
+    override fun string() = localize()
+}

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/Utils.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/Utils.kt
@@ -1,0 +1,17 @@
+package io.github.couchtracker.intl
+
+import androidx.compose.ui.text.intl.Locale
+import io.github.couchtracker.intl.datetime.Skeleton
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+
+expect fun formatAndList(items: List<String>): String
+
+/**
+ * Formats the given [instant] and [timeZone] with the give [skeleton] for [locale].
+ *
+ * Note: with `kotlinx-datetime` there is no standard way to pass a generic temporal-like object, like in `java.time` APIs.
+ * All the "local" parts used are for the given [instant] at the given [timeZone]. For instance, passing the epoch (`0`) with a timezone of
+ * `GMT+05:00` will make the hour value be `5 AM`.
+ */
+expect fun formatDateTimeSkeleton(instant: Instant, timeZone: TimeZone, skeleton: Skeleton, locale: Locale): String

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/datetime/LocalizedSkeletonPartialDateTime.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/datetime/LocalizedSkeletonPartialDateTime.kt
@@ -1,0 +1,87 @@
+package io.github.couchtracker.intl.datetime
+
+import androidx.compose.ui.text.intl.Locale
+import io.github.couchtracker.db.user.model.partialtime.PartialDateTime
+import io.github.couchtracker.db.user.model.partialtime.PartialDateTime.Local
+import io.github.couchtracker.db.user.model.partialtime.PartialDateTime.Zoned
+import io.github.couchtracker.intl.Localized
+import io.github.couchtracker.intl.formatDateTimeSkeleton
+import kotlinx.datetime.TimeZone
+
+/**
+ * Specialization of [Localized] for [PartialDateTime] that are localized with a [Skeleton].
+ */
+abstract class LocalizedSkeletonPartialDateTime<out PDT : PartialDateTime>(item: PDT) : Localized<PDT>(item) {
+    abstract val skeleton: Skeleton
+}
+
+private class LocalizedSkeletonPartialDateTimeImpl<out PDT : PartialDateTime>(
+    item: PDT,
+    override val skeleton: Skeleton,
+) : LocalizedSkeletonPartialDateTime<PDT>(item) {
+
+    override fun localize(locale: Locale): String {
+        val (instant, timeZone) = when (val pdt = item as PartialDateTime) {
+            is Local -> {
+                val defaultTimeZone = TimeZone.currentSystemDefault()
+                pdt.toInstant(defaultTimeZone) to defaultTimeZone
+            }
+
+            is Zoned -> pdt.toInstant() to pdt.zone
+        }
+
+        return formatDateTimeSkeleton(
+            instant = instant,
+            timeZone = timeZone,
+            skeleton = skeleton,
+            locale = locale,
+        )
+    }
+}
+
+/**
+ * Localizes this [PartialDateTime.Local] with the given skeletons, which are concatenated together.
+ */
+fun <L : Local> L.localized(skeletons: Collection<LocalSkeleton<L>>): LocalizedSkeletonPartialDateTime<L> {
+    return LocalizedSkeletonPartialDateTimeImpl(this, skeletons.sum())
+}
+
+fun <L : Local> L.localized(
+    firstSkeleton: LocalSkeleton<L>,
+    vararg otherSkeletons: LocalSkeleton<L>,
+): LocalizedSkeletonPartialDateTime<L> {
+    return LocalizedSkeletonPartialDateTimeImpl(this, (listOf(firstSkeleton) + otherSkeletons).toList().sum())
+}
+
+/**
+ * Localizes a [PartialDateTime.Zoned].
+ *
+ * @param timezoneSkeleton the skeleton to use to format the timezone
+ * @param localSkeletons a function to select the way to localize the inner [PartialDateTime.Local] instance.
+ */
+fun Zoned.localized(
+    timezoneSkeleton: TimezoneSkeleton,
+    localSkeletons: (Local) -> LocalizedSkeletonPartialDateTime<Local>,
+): LocalizedSkeletonPartialDateTime<Zoned> {
+    val list = listOf(localSkeletons(this.local).skeleton, timezoneSkeleton).sum()
+    return LocalizedSkeletonPartialDateTimeImpl(this, list)
+}
+
+/**
+ * Localizes a generic [PartialDateTime].
+ *
+ * If you know that your instance is a [PartialDateTime.Local] or a [PartialDateTime.Zoned], use the appropriate overloads.
+ *
+ * @param timezoneSkeleton the skeleton to use to format the timezone, if present. In case of a [PartialDateTime.Local] this is ignored.
+ * @param localSkeletons a function to select how to localize a [PartialDateTime.Local], whether it's this instance or the one within a
+ * [Zoned].
+ */
+fun PartialDateTime.localized(
+    timezoneSkeleton: TimezoneSkeleton,
+    localSkeletons: (Local) -> LocalizedSkeletonPartialDateTime<Local>,
+): LocalizedSkeletonPartialDateTime<PartialDateTime> {
+    return when (this) {
+        is Local -> localSkeletons(this)
+        is Zoned -> this.localized(timezoneSkeleton, localSkeletons)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/datetime/Skeletons.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/intl/datetime/Skeletons.kt
@@ -1,0 +1,165 @@
+package io.github.couchtracker.intl.datetime
+
+import io.github.couchtracker.db.user.model.partialtime.PartialDateTime
+
+/**
+ * Represents a Unicode CLDR Skeleton.
+ *
+ * The skeleton itself is not a pattern that is formatted directly, but the most appropriate pattern will be selected given the information
+ * provided by the skeleton.
+ */
+interface Skeleton {
+    /**
+     * The value of the skeleton, e.g. `y MM` for a string containing the year number and the month number
+     */
+    val value: String
+}
+
+/**
+ * A specialization of [Skeleton], which has a type [L] that must be a subtype of [PartialDateTime.Local].
+ *
+ * This is helpful to know which component is required for this skeleton to have a meaning.
+ */
+interface LocalSkeleton<in L : PartialDateTime.Local> : Skeleton
+
+/**
+ * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-year).
+ */
+enum class YearSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithYear> {
+
+    /**
+     * Two low-order digits of the year, e.g. `95` for 1995
+     */
+    SHORT("yy"),
+
+    /**
+     * Numeric, non-padded year number, e.g. `201`, `2017`
+     */
+    NUMERIC("y"),
+}
+
+/**
+ * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-month).
+ */
+enum class MonthSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithMonth> {
+    /**
+     * Numeric, zero-padded month, e.g. `02` for February
+     */
+    NUMERIC("MM"),
+
+    /**
+     * Numeric, non-padded month, e.g. `2` for February
+     */
+    NUMERIC_NON_PADDED("M"),
+
+    /**
+     * Narrow month name, e.g. `F` for February
+     */
+    NARROW("MMMMM"),
+
+    /**
+     * Abbreviated month name, e.g. `Feb` for February
+     */
+    ABBREVIATED("MMM"),
+
+    /**
+     * Full moth name, e.g. `February`
+     */
+    WIDE("MMMM"),
+}
+
+/**
+ * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-day).
+ */
+enum class DayOfMonthSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithDay> {
+    /**
+     * Numeric, zero-padded day-of-month, e.g. `09`
+     */
+    NUMERIC("dd"),
+
+    /**
+     * Numeric, non-padded day-of-month, e.g. `9`
+     */
+    NUMERIC_NON_PADDED("d"),
+}
+
+/**
+ * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-weekday).
+ */
+enum class DayOfWeekSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithDay> {
+    /**
+     * Narrow day-of-week name, e.g. `T` for Tuesday
+     */
+    NARROW("EEEEE"),
+
+    /**
+     * Short day-of-week name, e.g. `Tu` for Tuesday
+     */
+    SHORT("EEEEEE"),
+
+    /**
+     * Abbreviated day-of-week name, e.g. `Tue` for Tuesday
+     */
+    ABBREVIATED("E"),
+
+    /**
+     * Full day-of-week name, e.g. `Tuesday`
+     */
+    WIDE("EEEE"),
+}
+
+/**
+ * See Unicode docs:
+ *  - [hour](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-minute)
+ *  - [minute](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-minute)
+ *  - [second](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-second)
+ */
+enum class TimeSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithTime> {
+    /**
+     * Time with hours and minutes, zero-padded. 12/24 hours is locale-dependent
+     */
+    MINUTES("jj mm"),
+
+    /**
+     * Time with hours, minutes and seconds, zero-padded. 12/24 hours is locale-dependent
+     */
+    SECONDS("jj mm ss"),
+}
+
+/**
+ * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-zone).
+ */
+enum class TimezoneSkeleton(override val value: String) : Skeleton {
+    /**
+     * The ISO8601 extended format with hours and minutes fields, e.g. `+01:00`
+     */
+    OFFSET("xxx"),
+
+    /**
+     * The long timezone ID, e.g. `Europe/Dublin`
+     */
+    TIMEZONE_ID("VV"),
+
+    /**
+     * The long specific non-location format, e.g. `Irish standard time`
+     */
+    SPECIFIC_NON_LOCATION("zzzz"),
+}
+
+private class PlusSkeleton(skeletons: Collection<Skeleton>) : Skeleton {
+    override val value = skeletons.joinToString(separator = " ") { it.value }
+}
+
+/**
+ * Creates a new [Skeleton] all concatenating all items in this collection.
+ */
+fun Collection<Skeleton>.sum(): Skeleton = PlusSkeleton(this)
+
+private typealias DateSkeleton = LocalSkeleton<PartialDateTime.Local.WithDate>
+
+object Skeletons {
+    val NUMERIC_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.NUMERIC, DayOfMonthSkeleton.NUMERIC)
+    val MEDIUM_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.ABBREVIATED, DayOfMonthSkeleton.NUMERIC)
+    val LONG_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.WIDE, DayOfMonthSkeleton.NUMERIC)
+    val FULL_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.WIDE, DayOfMonthSkeleton.NUMERIC, DayOfWeekSkeleton.WIDE)
+}

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/utils/Intl.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/utils/Intl.kt
@@ -1,3 +1,0 @@
-package io.github.couchtracker.utils
-
-expect fun formatAndList(items: List<String>): String

--- a/composeApp/src/commonMain/kotlin/io/github/couchtracker/utils/Text.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/couchtracker/utils/Text.kt
@@ -9,7 +9,7 @@ import org.jetbrains.compose.resources.stringResource
  *
  * This could be a localized string bundled in the app or something externally-provided.
  */
-sealed interface Text {
+interface Text {
 
     @Composable
     fun string(): String


### PR DESCRIPTION
Example usage:
```kotlin
val dates = listOf(
        PartialDateTime.parse("2024"),
        PartialDateTime.parse("2024[Europe/Dublin]"),

        PartialDateTime.parse("2024-10"),
        PartialDateTime.parse("2024-10[Europe/Dublin]"),

        PartialDateTime.parse("2024-10-22"),
        PartialDateTime.parse("2024-10-22[Europe/Dublin]"),

        PartialDateTime.parse("2024-10-22T23:35:47"),
        PartialDateTime.parse("2024-10-22T23:35:47[Europe/Rome]"),
    )

    for (locale in listOf(Locale.current, Locale("it"))) {
        Text(locale.language)
        for (it in dates) {
            val loc = it.localized(TimezoneSkeleton.TIMEZONE_ID) {
                when (it) {
                    is PartialDateTime.Local.Year -> it.localized(YearSkeleton.NUMERIC)
                    is PartialDateTime.Local.YearMonth -> it.localized(YearSkeleton.SHORT, MonthSkeleton.NARROW)
                    is PartialDateTime.Local.Date -> it.localized(Skeletons.NUMERIC_DATE)
                    is PartialDateTime.Local.DateTime -> it.localized(Skeletons.FULL_DATE + TimeSkeleton.MINUTES)
                }
            }
            Text(loc.localize(locale))
        }
        Spacer(Modifier.padding(4.dp))
    }
```

Result:
![immagine](https://github.com/user-attachments/assets/3f1c6930-8120-4c8c-9e60-40507262d6aa)
