### PR TITLE
Add delayed loading indicator when saving or deleting watched item (#103)

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/DelayedActionLoadingIndicator.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/DelayedActionLoadingIndicator.kt
@@ -1,0 +1,45 @@
+package io.github.couchtracker.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.couchtracker.utils.ActionState
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@Composable
+fun DelayedActionLoadingIndicator(
+    action: ActionState<*, *, *, *>,
+    modifier: Modifier = Modifier,
+    delay: Duration = 250.milliseconds,
+    indicator: @Composable () -> Unit = {
+        CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            strokeWidth = 2.dp,
+        )
+    },
+) {
+    var showProgressBar by remember { mutableStateOf(false) }
+
+    LaunchedEffect(action.isLoading) {
+        if (action.isLoading) {
+            delay(delay)
+            showProgressBar = true
+        } else {
+            showProgressBar = false
+        }
+    }
+
+    AnimatedVisibility(visible = showProgressBar, modifier = modifier) {
+        indicator()
+    }
+}


### PR DESCRIPTION
The loading indicator will appear only if the save takes more than 250 ms.

----

Tested adding 3s delay to save:


https://github.com/user-attachments/assets/65646236-fc9e-4482-8418-53185151db31

