### PR TITLE
Misc fixes for Uri/DbText

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/CouchTrackerUri.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/CouchTrackerUri.kt
@@ -12,7 +12,7 @@ import java.net.URI
 @JvmInline
 value class CouchTrackerUri(val uri: URI) {
 
-    val authority get() = requireNotNull(uri.authorityOrNull())
+    val authority get() = checkNotNull(uri.authorityOrNull())
 
     init {
         require(uri.scheme == SCHEME) { "Invalid schema for couch-tracker URI: ${uri.scheme}" }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/text/DbText.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/text/DbText.kt
@@ -2,7 +2,7 @@ package io.github.couchtracker.db.profile.model.text
 
 import io.github.couchtracker.db.profile.CouchTrackerUri
 import io.github.couchtracker.utils.Text
-import io.github.couchtracker.utils.encodeUriQuery
+import io.github.couchtracker.utils.encodeUriComponent
 import io.github.couchtracker.utils.pathSegments
 import io.github.couchtracker.utils.toText
 
@@ -27,7 +27,7 @@ sealed interface DbText {
 
     data class Custom(val value: String) : DbText {
         override val text get() = value.toText()
-        override fun toCouchTrackerUri() = CouchTrackerUri.Authority.TEXT.uri("$CUSTOM_TEXT_PATH/${encodeUriQuery(value)}")
+        override fun toCouchTrackerUri() = CouchTrackerUri.Authority.TEXT.uri("$CUSTOM_TEXT_PATH/${encodeUriComponent(value)}")
     }
 
     companion object {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Uri.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Uri.kt
@@ -19,12 +19,9 @@ fun Uri.toJavaUri(): URI {
 }
 
 fun URI.pathSegments(): List<String> {
-    return path
-        ?.removePrefix("/")
-        ?.removeSuffix("/")
-        ?.takeIf { it.isNotEmpty() }
-        ?.split('/')
-        .orEmpty()
+    return rawPath.split("/")
+        .filter { it.isNotEmpty() }
+        .map { decodeUriComponent(it) }
 }
 
 /**
@@ -39,6 +36,31 @@ fun encodeUriComponent(value: String): String {
             when {
                 char.isLetterOrDigit() || "-_.~".contains(char) -> append(char)
                 else -> append("%" + char.code.toString(radix = 16).uppercase().padStart(2, '0'))
+            }
+        }
+    }
+}
+
+private const val PERCENT_ESCAPE_LENGTH = 3
+
+/**
+ * Decodes the given [value] to be used, as a whole, in a URI query component, compliant with
+ * [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986).
+ */
+fun decodeUriComponent(value: String): String {
+    // Unfortunately there is no standard way to escape a URI component in the stdlib
+    // URLDecoder.decode decodes `+` as spaces, so that's not RFC 3986 compliant
+    return buildString {
+        var i = 0
+        while (i < value.length) {
+            if (value[i] == '%' && i + 2 < value.length) {
+                val hex = value.substring(i + 1, i + PERCENT_ESCAPE_LENGTH)
+                val decodedChar = hex.toInt(radix = 16).toChar()
+                append(decodedChar)
+                i += PERCENT_ESCAPE_LENGTH
+            } else {
+                append(value[i])
+                i++
             }
         }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Uri.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Uri.kt
@@ -28,11 +28,18 @@ fun URI.pathSegments(): List<String> {
 }
 
 /**
- * Encodes the given [value] to be used, as a whole, in a URI query component.
- *
- * Warning: this function will not escape `&`, `=` or other similar characters, as this is NOT encoding for
- * `application/x-www-form-urlencoded`.
+ * Encodes the given [value] to be used, as a whole, in a URI query component, compliant with
+ * [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986).
  */
-fun encodeUriQuery(value: String): String {
-    return URI("scheme", "authority", "/path", value, "fragment").rawQuery
+fun encodeUriComponent(value: String): String {
+    // Unfortunately there is no standard way to escape a URI component in the stdlib
+    // URLEncoder.encode encodes spaces as `+`, so that's not RFC 3986 compliant
+    return buildString {
+        for (char in value) {
+            when {
+                char.isLetterOrDigit() || "-_.~".contains(char) -> append(char)
+                else -> append("%" + char.code.toString(radix = 16).uppercase().padStart(2, '0'))
+            }
+        }
+    }
 }

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/text/DbTextTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/text/DbTextTest.kt
@@ -3,74 +3,109 @@ package io.github.couchtracker.db.profile.model.text
 import io.github.couchtracker.db.profile.CouchTrackerUri
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.scopes.FunSpecContainerScope
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.enum
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.merge
+import io.kotest.property.arbitrary.string
+import io.kotest.property.forAll
 import java.net.URI
 
 class DbTextTest : FunSpec(
     {
-        context("fromUri()") {
-            context("default text") {
-                context("valid URIs return the correct text") {
-                    withData(
-                        "couch-tracker://text/default/place-home" to DbDefaultText.PLACE_HOME.toDbText(),
-                        "couch-tracker://text/default/place-plane" to DbDefaultText.PLACE_PLANE.toDbText(),
-                    ) { (uriString, expectedText) ->
-                        val uri = CouchTrackerUri(URI(uriString))
-                        DbText.fromUri(uri) shouldBe expectedText
-                    }
-                }
-                context("invalid default text returns unknown text") {
-                    withData(
-                        "couch-tracker://text/default/i-dont-exist",
-                        "couch-tracker://text/default/aaaaaaaaaaaaaaaaa",
-                    ) { uriString ->
-                        val uri = CouchTrackerUri(URI(uriString))
-                        val id = uriString.split('/').last()
-                        DbText.fromUri(uri) shouldBe DbText.UnknownDefault(id, uri)
-                    }
-                }
-                context("invalid default URIs fail") {
-                    withData(
-                        "couch-tracker://text/default",
-                        "couch-tracker://text/default/",
-                        "couch-tracker://text/default/%20",
-                    ) { uriString ->
-                        val uri = CouchTrackerUri(URI(uriString))
-                        shouldThrow<IllegalArgumentException> {
-                            DbText.fromUri(uri)
-                        }
-                    }
-                }
+        context("default text or unknown") {
+            uriTests(
+                valid = listOf(
+                    "couch-tracker://text/default/place-home" to DbDefaultText.PLACE_HOME.toDbText(),
+                    "couch-tracker://text/default/place-plane" to DbDefaultText.PLACE_PLANE.toDbText(),
+                    "couch-tracker://text/default/i-dont-exist" to DbText.UnknownDefault("i-dont-exist"),
+                    "couch-tracker://text/default/aaaaaaaaaaaaaaaaa" to DbText.UnknownDefault("aaaaaaaaaaaaaaaaa"),
+                ),
+                invalid = listOf(
+                    "couch-tracker://text/default",
+                    "couch-tracker://text/default/",
+                    "couch-tracker://text/default/%20",
+                    "couch-tracker://text/default/i-dont-exist#some-fragment",
+                    "couch-tracker://text/default/place-home#some-fragment",
+                ),
+            )
+        }
+        context("custom text") {
+            uriTests(
+                valid = listOf(
+                    "couch-tracker://text/custom?hello" to DbText.Custom("hello"),
+                    "couch-tracker://text/custom?" to DbText.Custom(""),
+                    "couch-tracker://text/custom?hello%20world" to DbText.Custom("hello world"),
+                    "couch-tracker://text/custom?special%2Bchars-in%21text%2Fwow" to DbText.Custom("special+chars-in!text/wow"),
+                ),
+                invalid = listOf(
+                    "couch-tracker://text/custom/something-else",
+                    "couch-tracker://text/custom?hello#some-fragment",
+                ),
+            )
+        }
+        test("round trip") {
+            forAll(Arb.defaultDbText()) {
+                it == DbText.fromUri(it.toCouchTrackerUri())
             }
-            context("custom text") {
-                withData(
-                    "couch-tracker://text/custom?hello" to "hello",
-                    "couch-tracker://text/custom?" to "",
-                    "couch-tracker://text/custom?hello%20world" to "hello world",
-                    "couch-tracker://text/custom?special+chars-in!text/wow" to "special+chars-in!text/wow",
-                    "couch-tracker://text/custom?special%2Bchars-in%21text%2Fwow" to "special+chars-in!text/wow",
-                ) { (uriString, expectedText) ->
-                    val uri = CouchTrackerUri(URI(uriString))
-                    DbText.fromUri(uri) shouldBe DbText.Custom(expectedText)
-                }
-            }
-            context("invalid URIs fail") {
-                withData(
-                    "couch-tracker://text",
-                    "couch-tracker://text/",
-                    "couch-tracker://text/new-format/abc?xyz=123",
+        }
+        context("other invalid URIs fail") {
+            withData(
+                "couch-tracker://text",
+                "couch-tracker://text/",
+                "couch-tracker://text/new-format/abc?xyz=123",
 
-                    // Wrong authority
-                    "couch-tracker://icon/home",
-                    "couch-tracker://icon/default/home",
-                ) { uriString ->
-                    val uri = CouchTrackerUri(URI(uriString))
-                    shouldThrow<IllegalArgumentException> {
-                        DbText.fromUri(uri)
-                    }
+                // Wrong authority
+                "couch-tracker://icon/home",
+                "couch-tracker://icon/default/home",
+            ) { uriString ->
+                val uri = CouchTrackerUri(URI(uriString))
+                shouldThrow<IllegalArgumentException> {
+                    DbText.fromUri(uri)
                 }
             }
         }
     },
 )
+
+private suspend fun FunSpecContainerScope.uriTests(
+    valid: List<Pair<String, DbText>>,
+    invalid: List<String>,
+) {
+    val uriToDbText = valid
+        .map { (uri, dbText) ->
+            CouchTrackerUri(URI(uri)) to dbText
+        }
+
+    context("toCouchTrackerUri()") {
+        withData(uriToDbText) { (ctUri, dbText) ->
+            dbText.toCouchTrackerUri() shouldBe ctUri
+        }
+    }
+    context("fromUri()") {
+        context("valid URIs return the correct text") {
+            withData(uriToDbText) { (ctUri, dbText) ->
+                DbText.fromUri(ctUri) shouldBe dbText
+            }
+        }
+        context("invalid URIs fail") {
+            withData(invalid) { uri ->
+                val ctUri = CouchTrackerUri(URI(uri))
+                shouldThrow<IllegalArgumentException> {
+                    DbText.fromUri(ctUri)
+                }
+            }
+        }
+    }
+}
+
+private fun Arb.Companion.defaultDbText(): Arb<DbText> {
+    val default = enum<DbDefaultText>().map { DbText.Default(it) }
+    val unknown = string(minSize = 1).map { DbText.UnknownDefault(it) }
+    val custom = string().map { DbText.Custom(it) }
+
+    return default.merge(unknown).merge(custom)
+}

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/UriTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/UriTest.kt
@@ -3,20 +3,36 @@ package io.github.couchtracker.utils
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import java.net.URI
 
 class UriTest : FunSpec(
     {
-        context("encodeUriQuery()") {
-            withData(
-                "" to "",
-                " " to "%20",
-                "hello" to "hello",
-                "hello world" to "hello%20world",
-                "hello+world" to "hello+world",
-                "hello/world" to "hello/world",
-                "hello#world" to "hello%23world",
-            ) { (decoded, expected) ->
-                encodeUriQuery(decoded) shouldBe expected
+        context("encodeUriComponent()") {
+            context("basic tests") {
+                withData(
+                    "" to "",
+                    " " to "%20",
+                    "hello" to "hello",
+                    "hello-to_everyone.in~the.world" to "hello-to_everyone.in~the.world",
+                    "hello world" to "hello%20world",
+                    "hello+world" to "hello%2Bworld",
+                    "hello/world" to "hello%2Fworld",
+                    "hello#world" to "hello%23world",
+                    "hello=world" to "hello%3Dworld",
+                    "hello&world" to "hello%26world",
+                ) { (decoded, expected) ->
+                    encodeUriComponent(decoded) shouldBe expected
+                }
+            }
+            test("escaped value is correctly parsed by URL") {
+                checkAll(Arb.string()) { query ->
+                    val encoded = encodeUriComponent(query)
+
+                    URI("https://ciao.com?$encoded").query shouldBe query
+                }
             }
         }
     },

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/UriTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/UriTest.kt
@@ -1,16 +1,18 @@
 package io.github.couchtracker.utils
 
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import java.net.URI
 
 class UriTest : FunSpec(
     {
-        context("encodeUriComponent()") {
+        context("encode/decode URI component") {
             context("basic tests") {
                 withData(
                     "" to "",
@@ -23,8 +25,13 @@ class UriTest : FunSpec(
                     "hello#world" to "hello%23world",
                     "hello=world" to "hello%3Dworld",
                     "hello&world" to "hello%26world",
-                ) { (decoded, expected) ->
-                    encodeUriComponent(decoded) shouldBe expected
+                ) { (decoded, encoded) ->
+                    withClue("encode") {
+                        encodeUriComponent(decoded) shouldBe encoded
+                    }
+                    withClue("decode") {
+                        decodeUriComponent(encoded) shouldBe decoded
+                    }
                 }
             }
             test("escaped value is correctly parsed by URL") {
@@ -32,6 +39,37 @@ class UriTest : FunSpec(
                     val encoded = encodeUriComponent(query)
 
                     URI("https://ciao.com?$encoded").query shouldBe query
+                }
+            }
+
+            test("round trip") {
+                checkAll(Arb.string()) {
+                    decodeUriComponent(encodeUriComponent(it)) shouldBe it
+                }
+            }
+        }
+
+        context("pathSegments") {
+            context("basic tests") {
+                withData(
+                    nameFn = { "${it.first} -> ${it.second}" },
+                    "schema://authority" to emptyList(),
+                    "schema://authority/" to emptyList(),
+                    "schema://authority/hello/world" to listOf("hello", "world"),
+                    "schema://authority/hello//world" to listOf("hello", "world"),
+                    "schema://authority/hello/world?query#fragment" to listOf("hello", "world"),
+                    "schema://authority/hello%2Fworld" to listOf("hello/world"),
+                    "schema://authority/hello+world" to listOf("hello+world"),
+                    "schema://authority/hello/world?key=val/ue" to listOf("hello", "world"),
+                ) { (uri, segments) ->
+                    URI(uri).pathSegments() shouldBe segments
+                }
+            }
+
+            test("round trip") {
+                checkAll(Arb.list(Arb.string(minSize = 1))) { paths ->
+                    val uri = URI("schema://authority/" + paths.joinToString(separator = "/") { encodeUriComponent(it) })
+                    uri.pathSegments() shouldBe paths
                 }
             }
         }


### PR DESCRIPTION
Some misc problems in these functions/classes.

### Fix DbText.Custom.toCouchTrackerUri() and improve tests
This function was putting the text in a path component rather than the query string, which was wrong.

Tests have been updated to catch this and expanded with property testing.

This also removes the URI from DbText.UknownDefault and restricts having fragments in DbText URIs, so that the URI can always be reconstructed by DbText.UknownDefault.

### Fix URI.pathSegments
The previous implementation was wrong because it started from the decoded path, which means that a `%2F` escape sequence in a path segment would be interpreted as an actual `/`, thus wronly plitting the single path segment.

### Fix encodeUriQuery and rename to encodeUriComponent
The old function was not working as expected, skipping escaping some characters.

As there is no build-in function to to this, we are implementing it ourselves.
