### PR TITLE
Show snackbar on errors

### DIFF
--- a/buildSrc/src/main/kotlin/SqlDelightTmdbCacheDefinitionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/SqlDelightTmdbCacheDefinitionsGenerator.kt
@@ -130,6 +130,7 @@ open class SqlDelightTmdbCacheDefinitionsGenerator : DefaultTask() {
     init {
         group = "io.github.couchtracker"
         description = "Generates the SqlDelight definitions for local the Tmdb Cache"
+        outputs.dir(sqldelightRoot)
     }
 
     @TaskAction

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MediaScreenScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MediaScreenScaffold.kt
@@ -6,9 +6,12 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -33,6 +36,7 @@ fun MediaScreenScaffold(
     title: String,
     backdrop: ImageRequest?,
     modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     floatingActionButton: @Composable () -> Unit = {},
     content: @Composable (PaddingValues) -> Unit,
 ) {
@@ -51,6 +55,7 @@ fun MediaScreenScaffold(
                     OverviewScreenComponents.Header(title, backdrop, topAppBarScrollBehavior)
                 },
                 floatingActionButton = floatingActionButton,
+                snackbarHost = { SnackbarHost(snackbarHostState) },
                 content = content,
             )
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/HomeSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/HomeSection.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
 import io.github.couchtracker.ui.components.ProfileSwitcherDialog
@@ -37,7 +36,7 @@ fun HomeSection(innerPadding: PaddingValues) {
     MainSection(
         innerPadding = innerPadding,
         pagerState = pagerState,
-        backgroundImage = painterResource(R.drawable.sunset),
+        imageModel = R.drawable.sunset,
         actions = {
             MainSectionDefaults.SearchButton(
                 onOpenSearch = {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainSection.kt
@@ -3,7 +3,6 @@
 package io.github.couchtracker.ui.screens.main
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -31,9 +30,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
 import io.github.couchtracker.R
 import io.github.couchtracker.ui.components.BackgroundTopAppBar
 import io.github.couchtracker.utils.str
@@ -43,7 +42,7 @@ import kotlinx.coroutines.launch
 fun MainSection(
     innerPadding: PaddingValues,
     pagerState: PagerState,
-    backgroundImage: Painter,
+    imageModel: Any?,
     actions: @Composable RowScope.() -> Unit = {},
     tabText: @Composable (page: Int) -> Unit,
     page: @Composable (page: Int) -> Unit,
@@ -61,9 +60,9 @@ fun MainSection(
             BackgroundTopAppBar(
                 scrollBehavior = scrollBehavior,
                 image = { modifier ->
-                    Image(
+                    AsyncImage(
                         modifier = modifier,
-                        painter = backgroundImage,
+                        model = imageModel,
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
                     )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -51,7 +50,7 @@ fun MoviesSection(
     MainSection(
         innerPadding = innerPadding,
         pagerState = pagerState,
-        backgroundImage = painterResource(R.drawable.aurora_borealis),
+        imageModel = R.drawable.aurora_borealis,
         actions = {
             MainSectionDefaults.SearchButton(
                 onOpenSearch = {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -50,7 +49,7 @@ fun ShowSection(
     MainSection(
         innerPadding = innerPadding,
         pagerState = pagerState,
-        backgroundImage = painterResource(R.drawable.sunset),
+        imageModel = R.drawable.sunset,
         actions = {
             MainSectionDefaults.SearchButton(
                 onOpenSearch = {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -51,6 +51,8 @@ data class MovieScreenModel(
     val backdrop: ImageRequest?,
     val colorScheme: ColorScheme,
 ) {
+    val allDeferred: Set<DeferredApiResult<*>> = setOf(credits, images)
+
     data class Credits(
         val director: List<TmdbCrew>,
         val cast: List<CastPortraitModel>,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
@@ -46,6 +46,8 @@ data class ShowScreenModel(
     val backdrop: ImageRequest?,
     val colorScheme: ColorScheme,
 ) {
+    val allDeferred: Set<DeferredApiResult<*>> = setOf(credits, images)
+
     data class Credits(
         val cast: List<CastPortraitModel>,
         val crew: List<CrewCompactListItemModel>,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
@@ -6,9 +6,9 @@ import kotlin.time.Duration.Companion.milliseconds
 
 private const val INJECT_ERRORS = false
 
-private const val MAX_DELAY_MS = 10_000
-private const val ERROR_PROBABILITY = 0.2f
-private const val CACHE_MISS_CHANCE = 0.5f
+private const val MAX_DELAY_MS = 3_000
+private const val ERROR_PROBABILITY = 0.25f
+private const val CACHE_MISS_CHANCE = 0.25f
 
 /**
  * @throws ApiException

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Deferred.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Deferred.kt
@@ -3,6 +3,9 @@ package io.github.couchtracker.utils
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 
@@ -15,5 +18,14 @@ suspend fun List<Deferred<*>>.awaitAll(timeout: Duration) {
             awaitAll()
         }
     } catch (_: TimeoutCancellationException) {
+    }
+}
+
+fun <T> Collection<Deferred<T>>.emitAsFlow(): Flow<T> {
+    val deferred = this
+    return channelFlow {
+        for (value in deferred) {
+            launch { send(value.await()) }
+        }
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
@@ -54,7 +54,7 @@ inline fun <T, E> Result<T, E>.onError(block: (Result.Error<E>) -> Unit) {
 @OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun <T, E> Deferred<Result<T, E>>.awaitAsLoadable(): Loadable<T, E> {
-    var ret: Loadable<T, E> by remember {
+    var ret: Loadable<T, E> by remember(this) {
         val initialValue = try {
             this.getCompleted()
         } catch (_: IllegalStateException) {

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -31,6 +31,7 @@
     </string>
     <string name="db_io_error">Si è verificato un problema di I/O.</string>
     <string name="error_opening_profile">Errore nell\'apertura del profilo</string>
+    <string name="error_loading_data">Errore nel caricare i dati</string>
 
     <string name="item_tile_with_year">%1$s (%2$d)</string>
 

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="db_cant_open_error_security">The app has not been granted permission to open the file.</string>
     <string name="db_io_error">An I/O issue has been encountered.</string>
     <string name="error_opening_profile">Error opening profile</string>
+    <string name="error_loading_data">Error loading data</string>
 
     <string name="item_tile_with_year">%1$s (%2$d)</string>
 


### PR DESCRIPTION
This PR also:
 - reworks `ImageModel` so we get equality among identical images (the lambda of `ImageModelk.Url` was breaking that)
 - Fixes a performance related warning during compilation
 - Uses AsyncImage to dispay the header in the main section (this avoids decoding the image when moving between screens)

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/1d0136cd-270c-4ae8-a822-cc263b8fa2d1" />
