### PR TITLE
Add audio/subtitle language default dimension (#115)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
         implementation(libs.androidx.datastore.preferences)
         implementation(libs.androidx.documentfile)
         implementation(libs.byteSize)
+        implementation(libs.icu4j)
         implementation(libs.palette)
         implementation(libs.preference)
         implementation(libs.tmdb.api)

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -2,3 +2,6 @@
 -dontwarn com.intellij.icons.*
 -dontwarn org.slf4j.impl.*
 -dontwarn reactor.blockhound.**
+
+# ICU4J uses reflection, so we need to keep its classes if we want to access its data
+-keep class com.ibm.icu.** { *; }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/common/adapters/Bcp47LanguageColumnAdapter.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/common/adapters/Bcp47LanguageColumnAdapter.kt
@@ -1,0 +1,15 @@
+package io.github.couchtracker.db.common.adapters
+
+import app.cash.sqldelight.ColumnAdapter
+import io.github.couchtracker.db.profile.Bcp47Language
+
+object Bcp47LanguageColumnAdapter : ColumnAdapter<Bcp47Language, String> {
+
+    override fun decode(databaseValue: String): Bcp47Language {
+        return Bcp47Language.of(databaseValue)
+    }
+
+    override fun encode(value: Bcp47Language): String {
+        return value.toString()
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/Bcp47Language.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/Bcp47Language.kt
@@ -1,0 +1,56 @@
+package io.github.couchtracker.db.profile
+
+import com.ibm.icu.util.ULocale
+import io.github.couchtracker.utils.stripExtensions
+
+/**
+ * This class represents a language, as per the [IETF BCP 47 standard](https://en.wikipedia.org/wiki/IETF_language_tag).
+ *
+ * It wraps a [ULocale], disallowing anything that doesn't represent an IETF BCP 47 language tag.
+ */
+@JvmInline
+value class Bcp47Language(val locale: ULocale) {
+    init {
+        // Extensions don't add identifying information about a language, but are just supplementary information
+        // For this reason, we want to disallow them from this class
+        require(locale.extensionKeys.isEmpty()) {
+            "The given ULocale ($locale) contains extensions, which are not allowed in Bcp47Language"
+        }
+        // If the round trip doesn't yield an identical locale, it means that it contains invalid information which was either transformed
+        // or omitted by the toLanguageTag() call.
+        // This means that the given ULocale does not represent a valid BCP47 language tag
+        require(ULocale.forLanguageTag(locale.toLanguageTag()) == locale) {
+            "The given ULocale ($locale) does not represent a valid BCP47 language tag"
+        }
+    }
+
+    infix fun isEqualTo(another: Bcp47Language): Boolean {
+        return locale == another.locale
+    }
+
+    override fun toString(): String = locale.toLanguageTag()
+
+    companion object {
+        fun of(languageTag: String): Bcp47Language {
+            require(languageTag.isNotEmpty()) { "invalid empty language tag" }
+
+            val locale = ULocale.forLanguageTag(languageTag)
+            if (languageTag != "und") {
+                // ULocale with empty language means `und`
+                // Any string passed to forLanguageTag that is no recognized/value, will return ULocale("")
+                // Unless we wanted to create the language `und` explicitly, we need to fail
+                require(locale.language.isNotBlank()) {
+                    "The given value ($languageTag) is not a valid IANA BCP47 language tag"
+                }
+            }
+            return Bcp47Language(locale)
+        }
+    }
+}
+
+/**
+ * Converts this [ULocale] to a [Bcp47Language], possibly losing information that is not representable in [Bcp47Language].
+ */
+fun ULocale.toLossyBcp47Language(): Bcp47Language {
+    return Bcp47Language(ULocale.forLanguageTag(this.stripExtensions().toLanguageTag()))
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ProfileDbCommonModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ProfileDbCommonModule.kt
@@ -1,6 +1,7 @@
 package io.github.couchtracker.db.profile
 
 import app.cash.sqldelight.EnumColumnAdapter
+import io.github.couchtracker.db.common.adapters.Bcp47LanguageColumnAdapter
 import io.github.couchtracker.db.common.adapters.DbIconColumnAdapter
 import io.github.couchtracker.db.common.adapters.DbTextColumnAdapter
 import io.github.couchtracker.db.common.adapters.InstantColumnAdapter
@@ -36,6 +37,9 @@ val ProfileDbCommonModule = module {
             WatchedItemDimensionChoiceAdapter = WatchedItemDimensionChoice.Adapter(
                 nameAdapter = DbTextColumnAdapter,
                 iconAdapter = DbIconColumnAdapter,
+            ),
+            WatchedItemLanguageAdapter = WatchedItemLanguage.Adapter(
+                languageAdapter = Bcp47LanguageColumnAdapter,
             ),
         ).also { db ->
             ProfileDefaultDataHandler.handle(db)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/defaultdata/WatchedItemDimensionAudioLanguageDefaultData.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/defaultdata/WatchedItemDimensionAudioLanguageDefaultData.kt
@@ -1,0 +1,24 @@
+package io.github.couchtracker.db.profile.defaultdata
+
+import io.github.couchtracker.db.common.defaultdata.DefaultData
+import io.github.couchtracker.db.profile.ProfileData
+import io.github.couchtracker.db.profile.model.text.DbDefaultText
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionType
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemType
+
+object WatchedItemDimensionAudioLanguageDefaultData : DefaultData<ProfileData> {
+
+    override fun insert(db: ProfileData) {
+        db.watchedItemDimensionQueries.insert(
+            name = DbDefaultText.AUDIO_LANGUAGE.toDbText(),
+            appliesTo = WatchedItemType.entries.toSet(),
+            type = WatchedItemDimensionType.Language,
+            isImportant = false,
+            manualSortIndex = null,
+        ).executeAsOne()
+    }
+
+    override fun upgradeTo(db: ProfileData, version: Int) {
+        // no-op
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/defaultdata/WatchedItemDimensionDefaultData.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/defaultdata/WatchedItemDimensionDefaultData.kt
@@ -12,5 +12,7 @@ object WatchedItemDimensionDefaultData : MultipleDefaultData<ProfileData>(
     WatchedItemDimensionStreamingProviderDefaultData,
     WatchedItemDimensionPhysicalMediaDefaultData,
     WatchedItemDimensionResolutionDefaultData,
+    WatchedItemDimensionAudioLanguageDefaultData,
+    WatchedItemDimensionSubtitleLanguageDefaultData,
     WatchedItemDimensionNotesDefaultData,
 )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/defaultdata/WatchedItemDimensionSubtitleLanguageDefaultData.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/defaultdata/WatchedItemDimensionSubtitleLanguageDefaultData.kt
@@ -1,0 +1,24 @@
+package io.github.couchtracker.db.profile.defaultdata
+
+import io.github.couchtracker.db.common.defaultdata.DefaultData
+import io.github.couchtracker.db.profile.ProfileData
+import io.github.couchtracker.db.profile.model.text.DbDefaultText
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionType
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemType
+
+object WatchedItemDimensionSubtitleLanguageDefaultData : DefaultData<ProfileData> {
+
+    override fun insert(db: ProfileData) {
+        db.watchedItemDimensionQueries.insert(
+            name = DbDefaultText.SUBTITLES_LANGUAGE.toDbText(),
+            appliesTo = WatchedItemType.entries.toSet(),
+            type = WatchedItemDimensionType.Language,
+            isImportant = false,
+            manualSortIndex = null,
+        ).executeAsOne()
+    }
+
+    override fun upgradeTo(db: ProfileData, version: Int) {
+        // no-op
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/text/DbDefaultText.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/text/DbDefaultText.kt
@@ -68,6 +68,8 @@ enum class DbDefaultText(val text: Text) {
     STREAMING_PROVIDER_PARAMOUNT_PLUS(R.string.streaming_provider_paramount_plus),
     STREAMING_PROVIDER_PRIME_VIDEO(R.string.streaming_provider_prime_video),
 
+    AUDIO_LANGUAGE(R.string.audio_language),
+    SUBTITLES_LANGUAGE(R.string.subtitle_language),
     NOTES(R.string.notes),
     ;
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionType.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionType.kt
@@ -24,6 +24,10 @@ sealed interface WatchedItemDimensionType {
     }
 
     @Serializable
+    @SerialName("language")
+    data object Language : WatchedItemDimensionType
+
+    @Serializable
     @SerialName("freeText")
     data object FreeText : WatchedItemDimensionType
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemWrapper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemWrapper.kt
@@ -39,6 +39,8 @@ data class WatchedItemWrapper(
                 }
             val freeTexts = db.watchedItemFreeTextQueries.selectAll().executeAsList()
                 .associateBy { it.watchedItem to it.watchedItemDimension }
+            val languages = db.watchedItemLanguageQueries.selectAll().executeAsList()
+                .associateBy { it.watchedItem to it.watchedItemDimension }
 
             return db.watchedItemQueries.selectAll().executeAsList().map { watchedItem ->
                 WatchedItemWrapper(
@@ -47,6 +49,7 @@ data class WatchedItemWrapper(
                         val key = watchedItem.id to dimension.id
                         when (dimension) {
                             is WatchedItemDimensionWrapper.Choice -> dimension.selection(choices[key].orEmpty())
+                            is WatchedItemDimensionWrapper.Language -> dimension.selection(languages[key])
                             is WatchedItemDimensionWrapper.FreeText -> dimension.selection(freeTexts[key])
                         }
                     },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/Utils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/Utils.kt
@@ -8,10 +8,13 @@ import app.moviebase.tmdb.image.TmdbImageUrlBuilder
 import app.moviebase.tmdb.model.TmdbCrew
 import app.moviebase.tmdb.model.TmdbFileImage
 import app.moviebase.tmdb.model.TmdbImages
+import app.moviebase.tmdb.model.TmdbMovieDetail
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
+import com.ibm.icu.util.ULocale
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.ui.generateColorScheme
 
 suspend fun TmdbImage?.prepareAndExtractColorScheme(
@@ -48,4 +51,13 @@ fun TmdbImages.linearize(): List<TmdbFileImage> {
 
 fun List<TmdbCrew>.directors(): List<TmdbCrew> {
     return filter { it.job == "Director" }
+}
+
+fun TmdbMovieDetail.language(): Bcp47Language {
+    val allLocales = ULocale.getAvailableLocales()
+    return originCountry
+        .map { ULocale(originalLanguage, it) }
+        .firstOrNull { it in allLocales }
+        ?.let { Bcp47Language(it) }
+        ?: Bcp47Language.of(originalLanguage)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LanguagePickerDialog.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LanguagePickerDialog.kt
@@ -1,0 +1,91 @@
+package io.github.couchtracker.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.Bcp47Language
+import io.github.couchtracker.utils.LanguageCategory
+import io.github.couchtracker.utils.LanguageItem
+import io.github.couchtracker.utils.MixedValueTree
+import io.github.couchtracker.utils.allLeafs
+import io.github.couchtracker.utils.countLeafs
+import io.github.couchtracker.utils.currentFirstLocale
+import io.github.couchtracker.utils.findLeafValue
+import io.github.couchtracker.utils.languageTree
+import io.github.couchtracker.utils.pluralStr
+import io.github.couchtracker.utils.str
+import io.github.couchtracker.utils.toULocale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LanguagePickerDialog(
+    language: Bcp47Language?,
+    onLanguageSelected: (Bcp47Language?) -> Unit,
+    suggestedLanguages: List<Bcp47Language>,
+    onClose: () -> Unit,
+) {
+    val userLocale = LocalConfiguration.currentFirstLocale.toULocale()
+    val languagesTreeRoot = remember { Bcp47Language.languageTree(userLocale) }
+    val selected = language?.let { languagesTreeRoot.findLeafValue { it.language isEqualTo language } }
+
+    TreePickerDialog(
+        selected = selected,
+        onSelect = { onLanguageSelected(it?.language) },
+        root = languagesTreeRoot,
+        suggestedOptions = SuggestedOptions(
+            suggestedString = { R.string.suggested_languages.str() },
+            allString = { R.string.all_languages.str() },
+            suggestedItems = { node ->
+                if (node is MixedValueTree.Root<*, *, *>) {
+                    languagesTreeRoot
+                        .allLeafs()
+                        .filter { it.value.language in suggestedLanguages }
+                        .sortedBy { suggestedLanguages.indexOf(it.value.language) }
+                        .toList()
+                } else {
+                    emptyList()
+                }
+            },
+        ),
+        itemName = { it.language.locale.getDisplayName(userLocale) },
+        itemTrailingContent = { Text(it.language.toString()) },
+        itemSupportingName = {
+            when (it) {
+                is LanguageItem.Normal -> it.language.locale.getDisplayName(it.language.locale)
+                is LanguageItem.Special -> it.description.str()
+            }
+        },
+        itemKey = { it.toString() },
+        itemSearchStrings = {
+            listOfNotNull(
+                it.language.locale.getDisplayName(userLocale),
+                when (it) {
+                    is LanguageItem.Normal -> it.language.locale.getDisplayName(it.language.locale)
+                    is LanguageItem.Special -> null
+                },
+                it.language.toString(),
+            )
+        },
+        categoryName = {
+            when (it.value) {
+                is LanguageCategory.Language -> it.value.language.locale.getDisplayName(userLocale)
+                LanguageCategory.Special -> R.string.language_category_special.str()
+            }
+        },
+        categorySupportingName = {
+            val cnt = it.countLeafs()
+            R.plurals.language_category_subtitle.pluralStr(cnt, cnt)
+        },
+        icon = { Icon(Icons.Default.Language, contentDescription = null) },
+        title = { Text(R.string.select_language.str()) },
+        searchPlaceHolder = { R.string.language_search_placeholder.str() },
+        nullSelectionButtonText = null,
+        onClose = onClose,
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/TimezonePickerDialog.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/TimezonePickerDialog.kt
@@ -13,7 +13,7 @@ import io.github.couchtracker.R
 import io.github.couchtracker.utils.TimeZoneCategory
 import io.github.couchtracker.utils.countLeafs
 import io.github.couchtracker.utils.currentFirstLocale
-import io.github.couchtracker.utils.findLeaf
+import io.github.couchtracker.utils.findLeafValue
 import io.github.couchtracker.utils.pluralStr
 import io.github.couchtracker.utils.str
 import io.github.couchtracker.utils.timezonesTree
@@ -27,7 +27,7 @@ fun TimezonePickerDialog(
     onClose: () -> Unit,
 ) {
     val timezonesTreeRoot = remember { TimeZone.timezonesTree() }
-    val selected = timezonesTreeRoot.findLeaf { it.timezone == timezone }
+    val selected = timezonesTreeRoot.findLeafValue { it.timezone == timezone }
 
     TreePickerDialog(
         selected = selected,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
@@ -142,7 +142,8 @@ private fun Content(movie: TmdbMovie) {
                 WatchedItemSheetScaffold(
                     scaffoldState = scaffoldState,
                     watchedItemType = WatchedItemType.MOVIE,
-                    approximateVideoRuntime = model.runtime ?: 2.hours,
+                    approximateMediaRuntime = model.runtime ?: 2.hours,
+                    mediaLanguages = listOf(model.originalLanguage),
                 ) {
                     Scaffold(
                         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -8,11 +8,13 @@ import app.moviebase.tmdb.model.TmdbFileImage
 import app.moviebase.tmdb.model.TmdbGenre
 import app.moviebase.tmdb.model.TmdbVideo
 import coil3.request.ImageRequest
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.tmdb.TmdbMovieId
 import io.github.couchtracker.tmdb.TmdbRating
 import io.github.couchtracker.tmdb.directors
+import io.github.couchtracker.tmdb.language
 import io.github.couchtracker.tmdb.linearize
 import io.github.couchtracker.tmdb.prepareAndExtractColorScheme
 import io.github.couchtracker.tmdb.rating
@@ -42,6 +44,7 @@ data class MovieScreenModel(
     val overview: String,
     val year: Int?,
     val runtime: Duration?,
+    val originalLanguage: Bcp47Language,
     val rating: TmdbRating?,
     val genres: List<TmdbGenre>,
     val director: List<TmdbCrew>,
@@ -84,6 +87,7 @@ suspend fun loadMovie(
                         overview = details.overview,
                         year = details.releaseDate?.year,
                         runtime = details.runtime?.minutes,
+                        originalLanguage = details.language(),
                         rating = details.rating(),
                         genres = details.genres,
                         director = credits.await().crew.directors(),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/LanguageSelection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/LanguageSelection.kt
@@ -1,0 +1,132 @@
+package io.github.couchtracker.ui.screens.watchedItem
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import io.github.couchtracker.LocalFullProfileDataContext
+import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.Bcp47Language
+import io.github.couchtracker.db.profile.FullProfileData
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionSelection
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionWrapper
+import io.github.couchtracker.db.profile.toLossyBcp47Language
+import io.github.couchtracker.ui.components.LanguagePickerDialog
+import io.github.couchtracker.utils.currentFirstLocale
+import io.github.couchtracker.utils.str
+import io.github.couchtracker.utils.toULocale
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.days
+
+private val USED_LANGUAGES_RECENCY_CUTOFF = 180.days
+private const val SUGGESTED_LANGAUGES_TOP_USED_LIMIT = 3
+private const val SUGGESTED_LANGAUGES_CHIPS_LIMT = 3
+
+@Composable
+fun WatchedItemSheetScope.LanguageSection(
+    enabled: Boolean,
+    mediaLanguages: List<Bcp47Language>,
+    selection: WatchedItemDimensionSelection.Language,
+    onSelectionChange: (WatchedItemDimensionSelection.Language) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val userLocale = LocalConfiguration.currentFirstLocale.toULocale()
+    val data = LocalFullProfileDataContext.current
+    val now = remember { Clock.System.now() }
+    val suggestedLanguages = mediaLanguages
+        .plus(userLocale.toLossyBcp47Language())
+        .plus(data.topUsedLanguages(now, selection.dimension).take(SUGGESTED_LANGAUGES_TOP_USED_LIMIT))
+        .distinct()
+
+    // We want the list of languages in the chip list to be mostly static, except if we select a new language
+    val initialSelection = remember { selection.value }
+    val chipLanguages = remember(selection.value) {
+        suggestedLanguages
+            .take(SUGGESTED_LANGAUGES_CHIPS_LIMT)
+            .plus(initialSelection)
+            .plus(selection.value)
+            .distinct()
+            .filterNotNull()
+    }
+
+    var showDialog by remember { mutableStateOf(false) }
+
+    Section(title = selection.dimension.name.text, validity = selection.validity(), modifier = modifier) {
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(chipLanguages, key = { it.toString() }) { language ->
+                FilterChip(
+                    enabled = enabled,
+                    selected = language == selection.value,
+                    onClick = { onSelectionChange(selection.toggled(language)) },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    ),
+                    label = { Text(language.locale.getDisplayName(userLocale)) },
+                )
+            }
+            item {
+                FilterChip(
+                    enabled = enabled,
+                    selected = false,
+                    onClick = { showDialog = true },
+                    label = { Text(R.string.watched_item_language_other.str()) },
+                )
+            }
+        }
+        if (showDialog) {
+            LanguagePickerDialog(
+                language = selection.value,
+                onLanguageSelected = {
+                    onSelectionChange(selection.copy(value = it))
+                    showDialog = false
+                },
+                suggestedLanguages = suggestedLanguages,
+                onClose = { showDialog = false },
+            )
+        }
+    }
+}
+
+/**
+ * Returns list of all previously used languages for the given [dimension] that were added in the last [USED_LANGUAGES_RECENCY_CUTOFF].
+ */
+private fun FullProfileData.topUsedLanguages(
+    now: Instant,
+    dimension: WatchedItemDimensionWrapper.Language,
+): List<Bcp47Language> {
+    return this.watchedItems
+        // Filter items that have been added recently
+        .filter { now - it.addedAt < USED_LANGUAGES_RECENCY_CUTOFF }
+        // Sort by descending added date so that count parity, most recently used languages win
+        .sortedByDescending { it.addedAt }
+        // Get selected language for the same dimension, excluding null selections
+        .mapNotNull { watchedItem ->
+            watchedItem.dimensions
+                .find { it.dimension == dimension }
+                ?.let { it as WatchedItemDimensionSelection.Language }
+                ?.value
+        }
+        // Count each occurrence
+        .groupingBy { it }
+        .eachCount()
+        .entries
+        // Sort by most used
+        .sortedByDescending { (_, count) -> count }
+        .map { it.key }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemSheetScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemSheetScaffold.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionSelection
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionSelectionValidity
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemSelections
@@ -131,7 +132,8 @@ fun rememberWatchedItemSheetScaffoldState(): WatchedItemSheetScaffoldState {
 fun WatchedItemSheetScaffold(
     scaffoldState: WatchedItemSheetScaffoldState,
     watchedItemType: WatchedItemType,
-    approximateVideoRuntime: Duration,
+    approximateMediaRuntime: Duration,
+    mediaLanguages: List<Bcp47Language>,
     content: @Composable () -> Unit,
 ) {
     val bottomSheetState = scaffoldState.scaffoldState.bottomSheetState
@@ -170,7 +172,8 @@ fun WatchedItemSheetScaffold(
                         selections = rememberWatchedItemSelections(watchedItemType, mode = mode),
                         bottomSheetState = bottomSheetState,
                         watchedItemType = watchedItemType,
-                        approximateVideoRuntime = approximateVideoRuntime,
+                        approximateMediaRuntime = approximateMediaRuntime,
+                        mediaLanguages = mediaLanguages,
                         onDismissRequest = { scaffoldState.close() },
                         onHeaderHeightChange = { headerHeight = it },
                         onScrollLabelHeightChange = { scrollLabelHeight = it },
@@ -199,7 +202,8 @@ private fun WatchedItemSheetContent(
     selections: WatchedItemSelections,
     bottomSheetState: SheetState,
     watchedItemType: WatchedItemType,
-    approximateVideoRuntime: Duration,
+    approximateMediaRuntime: Duration,
+    mediaLanguages: List<Bcp47Language>,
     onDismissRequest: () -> Unit,
     onHeaderHeightChange: (Int) -> Unit,
     onScrollLabelHeightChange: (Int) -> Unit,
@@ -229,6 +233,13 @@ private fun WatchedItemSheetContent(
         when (selection) {
             is WatchedItemDimensionSelection.Choice -> ChoiceSection(
                 enabled = enabled,
+                selection = selection,
+                onSelectionChange = selections::update,
+            )
+
+            is WatchedItemDimensionSelection.Language -> LanguageSection(
+                enabled = enabled,
+                mediaLanguages = mediaLanguages,
                 selection = selection,
                 onSelectionChange = selections::update,
             )
@@ -265,7 +276,7 @@ private fun WatchedItemSheetContent(
                             style = MaterialTheme.typography.titleLarge,
                         )
                         Spacer(Modifier.height(16.dp))
-                        DateTimeSection(enabled = enabled, selections.datetime, watchedItemType, approximateVideoRuntime)
+                        DateTimeSection(enabled = enabled, selections.datetime, watchedItemType, approximateMediaRuntime)
                         for (selection in selections.dimensions.filter { it.dimension.isImportant }) {
                             AnimatedVisibility(visible = selection.dimension.isVisible(selections)) {
                                 DimensionSection(selection)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Language.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Language.kt
@@ -1,0 +1,95 @@
+package io.github.couchtracker.utils
+
+import androidx.annotation.StringRes
+import com.ibm.icu.util.ULocale
+import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.Bcp47Language
+
+sealed interface LanguageCategory {
+
+    data object Special : LanguageCategory
+
+    @JvmInline
+    value class Language(val language: Bcp47Language) : LanguageCategory {
+        init {
+            require(language.isLanguageOnly()) { "Illegal category language, $language given" }
+        }
+    }
+}
+
+sealed interface LanguageItem {
+
+    val language: Bcp47Language
+
+    /**
+     * Represents a "normal" language, that has no special meaning beyond identifying a specific language.
+     */
+    @JvmInline
+    value class Normal(override val language: Bcp47Language) : LanguageItem
+
+    /**
+     * Represents a special language, as defined by ISO/BCP standards.
+     *
+     * These languages are hardcoded and don't represent any particular language, but represent a concept.
+     */
+    enum class Special(
+        override val language: Bcp47Language,
+        @StringRes val description: Int,
+    ) : LanguageItem {
+        NO_LINGUISTIC_CONTENT(Bcp47Language.of("zxx"), R.string.language_no_lingusitc_content_description),
+        MULTIPLE_LANGUAGES(Bcp47Language.of("mul"), R.string.language_multilanguage_description),
+        UNDETERMINED(Bcp47Language.of("und"), R.string.language_undetermined_description),
+        ;
+
+        companion object {
+            val LANGUAGES = Special.entries.map { it.language }.toSet()
+        }
+    }
+}
+
+/**
+ * Builds a tree of [Bcp47Language], which are grouped by base language.
+ *
+ * They are sorted by display name according to [sortLocale].
+ */
+fun Bcp47Language.Companion.languageTree(sortLocale: ULocale): MixedValueTree.Root<Unit, LanguageCategory, LanguageItem> {
+    return MixedValueTree.Root(
+        value = Unit,
+        children = listOf(
+            MixedValueTree.Intermediate(
+                value = LanguageCategory.Special,
+                children = LanguageItem.Special.entries.map { MixedValueTree.Leaf(it) },
+            ),
+        ).plus(
+            ULocale.getAvailableLocales()
+                .map { Bcp47Language(it) }
+                .filter { it !in LanguageItem.Special.LANGUAGES }
+                .groupBy { it.locale.language }
+                .values
+                .map { languages ->
+                    if (languages.size == 1) {
+                        MixedValueTree.Leaf(LanguageItem.Normal(languages.single()))
+                    } else {
+                        MixedValueTree.Intermediate(
+                            value = LanguageCategory.Language(languages.single { it.isLanguageOnly() }),
+                            children = languages.map { MixedValueTree.Leaf(LanguageItem.Normal(it)) },
+                        )
+                    }
+                }
+                .sortedBy {
+                    when (it) {
+                        is MixedValueTree.Intermediate -> it.value.language
+                        is MixedValueTree.Leaf -> it.value.language
+                    }.locale.getDisplayName(sortLocale)
+                },
+        ),
+    )
+}
+
+fun Bcp47Language.isLanguageOnly(): Boolean {
+    return locale.country.isNullOrBlank() && locale.variant.isNullOrBlank() && locale.script.isNullOrBlank()
+}
+
+fun Bcp47Language.Companion.getDefault(): Bcp47Language {
+    return Bcp47Language(ULocale.getDefault().stripExtensions())
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Locale.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Locale.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
+import com.ibm.icu.util.ULocale
 import java.util.Locale
 
 val CompositionLocal<Configuration>.currentLocales
@@ -22,3 +23,5 @@ val CompositionLocal<Configuration>.currentFirstLocale
     get(): Locale {
         return checkNotNull(currentLocales.get(0)) { "No locales available" }
     }
+
+fun Locale.toULocale() = ULocale(toString())

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/ULocale.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/ULocale.kt
@@ -1,0 +1,13 @@
+package io.github.couchtracker.utils
+
+import com.ibm.icu.util.ULocale
+
+fun ULocale.stripExtensions(): ULocale {
+    val id = toString()
+    return ULocale(
+        when {
+            '@' in id -> id.removeRange(id.indexOf('@')..<id.length)
+            else -> id
+        },
+    )
+}

--- a/composeApp/src/main/res/values-it/default-strings.xml
+++ b/composeApp/src/main/res/values-it/default-strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="audio_language">Lingua audio</string>
+    <string name="subtitle_language">Lingua sottotitoli</string>
     <string name="notes">Note</string>
 </resources>

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -71,6 +71,7 @@
     <string name="watched_movie_time_just_finished">Appena finito</string>
     <string name="watched_item_time_today">Oggi</string>
     <string name="watched_item_time_custom">Personalizzato</string>
+    <string name="watched_item_language_other">Altra</string>
     <string name="too_many_choices_selected">Troppe scelte selezionate, il massmo è %d</string>
 
     <string name="mark_movie_as_watched">Segna come visto</string>
@@ -88,4 +89,18 @@
         <item quantity="many">%1$d episodi</item>
         <item quantity="other">%1$d episodi</item>
     </plurals>
+
+    <string name="select_language">Seleziona lingua</string>
+    <string name="language_category_special">Lingue speciali</string>
+    <string name="language_no_lingusitc_content_description">Il contenuto non ha nessuna lingua</string>
+    <string name="language_multilanguage_description">Il contenuto ha più di una lingua</string>
+    <string name="language_undetermined_description">La lingua del contenuto è sconosciuta</string>
+    <plurals name="language_category_subtitle">
+        <item quantity="one">%1$d variante</item>
+        <item quantity="many">%1$d varianti</item>
+        <item quantity="other">%1$d varianti</item>
+    </plurals>
+    <string name="language_search_placeholder">Nome, nome originale, id</string>
+    <string name="suggested_languages">Suggerite</string>
+    <string name="all_languages">Tutte le lingue</string>
 </resources>

--- a/composeApp/src/main/res/values/default-strings.xml
+++ b/composeApp/src/main/res/values/default-strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="audio_language">Audio language</string>
+    <string name="subtitle_language">Subtitle language</string>
     <string name="notes">Notes</string>
 </resources>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -70,6 +70,7 @@
     <string name="watched_movie_time_just_finished">Just finished</string>
     <string name="watched_item_time_today">Today</string>
     <string name="watched_item_time_custom">Custom</string>
+    <string name="watched_item_language_other">Other</string>
     <string name="too_many_choices_selected">Too many choices selected, the maximum is %d</string>
 
     <string name="mark_movie_as_watched">Mark as watched</string>
@@ -86,4 +87,17 @@
         <item quantity="one">%1$d episode</item>
         <item quantity="other">%1$d episodes</item>
     </plurals>
+
+    <string name="select_language">Select language</string>
+    <string name="language_category_special">Special languages</string>
+    <string name="language_no_lingusitc_content_description">The content has no language</string>
+    <string name="language_multilanguage_description">The content has multiple languages</string>
+    <string name="language_undetermined_description">The language of the content is unknown</string>
+    <plurals name="language_category_subtitle">
+        <item quantity="one">%1$d variant</item>
+        <item quantity="other">%1$d variants</item>
+    </plurals>
+    <string name="language_search_placeholder">Name, original name, identifier</string>
+    <string name="suggested_languages">Suggested</string>
+    <string name="all_languages">All languages</string>
 </resources>

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemLanguage.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemLanguage.sq
@@ -1,0 +1,25 @@
+import io.github.couchtracker.db.profile.Bcp47Language;
+
+/**
+ * Contains the values for the dimensions of type language for a single `WatchedItem`.
+ */
+CREATE TABLE WatchedItemLanguage(
+  watchedItem INTEGER NOT NULL,
+  watchedItemDimension INTEGER NOT NULL,
+  language TEXT AS Bcp47Language NOT NULL,
+  PRIMARY KEY(watchedItem, watchedItemDimension),
+  FOREIGN KEY(watchedItem) REFERENCES WatchedItem(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY(watchedItemDimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+selectAll:
+SELECT * FROM WatchedItemLanguage;
+
+delete:
+DELETE FROM WatchedItemLanguage
+WHERE watchedItem = :watchedItem AND watchedItemDimension = :watchedItemDimension;
+
+upsert:
+INSERT INTO WatchedItemLanguage(watchedItem, watchedItemDimension, language)
+VALUES(:watchedItem, :watchedItemDimension, :language)
+ON CONFLICT(watchedItem, watchedItemDimension) DO UPDATE SET language = :language;

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/Bcp47LanguageTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/Bcp47LanguageTest.kt
@@ -1,0 +1,92 @@
+package io.github.couchtracker.db.profile
+
+import com.ibm.icu.util.ULocale
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.lang.IllegalArgumentException
+
+class Bcp47LanguageTest : FunSpec(
+    {
+        context("constructor") {
+            context("fails with invalid locales") {
+                withData(
+                    nameFn = { it.toString().ifBlank { "<blank>" } },
+                    // Invalid language
+                    ULocale("x"),
+                    ULocale("   "),
+
+                    // Invalid variant
+                    ULocale("it_IT_#U_FW_MON_MU_CELSIUS"),
+
+                    // Contains extensions
+                    ULocale("es_ES@currency=EUR;collation=traditional"),
+                    ULocale("de_DE@attribute=email;collation=phonebook;x=linux"),
+                ) { locale ->
+                    shouldThrow<IllegalArgumentException> {
+                        Bcp47Language(locale)
+                    }
+                }
+            }
+
+            context("succeeds with all available locales and special ones") {
+                withData(
+                    nameFn = { it.toString().ifEmpty { "<empty>" } },
+                    ULocale.getAvailableLocales().toList() + listOf(
+                        ULocale("und"),
+                        ULocale("mul"),
+                        ULocale("zxx"),
+                    ),
+                ) { locale ->
+                    shouldNotThrowAny {
+                        Bcp47Language(locale)
+                    }
+                }
+            }
+        }
+
+        context("of") {
+            context("returns expected value") {
+                withData(
+                    nameFn = { it.first },
+                    "it" to Bcp47Language(ULocale("it")),
+                    "pt-BR" to Bcp47Language(ULocale("pt", "BR")),
+                    "it-Latn-IT" to Bcp47Language(ULocale("it", "Latn", "IT")),
+                    "en-US-u-va-posix" to Bcp47Language(ULocale("en", "US", "POSIX")),
+                ) { (value, expected) ->
+                    Bcp47Language.of(value) shouldBe expected
+                }
+            }
+            context("fails on invalid inputs") {
+                ->
+                withData(
+                    nameFn = { it.ifEmpty { "<empty>" }.ifBlank { "<blank>" } },
+                    "",
+                    "  ",
+                    "not a valid language tag",
+                    "it_IT", // Invalid separator
+                    "xxxxxxxxxxxxxxxxxxxx",
+                ) { value ->
+                    val thrown = shouldThrow<IllegalArgumentException> {
+                        Bcp47Language.of(value)
+                    }
+                    thrown.message shouldContain value
+                }
+            }
+        }
+
+        context("toLossyBcp47Language") {
+            withData(
+                nameFn = { it.first.toString() },
+                ULocale("it_IT_#U_FW_MON_MU_CELSIUS") to Bcp47Language.of("it-IT"),
+                ULocale("es_ES@currency=EUR;collation=traditional") to Bcp47Language.of("es-ES"),
+                ULocale("de_DE@attribute=email;collation=phonebook;x=linux") to Bcp47Language.of("de-DE"),
+            ) { (locale, expectedLanguage) ->
+                locale.toLossyBcp47Language() shouldBe expectedLanguage
+            }
+        }
+    },
+)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/tmdb/UtilsTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/tmdb/UtilsTest.kt
@@ -1,0 +1,30 @@
+package io.github.couchtracker.tmdb
+
+import app.moviebase.tmdb.model.TmdbMovieDetail
+import io.github.couchtracker.db.profile.Bcp47Language
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.tuple
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class UtilsTest : FunSpec(
+    {
+        context("TmdbDetail.language") {
+            withData(
+                nameFn = { "originalLanguage=${it.a}, originCountry=${it.b} should return ${it.c} " },
+                tuple("it", emptyList(), Bcp47Language.of("it")),
+                tuple("it", listOf("IT"), Bcp47Language.of("it-IT")),
+                tuple("it", listOf("IE", "CH", "IT"), Bcp47Language.of("it-CH")),
+                tuple("it", listOf("JP", "ZH", "UK"), Bcp47Language.of("it")),
+            ) { (lang, countries, expected) ->
+                val detail = mockk<TmdbMovieDetail> {
+                    every { originalLanguage } returns lang
+                    every { originCountry } returns countries
+                }
+                detail.language() shouldBe expected
+            }
+        }
+    },
+)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/ULocaleTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/ULocaleTest.kt
@@ -1,0 +1,32 @@
+package io.github.couchtracker.utils
+
+import com.ibm.icu.util.ULocale
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+
+class ULocaleTest : FunSpec(
+    {
+        context("stripExtensions") {
+            context("returns expected locale") {
+                withData(
+                    "en" to "en",
+                    "en_IE" to "en_IE",
+                    "es_ES@currency=EUR;collation=traditional" to "es_ES",
+                    "it_IT#U_FW_MON_MU_CELSIUS@attribute=email;collation=phonebook;x=linux" to "it_IT#U_FW_MON_MU_CELSIUS",
+                ) { (locale, expected) ->
+                    ULocale(locale).stripExtensions() shouldBe ULocale(expected)
+                }
+            }
+
+            context("doesn't break any existing locale") {
+                withData(
+                    nameFn = { it.toString() },
+                    ULocale.getAvailableLocales().filter { it.extensionKeys.isEmpty() }.toList(),
+                ) { locale ->
+                    locale.stripExtensions() shouldBe locale
+                }
+            }
+        }
+    },
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ coil = "3.1.0"
 compose-paging = "3.3.6"
 compose-plugin = "1.9.0-alpha02"
 detekt = "1.23.8"
+icu = "77.1"
 koin-bom = "4.0.4"
 kotest = "5.9.1"
 kotlin = "2.1.21"
@@ -37,6 +38,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" 
 coil-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 compose-paging = { module = "androidx.paging:paging-compose", version.ref = "compose-paging" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin-bom" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }


### PR DESCRIPTION
We will use BCP47 langauge tags to store the language of something. For this, a `Bcp47Language` wrapping a `ULocale` has been created.

This also supports the "special" languages `und`, `mul` and `zxx`.



https://github.com/user-attachments/assets/d717a7bd-2504-40dd-9de1-f8a183cae7ed


https://github.com/user-attachments/assets/429d1c42-0b9f-4439-95b2-600d7e6a91f7

