### PR TITLE
Upgrade target SDK to 36, Kotlin to 2.2 and other libraries

### DIFF
--- a/buildSrc/src/main/kotlin/SqlDelightTmdbCacheDefinitionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/SqlDelightTmdbCacheDefinitionsGenerator.kt
@@ -95,7 +95,7 @@ private data class SqlTable(
     val key: List<SqlColumn>,
     val value: SqlColumn,
 ) {
-    val lastUpdate = SqlColumn.text("lastUpdate", "kotlinx.datetime.Instant")
+    val lastUpdate = SqlColumn.text("lastUpdate", "kotlin.time.Instant")
 
     init {
         require(key.isNotEmpty())

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -25,8 +25,10 @@ buildConfig {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_1_8
+        jvmTarget = JvmTarget.JVM_11
         allWarningsAsErrors = true
+        freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 
     dependencies {
@@ -36,6 +38,10 @@ kotlin {
         implementation(libs.kotlinx.datetime)
         implementation(libs.serialization.core)
         implementation(libs.serialization.json)
+
+        // AndroidX & other misc Google libs
+        implementation(libs.androidx.datastore.preferences)
+        implementation(libs.androidx.documentfile)
 
         // Compose
         implementation(compose.foundation)
@@ -74,8 +80,6 @@ kotlin {
         implementation(libs.coil.ktor)
 
         // Other
-        implementation(libs.androidx.datastore.preferences)
-        implementation(libs.androidx.documentfile)
         implementation(libs.byteSize)
         implementation(libs.icu4j)
         implementation(libs.palette)
@@ -135,8 +139,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     testOptions.unitTests {
         all {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
@@ -25,7 +25,6 @@ import io.github.couchtracker.ui.screens.movie.MovieScreen
 import io.github.couchtracker.ui.screens.settings.settings
 import io.github.couchtracker.ui.screens.show.ShowScreen
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemsScreen
-import org.koin.compose.KoinContext
 import kotlin.math.roundToInt
 
 val LocalNavController = staticCompositionLocalOf<NavController> { error("no default nav controller") }
@@ -36,38 +35,36 @@ private val FADE_ANIMATION_SPEC = tween<Float>(AnimationDefaults.ANIMATION_DURAT
 @Composable
 fun App() {
     val navController = rememberNavController()
-    KoinContext {
-        MaterialTheme(colorScheme = darkColorScheme()) {
-            CompositionLocalProvider(LocalNavController provides navController) {
-                Surface(color = MaterialTheme.colorScheme.background) {
-                    ProfilesContext {
-                        NavHost(
-                            navController = navController,
-                            startDestination = MainScreen,
-                            enterTransition = {
-                                val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = LinearOutSlowInEasing)
-                                slideInVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
-                                    fadeIn(FADE_ANIMATION_SPEC)
-                            },
-                            exitTransition = {
-                                fadeOut(FADE_ANIMATION_SPEC)
-                            },
-                            popEnterTransition = {
+    MaterialTheme(colorScheme = darkColorScheme()) {
+        CompositionLocalProvider(LocalNavController provides navController) {
+            Surface(color = MaterialTheme.colorScheme.background) {
+                ProfilesContext {
+                    NavHost(
+                        navController = navController,
+                        startDestination = MainScreen,
+                        enterTransition = {
+                            val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = LinearOutSlowInEasing)
+                            slideInVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
                                 fadeIn(FADE_ANIMATION_SPEC)
-                            },
-                            popExitTransition = {
-                                val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = FastOutLinearInEasing)
-                                slideOutVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
-                                    fadeOut(FADE_ANIMATION_SPEC)
-                            },
-                        ) {
-                            composable<MainScreen>()
-                            composable<SearchScreen>()
-                            composable<MovieScreen>()
-                            composable<ShowScreen>()
-                            composable<WatchedItemsScreen>()
-                            settings()
-                        }
+                        },
+                        exitTransition = {
+                            fadeOut(FADE_ANIMATION_SPEC)
+                        },
+                        popEnterTransition = {
+                            fadeIn(FADE_ANIMATION_SPEC)
+                        },
+                        popExitTransition = {
+                            val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = FastOutLinearInEasing)
+                            slideOutVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
+                                fadeOut(FADE_ANIMATION_SPEC)
+                        },
+                    ) {
+                        composable<MainScreen>()
+                        composable<SearchScreen>()
+                        composable<MovieScreen>()
+                        composable<ShowScreen>()
+                        composable<WatchedItemsScreen>()
+                        settings()
                     }
                 }
             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/DocumentFileUtils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/DocumentFileUtils.kt
@@ -3,8 +3,8 @@ package io.github.couchtracker.db
 import android.content.Context
 import androidx.documentfile.provider.DocumentFile
 import io.github.couchtracker.utils.toAndroidUri
-import kotlinx.datetime.Instant
 import java.net.URI
+import kotlin.time.Instant
 
 /**
  * Returns a [DocumentFile] representing [this] single [URI].

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/common/adapters/InstantColumnAdapter.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/common/adapters/InstantColumnAdapter.kt
@@ -1,7 +1,7 @@
 package io.github.couchtracker.db.common.adapters
 
 import app.cash.sqldelight.ColumnAdapter
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 object InstantColumnAdapter : ColumnAdapter<Instant, String> {
     override fun encode(value: Instant) = value.toString()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ExternalProfileDb.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ExternalProfileDb.kt
@@ -12,11 +12,11 @@ import io.github.couchtracker.utils.map
 import io.github.couchtracker.utils.onError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import java.net.URI
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Instant
 
 /**
  * A [ProfileDb] that is managed in an external file.

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ManagedProfileDb.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ManagedProfileDb.kt
@@ -12,13 +12,13 @@ import io.github.couchtracker.utils.onError
 import io.github.couchtracker.utils.toAndroidUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.toKotlinInstant
 import org.koin.core.component.get
 import java.io.IOException
 import java.net.URI
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.fileSize
 import kotlin.io.path.getLastModifiedTime
+import kotlin.time.toKotlinInstant
 
 /**
  * A [ProfileDb] that is managed internally by the app.

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ProfileDb.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ProfileDb.kt
@@ -11,7 +11,6 @@ import io.github.couchtracker.db.profile.ProfileDbError.FileError.AttemptedOpera
 import io.github.couchtracker.utils.Result
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
 import org.koin.core.parameter.parametersOf
@@ -22,6 +21,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.net.URI
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Instant
 
 typealias DatabaseTransaction<T> = suspend (db: ProfileData) -> T
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTime.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTime.kt
@@ -6,7 +6,6 @@ import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime.Local
 import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime.Local.YearMonth
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.FixedOffsetTimeZone
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
@@ -22,8 +21,10 @@ import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.alternativeParsing
 import kotlinx.datetime.format.char
 import kotlinx.datetime.format.format
+import kotlinx.datetime.number
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
 
 /**
  * Represents a date/time value that might not have all the components present.
@@ -153,7 +154,7 @@ sealed interface PartialDateTime {
             override val year get() = date.year
             override val month get() = date.month
             override val dayOfWeek get() = date.dayOfWeek
-            override val dayOfMonth get() = date.dayOfMonth
+            override val dayOfMonth get() = date.day
             override val dayOfYear get() = date.dayOfYear
         }
 
@@ -185,7 +186,7 @@ sealed interface PartialDateTime {
                 year = this@Year.year
             }
 
-            override fun toInstant(zone: TimeZone) = LocalDate(year, Month.JANUARY, dayOfMonth = 1).atStartOfDayIn(zone)
+            override fun toInstant(zone: TimeZone) = LocalDate(year, Month.JANUARY, day = 1).atStartOfDayIn(zone)
 
             companion object : ICompanionWithFormat<Year>() {
                 override val FORMAT = DateTimeComponents.Format { year(Padding.ZERO) }
@@ -204,7 +205,7 @@ sealed interface PartialDateTime {
                 month = this@YearMonth.month
             }
 
-            override fun toInstant(zone: TimeZone) = LocalDate(year, month, dayOfMonth = 1).atStartOfDayIn(zone)
+            override fun toInstant(zone: TimeZone) = LocalDate(year, month, day = 1).atStartOfDayIn(zone)
 
             companion object : ICompanionWithFormat<YearMonth>() {
                 override val FORMAT = DateTimeComponents.Format {
@@ -377,9 +378,9 @@ sealed interface PartialDateTime {
         }.thenBy {
             when (val local = it.local) {
                 is Year -> 0
-                is YearMonth -> local.month.value
-                is Date -> local.date.month.value
-                is DateTime -> local.dateTime.month.value
+                is YearMonth -> local.month.number
+                is Date -> local.date.month.number
+                is DateTime -> local.dateTime.month.number
             }
         }
 
@@ -388,7 +389,7 @@ sealed interface PartialDateTime {
          */
         private val LOCAL_COMPARATOR: Comparator<PartialDateTime> = LOCAL_YEAR_MONTH_COMPARATOR.thenBy {
             when (val local = it.local) {
-                is Year, is YearMonth -> Int.MIN_VALUE
+                is Year, is YearMonth -> Long.MIN_VALUE
                 is Date -> local.date.toEpochDays()
                 is DateTime -> local.dateTime.date.toEpochDays()
             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTimeGroup.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTimeGroup.kt
@@ -1,5 +1,7 @@
 package io.github.couchtracker.db.profile.model.partialtime
 
+import kotlinx.datetime.number
+
 /**
  * When showing a list of objects with an associated [PartialDateTime], they should be split into groups in order to provide a clear UI to
  * the user.
@@ -44,7 +46,7 @@ sealed class PartialDateTimeGroup : Comparable<PartialDateTimeGroup> {
         }.thenBy {
             when (it) {
                 Unknown, is Year -> 0
-                is YearMonth -> it.value.month.value // January is 1, December is 12
+                is YearMonth -> it.value.month.number // January is 1, December is 12
             }
         }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/tmdbCache/TmdbTimestampedEntry.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/tmdbCache/TmdbTimestampedEntry.kt
@@ -1,6 +1,6 @@
 package io.github.couchtracker.db.tmdbCache
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class TmdbTimestampedEntry<T>(
     val value: T,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/Utils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/Utils.kt
@@ -4,11 +4,11 @@ import android.icu.text.ListFormatter
 import android.text.format.DateFormat
 import androidx.compose.ui.text.intl.Locale
 import io.github.couchtracker.intl.datetime.Skeleton
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toJavaInstant
 import kotlinx.datetime.toJavaZoneId
 import java.time.format.DateTimeFormatter
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
 
 fun formatAndList(items: List<String>): String {
     return ListFormatter.getInstance().format(items)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
@@ -11,10 +11,10 @@ import io.ktor.client.plugins.ResponseException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
 import kotlinx.io.IOException
 import kotlinx.serialization.SerializationException
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/RelativeTime.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/RelativeTime.kt
@@ -15,10 +15,10 @@ import io.github.couchtracker.utils.rememberTickingValue
 import io.github.couchtracker.utils.toIbmIcuTimeUnit
 import io.github.couchtracker.utils.toULocale
 import io.github.couchtracker.utils.unitPart
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
+import kotlin.time.Instant
 
 data class RelativeDurationFormatter(
     private val omitZeros: Boolean,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/PartialDateTimePickerDialog.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/PartialDateTimePickerDialog.kt
@@ -38,13 +38,13 @@ import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime
 import io.github.couchtracker.intl.datetime.Skeletons
 import io.github.couchtracker.intl.datetime.localized
 import io.github.couchtracker.utils.str
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 private enum class DatePrecision {
     YEAR,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/DateTimeSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/DateTimeSection.kt
@@ -53,11 +53,11 @@ import io.github.couchtracker.ui.screens.watchedItem.DateTimeSectionState.Custom
 import io.github.couchtracker.utils.Text
 import io.github.couchtracker.utils.roundToSeconds
 import io.github.couchtracker.utils.str
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 class DateTimeSectionState(val initial: PartialDateTime? = null) {
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/LanguageSelection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/LanguageSelection.kt
@@ -28,9 +28,9 @@ import io.github.couchtracker.ui.components.LanguagePickerDialog
 import io.github.couchtracker.utils.currentFirstLocale
 import io.github.couchtracker.utils.str
 import io.github.couchtracker.utils.toULocale
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
 
 private val USED_LANGUAGES_RECENCY_CUTOFF = 180.days
 private const val SUGGESTED_LANGAUGES_TOP_USED_LIMIT = 3

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemProgress.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemProgress.kt
@@ -21,7 +21,7 @@ import io.github.couchtracker.utils.Text
 import io.github.couchtracker.utils.TickingValue
 import io.github.couchtracker.utils.map
 import io.github.couchtracker.utils.str
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemProgressState.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemProgressState.kt
@@ -8,11 +8,11 @@ import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemWrapper
 import io.github.couchtracker.db.profile.type
 import io.github.couchtracker.utils.TickingValue
 import io.github.couchtracker.utils.rememberTickingValue
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 /**
  * Represents the progress state of a [WatchedItem] in the time:

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Time.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Time.kt
@@ -5,7 +5,7 @@ import kotlinx.datetime.LocalDateTime
 fun LocalDateTime.roundToSeconds() = LocalDateTime(
     year = year,
     month = month,
-    dayOfMonth = dayOfMonth,
+    day = day,
     hour = hour,
     minute = minute,
     second = second,

--- a/composeApp/src/main/sqldelight/app/io/github/couchtracker/db/app/Profile.sq
+++ b/composeApp/src/main/sqldelight/app/io/github/couchtracker/db/app/Profile.sq
@@ -1,5 +1,5 @@
 import java.net.URI;
-import kotlinx.datetime.Instant;
+import kotlin.time.Instant;
 
 CREATE TABLE Profile (
   id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/Metadata.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/Metadata.sq
@@ -1,5 +1,5 @@
 import io.github.couchtracker.db.profile.show.ExternalShowId;
-import kotlinx.datetime.Instant;
+import kotlin.time.Instant;
 
 /**
  * Contains metadata about the database.

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/ShowInCollection.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/ShowInCollection.sq
@@ -1,5 +1,5 @@
 import io.github.couchtracker.db.profile.show.ExternalShowId;
-import kotlinx.datetime.Instant;
+import kotlin.time.Instant;
 
 /**
  * Saves the list of shows in the user's collection.

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItem.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItem.sq
@@ -1,6 +1,6 @@
 import io.github.couchtracker.db.profile.WatchableExternalId;
 import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime;
-import kotlinx.datetime.Instant;
+import kotlin.time.Instant;
 
 /**
  * Saves every movie the user ever watched.

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/DocumentFileUtilsTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/DocumentFileUtilsTest.kt
@@ -6,7 +6,7 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class DocumentFileUtilsTest : FunSpec(
     {

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/common/adapters/InstantColumnAdapterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/common/adapters/InstantColumnAdapterTest.kt
@@ -3,7 +3,7 @@ package io.github.couchtracker.db.common.adapters
 import io.kotest.core.spec.style.FunSpec
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class InstantColumnAdapterTest : FunSpec(
     {

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTimeSerializationTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTimeSerializationTest.kt
@@ -28,18 +28,18 @@ private val LOCAL_TEST_CASES = listOf(
     ValidTestCase(
         testName = "Date",
         serialized = "2024-07-01",
-        value = Local.Date(LocalDate(2024, Month.JULY, dayOfMonth = 1)),
+        value = Local.Date(LocalDate(2024, Month.JULY, day = 1)),
     ),
     ValidTestCase(
         testName = "Date and time at hour mark",
         serialized = "2024-07-01T08:00:00",
         otherAcceptedParsableFormats = listOf("2024-07-01T08:00"),
-        value = Local.DateTime(LocalDateTime(2024, Month.JULY, dayOfMonth = 1, hour = 8, minute = 0)),
+        value = Local.DateTime(LocalDateTime(2024, Month.JULY, day = 1, hour = 8, minute = 0)),
     ),
     ValidTestCase(
         testName = "Date and time with minutes and seconds",
         serialized = "2024-07-01T22:12:34",
-        value = Local.DateTime(LocalDateTime(2024, Month.JULY, dayOfMonth = 1, hour = 22, minute = 12, second = 34)),
+        value = Local.DateTime(LocalDateTime(2024, Month.JULY, day = 1, hour = 22, minute = 12, second = 34)),
     ),
 )
 

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTimeTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTimeTest.kt
@@ -4,9 +4,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.FixedOffsetTimeZone
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.UtcOffset
+import kotlin.time.Instant
 
 class PartialDateTimeTest : FunSpec(
     {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,30 +1,30 @@
 [versions]
 agp = "8.9.1"
-android-compileSdk = "35"
+android-compileSdk = "36"
 android-minSdk = "26"
-android-targetSdk = "35"
+android-targetSdk = "36"
 androidx-activityCompose = "1.10.1"
 androidx-datastore = "1.1.7"
 androidx-documentfile = "1.1.0"
-androidx-lifecycle = "2.9.0"
-buildConfig = "5.6.2"
-byte-size = "2.0.0-beta04"
-coil = "3.1.0"
+androidx-lifecycle = "2.9.2"
+buildConfig = "5.6.7"
+byte-size = "2.0.0"
+coil = "3.3.0"
 compose-paging = "3.3.6"
 compose-plugin = "1.9.0-alpha03"
 detekt = "1.23.8"
 icu = "77.1"
-koin-bom = "4.0.4"
+koin-bom = "4.1.0"
 kotest = "5.9.1"
-kotlin = "2.1.21"
-kotlinx-datetime = "0.6.2"
-ktor = "3.1.2"
-mockk = "1.14.0"
-navigation = "2.9.0"
+kotlin = "2.2.0"
+kotlinx-datetime = "0.7.1"
+ktor = "3.2.3"
+mockk = "1.14.5"
+navigation = "2.9.3"
 palette = "1.0.0"
-preference = "1.1.1"
-requeryAndroid = "3.45.0"
-serialization = "1.8.1"
+preference = "2.1.0"
+requeryAndroid = "3.49.0"
+serialization = "1.9.0"
 sqldelight = "2.1.0"
 tmdb-api = "1.4.0"
 
@@ -56,7 +56,7 @@ navigation-compose = { module = "androidx.navigation:navigation-compose", versio
 navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "navigation" }
 navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigation" }
 palette = { module = "androidx.palette:palette", version.ref = "palette" }
-preference = { module = "me.zhanghai.compose.preference:library", version.ref = "preference" }
+preference = { module = "me.zhanghai.compose.preference:preference", version.ref = "preference" }
 requery-android = { module = "com.github.requery:sqlite-android", version.ref = "requeryAndroid" }
 serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
- SDK to to 36 required no changes
- Kotlin 2.2. required `-Xannotation-default-target=param-property` (see https://youtrack.jetbrains.com/issue/KT-73255), we were getting warnings on all `@StringRes` annotated data class values
- `kotlinx.datetime` removes `Clock` and `Insant` because they moved into the stdlib. They are however experimental, so `-opt-in=kotlin.time.ExperimentalTime` was required
