### PR TITLE
Add TmdbLanguages class and extract some logic (#66)

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/Settings.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/Settings.kt
@@ -6,7 +6,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import io.github.couchtracker.tmdb.TmdbLanguage
 import io.github.couchtracker.utils.Setting
 
 private val Context.appSettings: DataStore<Preferences> by preferencesDataStore(name = "settings")
@@ -22,11 +21,7 @@ object Settings {
         dataStore = { appSettings },
         key = stringPreferencesKey("tmdbLanguages"),
         defaultValue = null,
-        parse = { pref ->
-            pref.split(",").map { TmdbLanguage.parse(it) }.distinct()
-        },
-        serialize = { languages ->
-            languages.joinToString(separator = ",") { it.serialize() }
-        },
+        parse = io.github.couchtracker.tmdb.TmdbLanguages::parse,
+        serialize = { it.serialize() },
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbLanguages.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbLanguages.kt
@@ -1,0 +1,71 @@
+package io.github.couchtracker.tmdb
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import io.github.couchtracker.utils.currentLocales
+import io.github.couchtracker.utils.toList
+import kotlin.collections.distinct
+import kotlin.collections.ifEmpty
+import kotlin.collections.take
+
+/**
+ * Class representing a list of [TmdbLanguages] to use to get the localized something of a TMDB item.
+ *
+ * Languages should be tried in order, and use the first available localized content.
+ *
+ * This class guarantees that the list is not empty, does not contain duplicates, and that does not exceed [TmdbLanguages.MAX_LANGUAGES].
+ */
+@JvmInline
+value class TmdbLanguages(val languages: List<TmdbLanguage>) {
+
+    init {
+        require(languages.isNotEmpty()) { "TMDB language list must not be empty" }
+        require(languages.size <= MAX_LANGUAGES) { "TMDB language list too big: ${languages.size}, max is $MAX_LANGUAGES" }
+        require(languages.distinct().size == languages.size) { "TMDB language list contains duplicates: $languages" }
+    }
+
+    val size get() = languages.size
+
+    fun tryPlus(another: TmdbLanguage) = TmdbLanguages((languages + another).distinct())
+
+    fun tryMinus(another: TmdbLanguage) = if (size > 1) TmdbLanguages(languages - another) else this
+
+    fun withMovedItem(fromIndex: Int, toIndex: Int): TmdbLanguages {
+        require(fromIndex in languages.indices)
+        require(toIndex in languages.indices)
+
+        return TmdbLanguages(
+            languages = languages.toMutableList().apply {
+                add(index = toIndex, element = removeAt(fromIndex))
+            },
+        )
+    }
+
+    fun isMaxLanguages() = size == MAX_LANGUAGES
+
+    fun serialize() = languages.joinToString(separator = ",") { it.serialize() }
+
+    companion object {
+        const val MAX_LANGUAGES = 5
+
+        fun parse(value: String): TmdbLanguages {
+            return TmdbLanguages(value.split(",").map { TmdbLanguage.parse(it) })
+        }
+    }
+}
+
+@Composable
+private fun rememberSystemTmdbLanguages(): TmdbLanguages {
+    return LocalConfiguration.currentLocales.toList()
+        .mapNotNull { it.toTmdbLanguage() }
+        .ifEmpty { listOf(TmdbLanguage.FALLBACK) }
+        .distinct()
+        .take(TmdbLanguages.MAX_LANGUAGES)
+        .let(::TmdbLanguages)
+}
+
+@Composable
+fun TmdbLanguages?.orDefault(): TmdbLanguages {
+    val systemTmdbLanguages = rememberSystemTmdbLanguages()
+    return this ?: systemTmdbLanguages
+}


### PR DESCRIPTION
Some of the logic to handle a list of TMDB langauges was extracted to its own class for better separation of concerns and reusability.

Minor behavioral change from previous version: list of system languages used for suggestions in picker dialog is not limited to 5 items and does not include English as fallback
