### PR TITLE
Improve error handling

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbException.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbException.kt
@@ -1,3 +1,0 @@
-package io.github.couchtracker.tmdb
-
-class TmdbException(e: Exception) : Exception(e.message, e)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbPagingSource.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbPagingSource.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import app.moviebase.tmdb.Tmdb3
 import app.moviebase.tmdb.model.TmdbPageResult
+import io.github.couchtracker.utils.ApiException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -35,7 +36,7 @@ class TmdbPagingSource<T : Any, O : Any>(
                 itemsBefore = loadedBefore,
                 itemsAfter = response.totalResults - loadedBefore - response.results.size,
             )
-        } catch (e: TmdbException) {
+        } catch (e: ApiException) {
             Log.w(LOG_TAG, "Error while loading page $nextPageNumber", e)
             return LoadResult.Error(e)
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
@@ -102,6 +102,15 @@ fun DefaultLoadingScreen() {
 }
 
 @Composable
-fun DefaultErrorScreen(message: String, retry: (() -> Unit)? = null) {
-    ErrorMessageComposable(Modifier.fillMaxSize(), message, retry)
+fun DefaultErrorScreen(
+    errorMessage: String,
+    errorDetails: String?,
+    retry: (() -> Unit)? = null,
+) {
+    ErrorMessageComposable(
+        modifier = Modifier.fillMaxSize(),
+        errorMessage = errorMessage,
+        errorDetails = errorDetails,
+        retry = retry,
+    )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MessageComposable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MessageComposable.kt
@@ -27,6 +27,7 @@ fun MessageComposable(
     modifier: Modifier = Modifier,
     icon: ImageVector,
     message: String,
+    details: String? = null,
     content: @Composable ColumnScope.() -> Unit = {},
 ) {
     Column(
@@ -37,6 +38,10 @@ fun MessageComposable(
         Icon(icon, contentDescription = null, Modifier.size(40.dp))
         Spacer(Modifier.height(24.dp))
         Text(message, textAlign = TextAlign.Center, style = MaterialTheme.typography.headlineSmall)
+        if (details != null) {
+            Spacer(Modifier.height(24.dp))
+            Text(details, textAlign = TextAlign.Center, style = MaterialTheme.typography.bodyMedium)
+        }
         content()
     }
 }
@@ -45,12 +50,14 @@ fun MessageComposable(
 fun ErrorMessageComposable(
     modifier: Modifier = Modifier,
     errorMessage: String,
+    errorDetails: String?,
     retry: (() -> Unit)? = null,
 ) {
     MessageComposable(
         modifier = modifier,
         icon = Icons.Filled.Error,
         message = errorMessage,
+        details = errorDetails,
     ) {
         if (retry != null) {
             Spacer(Modifier.height(24.dp))

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
@@ -60,7 +60,6 @@ import io.github.couchtracker.intl.datetime.TimezoneSkeleton
 import io.github.couchtracker.intl.datetime.YearSkeleton
 import io.github.couchtracker.intl.datetime.localized
 import io.github.couchtracker.intl.formatAndList
-import io.github.couchtracker.tmdb.TmdbException
 import io.github.couchtracker.tmdb.TmdbLanguage
 import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.tmdb.TmdbMovieId
@@ -71,6 +70,7 @@ import io.github.couchtracker.ui.components.OverviewScreenComponents
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetMode
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetScaffold
 import io.github.couchtracker.ui.screens.watchedItem.rememberWatchedItemSheetScaffoldState
+import io.github.couchtracker.utils.ApiException
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.str
 import kotlinx.coroutines.launch
@@ -102,7 +102,7 @@ private fun Content(movie: TmdbMovie) {
     val coroutineScope = rememberCoroutineScope()
     val ctx = LocalContext.current
     val tmdbCache = koinInject<TmdbCache>()
-    var screenModel by remember { mutableStateOf<Loadable<MovieScreenModel, TmdbException>>(Loadable.Loading) }
+    var screenModel by remember { mutableStateOf<Loadable<MovieScreenModel, ApiException>>(Loadable.Loading) }
 
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
@@ -127,8 +127,8 @@ private fun Content(movie: TmdbMovie) {
             onError = { exception ->
                 Surface {
                     DefaultErrorScreen(
-                        // TODO: translate
-                        message = exception.message ?: "Error",
+                        errorMessage = exception.title.string(),
+                        errorDetails = exception.details?.string(),
                         retry = {
                             coroutineScope.launch { load() }
                         },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
@@ -32,13 +32,13 @@ import io.github.couchtracker.db.profile.show.TmdbExternalShowId
 import io.github.couchtracker.db.profile.show.UnknownExternalShowId
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.intl.formatAndList
-import io.github.couchtracker.tmdb.TmdbException
 import io.github.couchtracker.tmdb.TmdbLanguage
 import io.github.couchtracker.tmdb.TmdbShow
 import io.github.couchtracker.ui.Screen
 import io.github.couchtracker.ui.components.DefaultErrorScreen
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.ui.components.OverviewScreenComponents
+import io.github.couchtracker.utils.ApiException
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.str
 import kotlinx.coroutines.launch
@@ -69,7 +69,7 @@ private fun Content(show: TmdbShow) {
     val coroutineScope = rememberCoroutineScope()
     val ctx = LocalContext.current
     val tmdbCache = koinInject<TmdbCache>()
-    var screenModel by remember { mutableStateOf<Loadable<ShowScreenModel, TmdbException>>(Loadable.Loading) }
+    var screenModel by remember { mutableStateOf<Loadable<ShowScreenModel, ApiException>>(Loadable.Loading) }
 
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
@@ -94,8 +94,8 @@ private fun Content(show: TmdbShow) {
             onError = { exception ->
                 Surface {
                     DefaultErrorScreen(
-                        // TODO: translate
-                        message = exception.message ?: "Error",
+                        errorMessage = exception.title.string(),
+                        errorDetails = exception.details?.string(),
                         retry = {
                             coroutineScope.launch { load() }
                         },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/ApiException.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/ApiException.kt
@@ -1,0 +1,32 @@
+package io.github.couchtracker.utils
+
+import io.github.couchtracker.R
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ResponseException
+import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
+
+sealed class ApiException(message: String?, cause: Throwable?) : Exception(message, cause) {
+    @Deprecated("Use title instead", ReplaceWith("title.string()"))
+    override val message: String?
+        get() = super.message
+
+    abstract val title: Text
+    open val details: Text? = message?.let { Text.Literal(it) }
+
+    class ClientError(message: String, override val cause: ClientRequestException) : ApiException(message, cause) {
+        override val title = Text.Resource(R.string.api_exception_client_error)
+    }
+
+    class ServerError(message: String?, override val cause: ResponseException) : ApiException(message, cause) {
+        override val title = Text.Resource(R.string.api_exception_server_error)
+    }
+
+    class IOError(message: String?, override val cause: IOException) : ApiException(message, cause) {
+        override val title = Text.Resource(R.string.api_exception_io_error)
+    }
+
+    class DeserializationError(message: String?, override val cause: SerializationException) : ApiException(message, cause) {
+        override val title = Text.Resource(R.string.api_exception_deserialization_error)
+    }
+}

--- a/composeApp/src/main/res/values-it/api_exception.xml
+++ b/composeApp/src/main/res/values-it/api_exception.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="api_exception_client_error">Errore del client</string>
+    <string name="api_exception_server_error">Errore del server</string>
+    <string name="api_exception_io_error">Errore di I/O</string>
+    <string name="api_exception_deserialization_error">Errore di deserializzazione</string>
+</resources>

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -12,6 +12,7 @@
 
     <string name="more_options">Più opzioni</string>
     <string name="error_loading_items">Errore nel caricare gli elementi</string>
+    <string name="error_loading_items_x">Errore nel caricare gli elementi: %1$s</string>
     <string name="save_failed">Salvataggio fallito</string>
     <string name="save_failed_message">Errore durante il salvataggio nel profilo. %s</string>
     <string name="show_exception">Mostra eccezione</string>

--- a/composeApp/src/main/res/values/api_exception.xml
+++ b/composeApp/src/main/res/values/api_exception.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="api_exception_client_error">Client error</string>
+    <string name="api_exception_server_error">Server error</string>
+    <string name="api_exception_io_error">I/O error</string>
+    <string name="api_exception_deserialization_error">Deserialization error</string>
+</resources>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
 
     <string name="more_options">More options</string>
     <string name="error_loading_items">Error loading items</string>
+    <string name="error_loading_items_x">Error loading items: %1$s</string>
     <string name="save_failed">Save failed</string>
     <string name="save_failed_message">Error saving data in your profile. %s</string>
     <string name="show_exception">Show exception</string>


### PR DESCRIPTION
This commit splits TmdbException in a finite number of errors. Also, the class hierarchy is generic, so it can be reused for other data providers.


PS: this also fixes a bug where Exceptions when loading show/movie weren't always caught

![Screenshot_20250708_221950](https://github.com/user-attachments/assets/bc33dca8-8b90-4d79-b9ba-3d2cbe429878)
![Screenshot_20250708_221943](https://github.com/user-attachments/assets/204bd207-e98d-41e4-a3e5-d7665d431f3f)
![Screenshot_20250708_221927](https://github.com/user-attachments/assets/d7fd201c-ac59-41f2-89fb-a6db07120c96)
