### PR TITLE
Better handling of invalid databases (#106)

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
@@ -16,13 +16,12 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import io.github.couchtracker.ui.AnimationDefaults
-import io.github.couchtracker.ui.screenContent
+import io.github.couchtracker.ui.composable
 import io.github.couchtracker.ui.screens.main.MainScreen
 import io.github.couchtracker.ui.screens.main.SearchScreen
-import io.github.couchtracker.ui.screens.movie.movieScreen
+import io.github.couchtracker.ui.screens.movie.MovieScreen
 import io.github.couchtracker.ui.screens.settings.settings
 import org.koin.compose.KoinContext
 import kotlin.math.roundToInt
@@ -39,10 +38,10 @@ fun App() {
         MaterialTheme(colorScheme = darkColorScheme()) {
             CompositionLocalProvider(LocalNavController provides navController) {
                 Surface(color = MaterialTheme.colorScheme.background) {
-                    ProfileContext {
+                    ProfileManagerContext {
                         NavHost(
                             navController = navController,
-                            startDestination = "main",
+                            startDestination = MainScreen,
                             enterTransition = {
                                 val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = LinearOutSlowInEasing)
                                 slideInVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
@@ -60,11 +59,9 @@ fun App() {
                                     fadeOut(FADE_ANIMATION_SPEC)
                             },
                         ) {
-                            composable("main") {
-                                MainScreen()
-                            }
-                            composable<SearchScreen> { it.screenContent<SearchScreen>() }
-                            movieScreen()
+                            composable<MainScreen>()
+                            composable<SearchScreen>()
+                            composable<MovieScreen>()
                             settings()
                         }
                     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ProfileDataContext.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ProfileDataContext.kt
@@ -1,0 +1,75 @@
+package io.github.couchtracker
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.couchtracker.db.profile.FullProfileData
+import io.github.couchtracker.db.profile.ProfileDbError
+import io.github.couchtracker.intl.errorMessage
+import io.github.couchtracker.ui.components.ExceptionStackTrace
+import io.github.couchtracker.ui.components.LoadableScreen
+import io.github.couchtracker.ui.components.MessageComposable
+import io.github.couchtracker.ui.components.ProfileSwitcherDialog
+import io.github.couchtracker.utils.Loadable
+import io.github.couchtracker.utils.str
+
+val LocalFullProfileDataContext = staticCompositionLocalOf<FullProfileData> { error("no default profile context") }
+
+@Composable
+fun ProfileDataContext(content: @Composable () -> Unit) {
+    val profileManager = LocalProfileManagerContext.current
+    val fullProfileDataState by profileManager.current.fullProfileDataState.collectAsStateWithLifecycle(initialValue = Loadable.Loading)
+
+    LoadableScreen(
+        data = fullProfileDataState,
+        onError = { ProfileError(it) },
+    ) { fullProfileData ->
+        CompositionLocalProvider(LocalFullProfileDataContext provides fullProfileData) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ProfileError(error: ProfileDbError) {
+    var showProfileDialog by remember { mutableStateOf(false) }
+
+    MessageComposable(
+        modifier = Modifier.fillMaxSize(),
+        icon = Icons.Filled.Error,
+        message = R.string.error_opening_profile.str(),
+    ) {
+        Text(error.errorMessage(), textAlign = TextAlign.Center)
+
+        Spacer(Modifier.height(24.dp))
+        Button(onClick = { showProfileDialog = true }) {
+            Text(R.string.switch_profile.str())
+        }
+        val exception = if (error is ProfileDbError.WithException) error.exception else null
+        if (exception != null) {
+            Spacer(Modifier.size(8.dp))
+            ExceptionStackTrace(exception, Modifier.heightIn(max = 200.dp))
+        }
+    }
+
+    if (showProfileDialog) {
+        ProfileSwitcherDialog(close = { showProfileDialog = false })
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ProfileManagerContext.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ProfileManagerContext.kt
@@ -3,26 +3,21 @@ package io.github.couchtracker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.couchtracker.db.app.AppData
 import io.github.couchtracker.db.app.Profile
 import io.github.couchtracker.db.app.ProfileManager
-import io.github.couchtracker.db.profile.FullProfileData
-import io.github.couchtracker.ui.components.DefaultErrorScreen
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
 import org.koin.compose.koinInject
 
 val LocalProfileManagerContext = staticCompositionLocalOf<ProfileManager> { error("no default profile context") }
-val LocalFullProfileDataContext = staticCompositionLocalOf<FullProfileData> { error("no default profile context") }
 
 @Composable
-fun ProfileContext(content: @Composable () -> Unit) {
+fun ProfileManagerContext(content: @Composable () -> Unit) {
     val appDb = koinInject<AppData>()
 
     val profilesState = remember { appDb.profileQueries.selectAll() }.asListState()
@@ -34,12 +29,12 @@ fun ProfileContext(content: @Composable () -> Unit) {
             false -> Result.Value(profiles)
         },
     ) { profiles ->
-        ProfileContext(profiles = profiles, content = content)
+        ProfileManagerContext(profiles = profiles, content = content)
     }
 }
 
 @Composable
-private fun ProfileContext(profiles: List<Profile>, content: @Composable () -> Unit) {
+private fun ProfileManagerContext(profiles: List<Profile>, content: @Composable () -> Unit) {
     val coroutineScope = rememberCoroutineScope()
     val profileManager = remember { ProfileManager(profiles, coroutineScope) }
     LaunchedEffect(profiles) {
@@ -47,21 +42,6 @@ private fun ProfileContext(profiles: List<Profile>, content: @Composable () -> U
     }
 
     CompositionLocalProvider(LocalProfileManagerContext provides profileManager) {
-        ProfileWithDataContext(content)
-    }
-}
-
-@Composable
-private fun ProfileWithDataContext(content: @Composable () -> Unit) {
-    val profileManager = LocalProfileManagerContext.current
-    val fullProfileDataState by profileManager.current.fullProfileDataState.collectAsStateWithLifecycle(initialValue = Loadable.Loading)
-
-    LoadableScreen(
-        data = fullProfileDataState,
-        onError = { DefaultErrorScreen("Error loading profile data") }, // TODO better error
-    ) { fullProfileData ->
-        CompositionLocalProvider(LocalFullProfileDataContext provides fullProfileData) {
-            content()
-        }
+        content()
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/app/ProfileManager.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/app/ProfileManager.kt
@@ -88,7 +88,7 @@ class ProfileManager(
             .shareIn(
                 scope = coroutineScope,
                 replay = 1,
-                started = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
+                started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 1000, replayExpirationMillis = 0),
             )
     }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/Screen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/Screen.kt
@@ -1,24 +1,33 @@
 package io.github.couchtracker.ui
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import io.github.couchtracker.ProfileDataContext
+import kotlinx.serialization.Serializable
 
-interface Screen {
+@Serializable
+abstract class Screen {
+
+    open fun profileDataContext(): Boolean = true
 
     @Composable
-    fun content()
+    protected abstract fun content()
+
+    @Composable
+    fun ScreenContent() {
+        if (profileDataContext()) {
+            ProfileDataContext { content() }
+        } else {
+            content()
+        }
+    }
 }
 
 // This fails compilation due to a bug: https://youtrack.jetbrains.com/issue/KT-77127
-// inline fun <reified T : Screen> NavGraphBuilder.composable2() {
-//     composable<T> { backStackEntry ->
-//         backStackEntry.toRoute<T>().content()
-//     }
-// }
-
-// Next best thing:
-@Composable
-inline fun <reified T : Screen> NavBackStackEntry.screenContent() {
-    toRoute<T>().content()
+inline fun <reified T : Screen> NavGraphBuilder.composable() {
+    composable<T> { backStackEntry ->
+        backStackEntry.toRoute<T>().ScreenContent()
+    }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ExceptionStackTrace.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ExceptionStackTrace.kt
@@ -1,0 +1,66 @@
+package io.github.couchtracker.ui.components
+
+import android.content.ClipData
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowLeft
+import androidx.compose.material.icons.automirrored.filled.ArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.text.style.TextDecoration
+import io.github.couchtracker.R
+import io.github.couchtracker.utils.str
+import kotlinx.coroutines.launch
+
+@Composable
+fun ExceptionStackTrace(
+    exception: Exception,
+    modifier: Modifier = Modifier,
+) {
+    val coroutineScope = rememberCoroutineScope()
+    var exceptionVisible by remember { mutableStateOf(false) }
+    Row(Modifier.clickable { exceptionVisible = !exceptionVisible }) {
+        val (icon, textRes) = if (exceptionVisible) {
+            Icons.AutoMirrored.Default.ArrowLeft to R.string.hide_exception
+        } else {
+            Icons.AutoMirrored.Default.ArrowRight to R.string.show_exception
+        }
+        Icon(icon, contentDescription = null)
+        Text(textRes.str(), textDecoration = TextDecoration.Underline)
+    }
+    if (exceptionVisible) {
+        val clipboard = LocalClipboard.current
+        val stacktrace = exception.stackTraceToString()
+
+        SelectionContainer(
+            modifier = modifier
+                .verticalScroll(rememberScrollState())
+                .horizontalScroll(rememberScrollState()),
+            content = { Text(stacktrace, style = MaterialTheme.typography.bodySmall) },
+        )
+        Text(
+            modifier = Modifier.clickable {
+                coroutineScope.launch {
+                    clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", stacktrace)))
+                }
+            },
+            text = R.string.copy_exception_stacktrace.str(),
+            textDecoration = TextDecoration.Underline,
+        )
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ProfileDbErrorDialog.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ProfileDbErrorDialog.kt
@@ -1,35 +1,16 @@
 package io.github.couchtracker.ui.components
 
-import android.content.ClipData
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowLeft
-import androidx.compose.material.icons.automirrored.filled.ArrowRight
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.ProfileDbError
@@ -37,7 +18,6 @@ import io.github.couchtracker.intl.errorMessage
 import io.github.couchtracker.utils.ProfileDbActionState
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.str
-import kotlinx.coroutines.launch
 
 @Composable
 fun ProfileDbErrorDialog(actionState: ProfileDbActionState<*>) {
@@ -55,7 +35,7 @@ fun ProfileDbErrorDialog(actionState: ProfileDbActionState<*>) {
 
                     if (exception != null) {
                         Spacer(Modifier.size(8.dp))
-                        ExceptionStackTrace(exception)
+                        ExceptionStackTrace(exception, Modifier.weight(1f))
                     }
                 }
             },
@@ -66,42 +46,6 @@ fun ProfileDbErrorDialog(actionState: ProfileDbActionState<*>) {
                     content = { Text(android.R.string.ok.str()) },
                 )
             },
-        )
-    }
-}
-
-@Composable
-private fun ColumnScope.ExceptionStackTrace(exception: Exception) {
-    val coroutineScope = rememberCoroutineScope()
-    var exceptionVisible by remember { mutableStateOf(false) }
-    Row(Modifier.clickable { exceptionVisible = !exceptionVisible }) {
-        val (icon, textRes) = if (exceptionVisible) {
-            Icons.AutoMirrored.Default.ArrowLeft to R.string.hide_exception
-        } else {
-            Icons.AutoMirrored.Default.ArrowRight to R.string.show_exception
-        }
-        Icon(icon, contentDescription = null)
-        Text(textRes.str(), textDecoration = TextDecoration.Underline)
-    }
-    if (exceptionVisible) {
-        val clipboard = LocalClipboard.current
-        val stacktrace = exception.stackTraceToString()
-
-        SelectionContainer(
-            modifier = Modifier
-                .weight(1f)
-                .verticalScroll(rememberScrollState())
-                .horizontalScroll(rememberScrollState()),
-            content = { Text(stacktrace, style = MaterialTheme.typography.bodySmall) },
-        )
-        Text(
-            modifier = Modifier.clickable {
-                coroutineScope.launch {
-                    clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("", stacktrace)))
-                }
-            },
-            text = R.string.copy_exception_stacktrace.str(),
-            textDecoration = TextDecoration.Underline,
         )
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
@@ -24,10 +24,19 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import io.github.couchtracker.R
 import io.github.couchtracker.ui.ColorSchemes
+import io.github.couchtracker.ui.Screen
 import io.github.couchtracker.utils.str
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object MainScreen : Screen() {
+
+    @Composable
+    override fun content() = Content()
+}
 
 @Composable
-fun MainScreen() {
+private fun Content() {
     val insetTop = ScaffoldDefaults.contentWindowInsets.only(WindowInsetsSides.Top)
     val navController = rememberNavController()
     val currentSection = navController.currentBackStackEntryAsState().value?.destination?.route?.let { Section.fromId(it) } ?: Section.HOME

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/SearchScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/SearchScreen.kt
@@ -100,7 +100,7 @@ import kotlin.time.Duration.Companion.milliseconds
 typealias SearchMediaFilters = Set<SearchableMediaType>
 
 @Serializable
-data class SearchScreen(val filter: SearchableMediaType?) : Screen {
+data class SearchScreen(val filter: SearchableMediaType?) : Screen() {
     @Composable
     override fun content() {
         val navController = LocalNavController.current

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/MainSettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/MainSettingsScreen.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.preference
 
 @Serializable
-data object MainSettingsScreen : Screen {
+data object MainSettingsScreen : Screen() {
     @Composable
     override fun content() = Content()
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/ProfileSettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/ProfileSettingsScreen.kt
@@ -57,7 +57,10 @@ import me.zhanghai.compose.preference.Preference
 import org.koin.compose.koinInject
 
 @Serializable
-data class ProfileSettingsScreen(val id: Long) : Screen {
+data class ProfileSettingsScreen(val id: Long) : Screen() {
+
+    override fun profileDataContext() = false
+
     @Composable
     override fun content() {
         val navController = LocalNavController.current

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/ProfilesSettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/ProfilesSettingsScreen.kt
@@ -32,7 +32,10 @@ import me.zhanghai.compose.preference.Preference
 import org.koin.compose.koinInject
 
 @Serializable
-data object ProfilesSettingsScreen : Screen {
+data object ProfilesSettingsScreen : Screen() {
+
+    override fun profileDataContext() = false
+
     @Composable
     override fun content() = Content()
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/SettingsScreen.kt
@@ -24,11 +24,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
-import io.github.couchtracker.ui.screenContent
+import io.github.couchtracker.ui.composable
 import io.github.couchtracker.utils.str
 import kotlinx.serialization.Serializable
 import me.zhanghai.compose.preference.LocalPreferenceTheme
@@ -39,9 +38,9 @@ data object Settings
 
 fun NavGraphBuilder.settings() {
     navigation<Settings>(startDestination = MainSettingsScreen) {
-        composable<MainSettingsScreen> { it.screenContent<MainSettingsScreen>() }
-        composable<ProfilesSettingsScreen> { it.screenContent<ProfilesSettingsScreen>() }
-        composable<ProfileSettingsScreen> { it.screenContent<ProfileSettingsScreen>() }
+        composable<MainSettingsScreen>()
+        composable<ProfilesSettingsScreen>()
+        composable<ProfileSettingsScreen>()
     }
 }
 

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -26,6 +26,7 @@
     <string name="db_cant_open_error_file_not_found">Il file non esiste.</string>
     <string name="db_cant_open_error_security">All\'app non è stata concessa l\'autorizzazione per aprire il file.</string>
     <string name="db_io_error">Si è verificato un problema di I/O.</string>
+    <string name="error_opening_profile">Errore nell\'apertura del profilo</string>
 
     <string name="main_section_home">Home</string>
     <string name="main_section_shows">Serie</string>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="db_cant_open_error_file_not_found">The file doesn\'t exist.</string>
     <string name="db_cant_open_error_security">The app has not been granted permission to open the file.</string>
     <string name="db_io_error">An I/O issue has been encountered.</string>
+    <string name="error_opening_profile">Error opening profile</string>
 
     <string name="main_section_home">Home</string>
     <string name="main_section_shows">Shows</string>


### PR DESCRIPTION
- Using detailed error message
- Showing stacktrace if available
- Allow to change profile/open profile settings in case of error

Technical notes:
- Split `ProfileContext` in two: `ProfileManagerContext` is always at the top level and allows to have a single `ProfileManager` for the whole app; `ProfileDataContext` provides the full profile data and can be used only where needed. This allows the profile settings to not require it.
- All screens have been aligned to use the `Screen` abstract class so that we can wrap each screen in `ProfileDataContext` automatically.

Note: this has the side-effect of losing the full profile data from memory every time the user navigates to a screen that doesn't require a `ProfileDataContext`.
