### PR TITLE
Decouple loading/errors of separate API calls

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/Model.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/Model.kt
@@ -2,7 +2,9 @@ package io.github.couchtracker.ui
 
 import android.content.Context
 import app.moviebase.tmdb.image.TmdbImage
+import app.moviebase.tmdb.image.TmdbImageType
 import app.moviebase.tmdb.image.TmdbImageUrlBuilder
+import app.moviebase.tmdb.model.TmdbFileImage
 import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 
@@ -12,42 +14,59 @@ sealed interface ImagePreloadOptions {
 }
 
 sealed interface ImageModel {
+    val aspectRatio: Float?
     fun getCoilModel(width: Int, height: Int): Any?
 
-    data class Url(val urlProvider: (width: Int, height: Int) -> String) : ImageModel {
+    data class Url(override val aspectRatio: Float?, val urlProvider: (width: Int, height: Int) -> String) : ImageModel {
         override fun getCoilModel(width: Int, height: Int): Any? {
             return urlProvider(width, height)
         }
     }
 
-    data class Preloaded(val imageRequest: ImageRequest) : ImageModel {
+    data class Preloaded(override val aspectRatio: Float?, val coilModel: ImageRequest?) : ImageModel {
         override fun getCoilModel(width: Int, height: Int): Any? {
-            return imageRequest
+            return coilModel
         }
     }
 }
 
 suspend fun prepareImage(
-    options: ImagePreloadOptions,
+    aspectRatio: Float?,
+    options: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
     urlProvider: (width: Int, height: Int) -> String,
-): ImageModel? {
+): ImageModel {
     return when (options) {
-        ImagePreloadOptions.DoNotPreload -> ImageModel.Url(urlProvider)
+        ImagePreloadOptions.DoNotPreload -> ImageModel.Url(aspectRatio, urlProvider)
         is ImagePreloadOptions.Preload -> {
             val request = ImageRequest.Builder(options.context)
                 .data(urlProvider(options.width, options.height))
                 .size(options.width, options.height)
                 .build()
-            SingletonImageLoader.get(options.context).execute(request)
-            ImageModel.Preloaded(request)
+            val result = SingletonImageLoader.get(options.context).execute(request)
+            val aspectRatio = result.image?.let { it.width.toFloat() / it.height } ?: aspectRatio
+            ImageModel.Preloaded(aspectRatio, request)
         }
     }
 }
 
 suspend fun TmdbImage.toImageModel(
-    imagePreloadOptions: ImagePreloadOptions,
-): ImageModel? {
-    return prepareImage(imagePreloadOptions) { w, h ->
+    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
+): ImageModel {
+    return prepareImage(null, imagePreloadOptions) { w, h ->
         TmdbImageUrlBuilder.build(this, w, h)
+    }
+}
+
+suspend fun TmdbFileImage.toImageModel(
+    type: TmdbImageType,
+    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
+): ImageModel {
+    return prepareImage(aspectRation, imagePreloadOptions) { w, h ->
+        TmdbImageUrlBuilder.build(
+            imagePath = filePath,
+            type = type,
+            width = w,
+            height = h,
+        )
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CastPortrait.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CastPortrait.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.coroutineScope
 fun CastPortrait(
     modifier: Modifier,
     person: CastPortraitModel?,
-    onClick: ((CastPortraitModel) -> Unit)?,
+    onClick: (() -> Unit)?,
 ) {
     PortraitComposable(
         modifier,
@@ -41,7 +41,7 @@ fun CastPortrait(
                     model = person.posterModel?.getCoilModel(w, h),
                     modifier = Modifier
                         .fillMaxSize()
-                        .clickable(onClick != null) { onClick?.invoke(person) },
+                        .clickable(onClick != null) { onClick?.invoke() },
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     fallback = rememberPlaceholderPainter(PlaceholdersDefaults.PERSON.icon, isError = false),
@@ -55,22 +55,24 @@ fun CastPortrait(
                 textAlign = TextAlign.Center,
                 minLines = 1,
             )
-            person?.roles?.forEach { role ->
+            val subtitleItems = buildList {
+                if (person == null) {
+                    add(null)
+                } else {
+                    addAll(person.roles)
+                    person.episodesCount?.let { episodeCount ->
+                        add(R.plurals.n_episodes.pluralStr(episodeCount, episodeCount))
+                    }
+                }
+            }
+            subtitleItems.forEach { subtitle ->
                 Text(
-                    text = role,
+                    text = subtitle.orEmpty(),
                     textAlign = TextAlign.Center,
                     // Same style as ListItem's supporting content
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     style = MaterialTheme.typography.bodyMedium,
-                )
-            }
-            person?.episodesCount?.let { episodeCount ->
-                Text(
-                    text = R.plurals.n_episodes.pluralStr(episodeCount, episodeCount),
-                    textAlign = TextAlign.Center,
-                    // Same style as ListItem's supporting content
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
+                    minLines = 1,
                 )
             }
         },
@@ -122,7 +124,7 @@ data class CastPortraitModel(
 @JvmName("TmdbCast_toCastPortraitModel")
 suspend fun List<TmdbCast>.toCastPortraitModel(
     language: TmdbLanguage,
-    imagePreloadOptions: ImagePreloadOptions,
+    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
 ): List<CastPortraitModel> = coroutineScope {
     map {
         async {
@@ -134,7 +136,7 @@ suspend fun List<TmdbCast>.toCastPortraitModel(
 @JvmName("TmdbAggregateCast_toCastPortraitModel")
 suspend fun List<TmdbAggregateCast>.toCastPortraitModel(
     language: TmdbLanguage,
-    imagePreloadOptions: ImagePreloadOptions,
+    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
 ): List<CastPortraitModel> = coroutineScope {
     map {
         async {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CrewCompactListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CrewCompactListItem.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
 @Composable
-fun CrewCompactListItem(crew: CrewCompactListItemModel) {
+fun CrewCompactListItem(crew: CrewCompactListItemModel?) {
     CompactListItem(
         leadingContent = {
             Surface(
@@ -43,27 +43,31 @@ fun CrewCompactListItem(crew: CrewCompactListItemModel) {
                 modifier = Modifier.size(40.dp),
             ) {
                 BoxWithConstraints(contentAlignment = Alignment.Companion.BottomStart) {
-                    AsyncImage(
-                        model = crew.posterModel?.getCoilModel(
-                            this.constraints.maxWidth,
-                            this.constraints.maxHeight,
-                        ),
-                        modifier = Modifier.fillMaxSize(),
-                        contentDescription = null,
-                        contentScale = ContentScale.Companion.Crop,
-                        fallback = rememberPlaceholderPainter(PlaceholdersDefaults.PERSON.icon, isError = false),
-                        error = rememberPlaceholderPainter(PlaceholdersDefaults.PERSON.icon, isError = true),
-                    )
+                    if (crew != null) {
+                        AsyncImage(
+                            model = crew.posterModel?.getCoilModel(
+                                this.constraints.maxWidth,
+                                this.constraints.maxHeight,
+                            ),
+                            modifier = Modifier.fillMaxSize(),
+                            contentDescription = null,
+                            contentScale = ContentScale.Companion.Crop,
+                            fallback = rememberPlaceholderPainter(PlaceholdersDefaults.PERSON.icon, isError = false),
+                            error = rememberPlaceholderPainter(PlaceholdersDefaults.PERSON.icon, isError = true),
+                        )
+                    }
                 }
             }
         },
-        headlineContent = { Text(crew.name) },
+        headlineContent = { Text(crew?.name.orEmpty()) },
         supportingContent = {
-            Text(
-                text = formatAndList(crew.departments.map { it.title().string() }),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            if (!crew?.departments.isNullOrEmpty()) {
+                Text(
+                    text = formatAndList(crew.departments.map { it.title().string() }),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         },
     )
 }
@@ -120,7 +124,7 @@ data class CrewCompactListItemModel(
 @JvmName("TmdbCrew_toCrewCompactListItemModel")
 suspend fun List<TmdbCrew>.toCrewCompactListItemModel(
     language: TmdbLanguage,
-    imagePreloadOptions: ImagePreloadOptions,
+    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
 ): List<CrewCompactListItemModel> = coroutineScope {
     groupBy { it.id }.map { (_, crew) ->
         async {
@@ -132,7 +136,7 @@ suspend fun List<TmdbCrew>.toCrewCompactListItemModel(
 @JvmName("TmdbAggregateCrew_toCrewCompactListItemModel")
 suspend fun List<TmdbAggregateCrew>.toCrewCompactListItemModel(
     language: TmdbLanguage,
-    imagePreloadOptions: ImagePreloadOptions,
+    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
 ): List<CrewCompactListItemModel> = coroutineScope {
     groupBy { it.id }.map { (_, crew) ->
         async {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/PortraitComposable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/PortraitComposable.kt
@@ -55,7 +55,7 @@ fun PortraitComposable(
         }
         Spacer(Modifier.height(8.dp))
         CompositionLocalProvider(LocalTextStyle provides MaterialTheme.typography.titleSmall) {
-            Column(Modifier.animateContentSize(), horizontalAlignment = Alignment.Companion.CenterHorizontally) {
+            Column(Modifier.fillMaxWidth().animateContentSize(), horizontalAlignment = Alignment.CenterHorizontally) {
                 label()
             }
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -1,12 +1,10 @@
 package io.github.couchtracker.ui.screens.movie
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.material3.ColorScheme
+import app.moviebase.tmdb.image.TmdbImageType
 import app.moviebase.tmdb.model.TmdbCrew
-import app.moviebase.tmdb.model.TmdbFileImage
 import app.moviebase.tmdb.model.TmdbGenre
-import app.moviebase.tmdb.model.TmdbVideo
 import coil3.request.ImageRequest
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.tmdbCache.TmdbCache
@@ -19,20 +17,22 @@ import io.github.couchtracker.tmdb.prepareAndExtractColorScheme
 import io.github.couchtracker.tmdb.rating
 import io.github.couchtracker.tmdb.runtime
 import io.github.couchtracker.ui.ColorSchemes
-import io.github.couchtracker.ui.ImagePreloadOptions
+import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.components.CastPortraitModel
 import io.github.couchtracker.ui.components.CrewCompactListItemModel
 import io.github.couchtracker.ui.components.toCastPortraitModel
 import io.github.couchtracker.ui.components.toCrewCompactListItemModel
-import io.github.couchtracker.utils.ApiException
-import io.github.couchtracker.utils.Loadable
-import io.github.couchtracker.utils.Result
+import io.github.couchtracker.ui.toImageModel
+import io.github.couchtracker.utils.ApiResult
+import io.github.couchtracker.utils.DeferredApiResult
+import io.github.couchtracker.utils.awaitAll
+import io.github.couchtracker.utils.runApiCatching
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 private const val LOG_TAG = "MovieScreenModel"
 
@@ -46,62 +46,72 @@ data class MovieScreenModel(
     val originalLanguage: Bcp47Language,
     val rating: TmdbRating?,
     val genres: List<TmdbGenre>,
-    val director: List<TmdbCrew>,
-    val cast: List<CastPortraitModel>,
-    val crew: List<CrewCompactListItemModel>,
-    val images: List<TmdbFileImage>,
-    val videos: List<TmdbVideo>,
+    val credits: DeferredApiResult<Credits>,
+    val images: DeferredApiResult<List<ImageModel>>,
     val backdrop: ImageRequest?,
     val colorScheme: ColorScheme,
-)
+) {
+    data class Credits(
+        val director: List<TmdbCrew>,
+        val cast: List<CastPortraitModel>,
+        val crew: List<CrewCompactListItemModel>,
+    )
+}
 
-suspend fun loadMovie(
+suspend fun CoroutineScope.loadMovie(
     ctx: Context,
     tmdbCache: TmdbCache,
     movie: TmdbMovie,
     width: Int,
     height: Int,
     coroutineContext: CoroutineContext = Dispatchers.Default,
-): Loadable<MovieScreenModel, ApiException> {
-    return try {
-        coroutineScope {
-            withContext(coroutineContext) {
-                val credits = async { movie.credits(tmdbCache) }
-                val images = async { movie.images(tmdbCache) }
-                val videos = async { movie.videos(tmdbCache) }
-                val details = movie.details(tmdbCache)
-                val backdrop = async {
-                    details.backdropImage.prepareAndExtractColorScheme(
-                        ctx = ctx,
-                        width = width,
-                        height = height,
-                        fallbackColorScheme = ColorSchemes.Movie,
-                    )
-                }
-                Result.Value(
-                    MovieScreenModel(
-                        movie = movie,
-                        title = details.title,
-                        tagline = details.tagline,
-                        overview = details.overview,
-                        year = details.releaseDate?.year,
-                        runtime = details.runtime(),
-                        originalLanguage = details.language(),
-                        rating = details.rating(),
-                        genres = details.genres,
-                        director = credits.await().crew.directors(),
-                        cast = credits.await().cast.toCastPortraitModel(movie.language, ImagePreloadOptions.DoNotPreload),
-                        crew = credits.await().crew.toCrewCompactListItemModel(movie.language, ImagePreloadOptions.DoNotPreload),
-                        backdrop = backdrop.await().first,
-                        images = images.await().linearize(),
-                        videos = videos.await(),
-                        colorScheme = backdrop.await().second,
-                    ),
+): ApiResult<MovieScreenModel> {
+    return runApiCatching(LOG_TAG) {
+        val images = async(coroutineContext) {
+            runApiCatching(LOG_TAG) {
+                movie.images(tmdbCache)
+                    .linearize()
+                    .map { it.toImageModel(TmdbImageType.BACKDROP) }
+            }
+        }
+        val credits = async(coroutineContext) {
+            runApiCatching(LOG_TAG) {
+                val credits = movie.credits(tmdbCache)
+                MovieScreenModel.Credits(
+                    director = credits.crew.directors(),
+                    cast = credits.cast.toCastPortraitModel(movie.language),
+                    crew = credits.crew.toCrewCompactListItemModel(movie.language),
                 )
             }
         }
-    } catch (e: ApiException) {
-        Log.e(LOG_TAG, "Error while loading MovieScreenModel for ${movie.id.toExternalId().serialize()} (${movie.language})", e)
-        Result.Error(e)
+        val details = movie.details(tmdbCache)
+        val backdrop = async(coroutineContext) {
+            details.backdropImage.prepareAndExtractColorScheme(
+                ctx = ctx,
+                width = width,
+                height = height,
+                fallbackColorScheme = ColorSchemes.Movie,
+            )
+        }
+
+        // It can be disruptive to load in content at separate times.
+        // If the other content loads "fast enough", I'll wait for it.
+        listOf(images, credits).awaitAll(100.milliseconds)
+
+        MovieScreenModel(
+            movie = movie,
+            title = details.title,
+            tagline = details.tagline,
+            overview = details.overview,
+            year = details.releaseDate?.year,
+            runtime = details.runtime(),
+            originalLanguage = details.language(),
+            rating = details.rating(),
+            genres = details.genres,
+            credits = credits,
+            backdrop = backdrop.await().first,
+            images = images,
+            colorScheme = backdrop.await().second,
+        )
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
@@ -1,0 +1,32 @@
+package io.github.couchtracker.utils
+
+import kotlinx.coroutines.delay
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
+
+private const val INJECT_ERRORS = false
+
+private const val MAX_DELAY_MS = 10_000
+private const val ERROR_PROBABILITY = 0.2f
+private const val CACHE_MISS_CHANCE = 0.5f
+
+/**
+ * @throws ApiException
+ */
+suspend fun injectApiError() {
+    if (INJECT_ERRORS) {
+        delay(Random.nextInt(MAX_DELAY_MS).milliseconds)
+        if (Random.nextFloat() <= ERROR_PROBABILITY) {
+            throw ApiException.SimulatedError()
+        }
+    }
+}
+
+fun <T : Any> T?.injectCacheMiss(): T? {
+    if (INJECT_ERRORS) {
+        if (Random.nextFloat() <= CACHE_MISS_CHANCE) {
+            return null
+        }
+    }
+    return this
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Deferred.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Deferred.kt
@@ -1,0 +1,19 @@
+package io.github.couchtracker.utils
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+
+/**
+ * Awaits for the completion of all given referred, up to [timeout].
+ */
+suspend fun List<Deferred<*>>.awaitAll(timeout: Duration) {
+    try {
+        withTimeout(timeout) {
+            awaitAll()
+        }
+    } catch (_: TimeoutCancellationException) {
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
@@ -1,5 +1,14 @@
 package io.github.couchtracker.utils
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
 /**
  * Represents a value that can be in error.
  */
@@ -40,4 +49,21 @@ inline fun <T, E> Result<T, E>.onError(block: (Result.Error<E>) -> Unit) {
         is Result.Value -> {}
         is Result.Error -> block(this)
     }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Composable
+fun <T, E> Deferred<Result<T, E>>.awaitAsLoadable(): Loadable<T, E> {
+    var ret: Loadable<T, E> by remember {
+        val initialValue = try {
+            this.getCompleted()
+        } catch (_: IllegalStateException) {
+            Loadable.Loading
+        }
+        mutableStateOf(initialValue)
+    }
+    LaunchedEffect(this) {
+        ret = await()
+    }
+    return ret
 }


### PR DESCRIPTION
To test locally, switch `Debug.INJECT_ERRORS` to `true`.

As part of this change, I had to assign keys to LazyList items of movie/show screen, and to improve how various components handle animations