### PR TITLE
Batch API requests together

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BatcheableTmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BatcheableTmdbDownload.kt
@@ -1,0 +1,116 @@
+package io.github.couchtracker.tmdb
+
+import app.cash.sqldelight.Query
+import app.moviebase.tmdb.Tmdb3
+import io.github.couchtracker.db.tmdbCache.TmdbCache
+import io.github.couchtracker.db.tmdbCache.TmdbTimestampedEntry
+import io.github.couchtracker.utils.ApiException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+
+class BatchableDownloader<T : Any, Req, Res>(
+    val logTag: String,
+    val loadFromCache: (cache: TmdbCache) -> Query<TmdbTimestampedEntry<T>>,
+    val putInCache: (cache: TmdbCache, TmdbTimestampedEntry<T>) -> Unit,
+    val prepareRequest: (Req) -> Req,
+    val extractFromResponse: (Res) -> T,
+    val expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
+    val prefetch: Duration = expiration * TMDB_CACHE_PREFETCH_THRESHOLD,
+)
+
+class BatchableRequest<T : Any, Req, Res>(
+    val downloader: BatchableDownloader<T, Req, Res>,
+    val completable: CompletableDeferred<T> = CompletableDeferred(),
+)
+
+private fun <T : Any, Req, Res> BatchableRequest<T, Req, Res>.complete(downloadResult: Res) {
+    check(completable.complete(downloader.extractFromResponse(downloadResult)))
+}
+
+/**
+ * Fulfills the given requests, prioritising data from the cache (see [tmdbGetOrDownload]).
+ * Requests that have to be downloaded will be downloaded together using [downloader].
+ */
+suspend fun <Req, Res> tmdbGetOrDownloadBatched(
+    cache: TmdbCache,
+    requests: List<BatchableRequest<*, Req, Res>>,
+    initialRequestInput: Req,
+    downloader: suspend (Tmdb3, Req) -> Res,
+) = coroutineScope {
+    val requestsToDownload = requests.map { request ->
+        request.getOrRequestDownload(
+            scope = this,
+            cache = cache,
+        )
+    }
+    val toDownload = requestsToDownload.awaitAll().filterNotNull()
+    if (toDownload.isNotEmpty()) {
+        batchDownload(
+            toDownload,
+            initialRequestInput,
+            downloader,
+        )
+    }
+}
+
+/**
+ * Loads the item using [tmdbGetOrDownload].
+ * The caller has to perform the download if the returned value completes with a non-null request.
+ */
+private fun <T : Any, Req, Res> BatchableRequest<T, Req, Res>.getOrRequestDownload(
+    scope: CoroutineScope,
+    cache: TmdbCache,
+): CompletableDeferred<BatchableRequest<T, Req, Res>?> {
+    val toDownload = CompletableDeferred<BatchableRequest<T, Req, Res>?>()
+    scope.launch {
+        try {
+            val result = tmdbGetOrDownload(
+                entryTag = downloader.logTag,
+                get = { downloader.loadFromCache(cache) },
+                put = { downloader.putInCache(cache, it) },
+                downloader = {
+                    val downloadResult = CompletableDeferred<T>()
+                    check(toDownload.complete(BatchableRequest(downloader, downloadResult)))
+                    downloadResult.await()
+                },
+                expiration = downloader.expiration,
+                prefetch = downloader.prefetch,
+            )
+            check(completable.complete(result))
+        } catch (e: ApiException) {
+            check(completable.completeExceptionally(e))
+        } finally {
+            toDownload.complete(null)
+        }
+    }
+    return toDownload
+}
+
+/**
+ * Downloads all requests in batch.
+ * the input for [downloader] is computed by folding [initialRequestInput] with [BatchableDownloader.prepareRequest].
+ */
+private suspend fun <Req, Res> batchDownload(
+    requests: List<BatchableRequest<*, Req, Res>>,
+    initialRequestInput: Req,
+    downloader: suspend (Tmdb3, Req) -> Res,
+) {
+    require(requests.isNotEmpty())
+    val request: Req = requests.fold(initialRequestInput) { acc, request ->
+        request.downloader.prepareRequest(acc)
+    }
+    try {
+        val download = tmdbDownload { downloader(it, request) }
+        for (request in requests) {
+            request.complete(download)
+        }
+    } catch (e: ApiException) {
+        for (request in requests) {
+            request.completable.completeExceptionally(e)
+        }
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
@@ -37,14 +37,13 @@ const val TMDB_CACHE_PREFETCH_THRESHOLD = 0.5
 
 /**
  * Utility function to handle cached downloads towards TMDB.
- *
- * TODO: multiple calls on the same API should be batched, so the download is performed only once
+ * Handles caching, stale caching and prefetching.
  */
 suspend fun <T : Any> tmdbGetOrDownload(
     entryTag: String,
     get: () -> Query<TmdbTimestampedEntry<T>>,
     put: (TmdbTimestampedEntry<T>) -> Unit,
-    downloader: suspend (Tmdb3) -> T,
+    downloader: suspend () -> T,
     expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
     prefetch: Duration = expiration * TMDB_CACHE_PREFETCH_THRESHOLD,
     coroutineContext: CoroutineContext = Dispatchers.IO,
@@ -85,12 +84,12 @@ suspend fun <T : Any> tmdbGetOrDownload(
 }
 
 private suspend fun <T : Any> downloadAndSave(
-    download: suspend (Tmdb3) -> T,
+    download: suspend () -> T,
     save: (TmdbTimestampedEntry<T>) -> Unit,
     coroutineContext: CoroutineContext,
 ): T {
     val currentTime = Clock.System.now()
-    val element = tmdbDownload(download)
+    val element = download()
     withContext(coroutineContext) {
         save(TmdbTimestampedEntry(element, currentTime))
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMovie.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMovie.kt
@@ -8,7 +8,12 @@ import app.moviebase.tmdb.model.TmdbReleaseDates
 import app.moviebase.tmdb.model.TmdbVideo
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.db.tmdbCache.TmdbTimestampedEntry
+import io.github.couchtracker.utils.ApiException
+import kotlinx.coroutines.CompletableDeferred
 import app.moviebase.tmdb.model.TmdbMovie as ApiTmdbMovie
+
+private typealias MovieDetailsRequestInput = List<AppendResponse>
+private typealias MovieDetailsRequestOutput = TmdbMovieDetail
 
 /**
  * Class that represents a TMDB movie.
@@ -19,65 +24,137 @@ data class TmdbMovie(
     val id: TmdbMovieId,
     val language: TmdbLanguage,
 ) {
-    suspend fun details(cache: TmdbCache): TmdbMovieDetail = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-details",
-        get = { cache.movieDetailsCacheQueries.get(id, language, ::TmdbTimestampedEntry) },
-        put = { cache.movieDetailsCacheQueries.put(tmdbId = id, language = language, details = it.value, lastUpdate = it.lastUpdate) },
-        downloader = { it.movies.getDetails(id.value, language.apiParameter) },
+    private val detailsDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-$language-details",
+        loadFromCache = { cache ->
+            cache.movieDetailsCacheQueries.get(
+                tmdbId = id,
+                language = language,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.movieDetailsCacheQueries.put(
+                tmdbId = id,
+                language = language,
+                details = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: MovieDetailsRequestInput -> appendResponses },
+        extractFromResponse = { movieDetails: MovieDetailsRequestOutput -> movieDetails },
     )
-
-    suspend fun credits(cache: TmdbCache): TmdbCredits = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-credits",
-        get = { cache.movieCreditsCacheQueries.get(id, ::TmdbTimestampedEntry) },
-        put = { cache.movieCreditsCacheQueries.put(tmdbId = id, credits = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.movies.getDetails(
-                id.value,
-                null,
-                listOf(AppendResponse.CREDITS),
-            ).credits ?: error("credits cannot be null")
+    private val creditsDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-credits",
+        loadFromCache = { cache ->
+            cache.movieCreditsCacheQueries.get(
+                tmdbId = id,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.movieCreditsCacheQueries.put(
+                tmdbId = id,
+                credits = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: MovieDetailsRequestInput -> appendResponses.plusElement(AppendResponse.CREDITS) },
+        extractFromResponse = { movieDetails: MovieDetailsRequestOutput ->
+            movieDetails.credits ?: throw ApiException.DeserializationError("credits cannot be null", null)
         },
     )
-
-    suspend fun images(cache: TmdbCache): TmdbImages = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-images",
-        get = { cache.movieImagesCacheQueries.get(id, ::TmdbTimestampedEntry) },
-        put = { cache.movieImagesCacheQueries.put(tmdbId = id, images = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.movies.getDetails(
-                id.value,
-                null,
-                listOf(AppendResponse.IMAGES),
-            ).images ?: error("images cannot be null")
+    private val imagesDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-images",
+        loadFromCache = { cache ->
+            cache.movieImagesCacheQueries.get(
+                tmdbId = id,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.movieImagesCacheQueries.put(
+                tmdbId = id,
+                images = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: MovieDetailsRequestInput -> appendResponses.plusElement(AppendResponse.IMAGES) },
+        extractFromResponse = { movieDetails: MovieDetailsRequestOutput ->
+            movieDetails.images ?: throw ApiException.DeserializationError("images cannot be null", null)
         },
     )
-
-    suspend fun videos(cache: TmdbCache): List<TmdbVideo> = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-videos",
-        get = { cache.movieVideosCacheQueries.get(id, ::TmdbTimestampedEntry) },
-        put = { cache.movieVideosCacheQueries.put(tmdbId = id, videos = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.movies.getDetails(
-                id.value,
-                null,
-                listOf(AppendResponse.VIDEOS),
-            ).videos?.results ?: error("videos cannot be null")
+    private val videosDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-videos",
+        loadFromCache = { cache ->
+            cache.movieVideosCacheQueries.get(
+                tmdbId = id,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.movieVideosCacheQueries.put(
+                tmdbId = id,
+                videos = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: MovieDetailsRequestInput -> appendResponses.plusElement(AppendResponse.VIDEOS) },
+        extractFromResponse = { movieDetails: MovieDetailsRequestOutput ->
+            movieDetails.videos?.results ?: throw ApiException.DeserializationError("videos cannot be null", null)
         },
     )
-
-    suspend fun releaseDates(cache: TmdbCache): List<TmdbReleaseDates> = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-release_dates",
-        get = { cache.movieReleaseDatesCacheQueries.get(id, ::TmdbTimestampedEntry) },
-        put = { cache.movieReleaseDatesCacheQueries.put(tmdbId = id, releaseDates = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.movies.getDetails(
-                id.value,
-                null,
-                listOf(AppendResponse.RELEASES_DATES),
-            ).releaseDates?.results.orEmpty()
+    private val releaseDatesDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-release_dates",
+        loadFromCache = { cache ->
+            cache.movieReleaseDatesCacheQueries.get(
+                tmdbId = id,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.movieReleaseDatesCacheQueries.put(
+                tmdbId = id,
+                releaseDates = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: MovieDetailsRequestInput -> appendResponses.plusElement(AppendResponse.RELEASES_DATES) },
+        extractFromResponse = { movieDetails: MovieDetailsRequestOutput ->
+            movieDetails.releaseDates?.results ?: throw ApiException.DeserializationError("releaseDates cannot be null", null)
         },
         expiration = TMDB_CACHE_EXPIRATION_FAST,
     )
+
+    suspend fun details(
+        cache: TmdbCache,
+        details: CompletableDeferred<TmdbMovieDetail>? = null,
+        credits: CompletableDeferred<TmdbCredits>? = null,
+        images: CompletableDeferred<TmdbImages>? = null,
+        videos: CompletableDeferred<List<TmdbVideo>>? = null,
+        releaseDates: CompletableDeferred<List<TmdbReleaseDates>>? = null,
+    ) {
+        tmdbGetOrDownloadBatched(
+            cache = cache,
+            requests = listOfNotNull(
+                details?.let { BatchableRequest(detailsDownloader, details) },
+                credits?.let { BatchableRequest(creditsDownloader, credits) },
+                images?.let { BatchableRequest(imagesDownloader, images) },
+                videos?.let { BatchableRequest(videosDownloader, videos) },
+                releaseDates?.let { BatchableRequest(releaseDatesDownloader, releaseDates) },
+            ),
+            initialRequestInput = emptyList(),
+            downloader = { tmdb, appendToResponse ->
+                tmdb.movies.getDetails(id.value, language.apiParameter, appendToResponse.ifEmpty { null })
+            },
+        )
+    }
+
+    suspend fun details(cache: TmdbCache): TmdbMovieDetail {
+        return CompletableDeferred<TmdbMovieDetail>().also {
+            details(cache, details = it)
+        }.await()
+    }
 }
 
 fun ApiTmdbMovie.toInternalTmdbMovie(language: TmdbLanguage) = TmdbMovie(TmdbMovieId(id), language)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbShow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbShow.kt
@@ -6,7 +6,12 @@ import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbShowDetail
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.db.tmdbCache.TmdbTimestampedEntry
+import io.github.couchtracker.utils.ApiException
+import kotlinx.coroutines.CompletableDeferred
 import app.moviebase.tmdb.model.TmdbShow as ApiTmdbShow
+
+private typealias ShowDetailsRequestInput = List<AppendResponse>
+private typealias ShowDetailsRequestOutput = TmdbShowDetail
 
 /**
  * Class that represents a TMDB show.
@@ -17,43 +22,92 @@ data class TmdbShow(
     val id: TmdbShowId,
     val language: TmdbLanguage,
 ) {
-    suspend fun details(cache: TmdbCache): TmdbShowDetail = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-details",
-        get = { cache.showDetailsCacheQueries.get(id, language, ::TmdbTimestampedEntry) },
-        put = { cache.showDetailsCacheQueries.put(tmdbId = id, language = language, details = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.show.getDetails(
-                showId = id.value,
-                language = language.apiParameter,
+    private val detailsDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-$language-details",
+        loadFromCache = { cache ->
+            cache.showDetailsCacheQueries.get(
+                tmdbId = id,
+                language = language,
+                mapper = ::TmdbTimestampedEntry,
             )
         },
+        putInCache = { cache, data ->
+            cache.showDetailsCacheQueries.put(
+                tmdbId = id,
+                language = language,
+                details = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: ShowDetailsRequestInput -> appendResponses },
+        extractFromResponse = { showDetails: ShowDetailsRequestOutput -> showDetails },
     )
-
-    suspend fun images(cache: TmdbCache): TmdbImages = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-images",
-        get = { cache.showImagesCacheQueries.get(id, ::TmdbTimestampedEntry) },
-        put = { cache.showImagesCacheQueries.put(tmdbId = id, images = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.show.getDetails(
-                showId = id.value,
-                language = null,
-                appendResponses = listOf(AppendResponse.IMAGES),
-            ).images ?: error("images cannot be null")
+    private val aggregateCreditsDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-credits",
+        loadFromCache = { cache ->
+            cache.showAggregateCreditsCacheQueries.get(
+                tmdbId = id,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.showAggregateCreditsCacheQueries.put(
+                tmdbId = id,
+                credits = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: ShowDetailsRequestInput -> appendResponses.plusElement(AppendResponse.AGGREGATE_CREDITS) },
+        extractFromResponse = { showDetails: ShowDetailsRequestOutput ->
+            showDetails.aggregateCredits ?: throw ApiException.DeserializationError("aggregateCredits cannot be null", null)
+        },
+    )
+    private val imagesDownloader = BatchableDownloader(
+        logTag = "${id.toExternalId().serialize()}-images",
+        loadFromCache = { cache ->
+            cache.showImagesCacheQueries.get(
+                tmdbId = id,
+                mapper = ::TmdbTimestampedEntry,
+            )
+        },
+        putInCache = { cache, data ->
+            cache.showImagesCacheQueries.put(
+                tmdbId = id,
+                images = data.value,
+                lastUpdate = data.lastUpdate,
+            )
+        },
+        prepareRequest = { appendResponses: ShowDetailsRequestInput -> appendResponses.plusElement(AppendResponse.IMAGES) },
+        extractFromResponse = { showDetails: ShowDetailsRequestOutput ->
+            showDetails.images ?: throw ApiException.DeserializationError("images cannot be null", null)
         },
     )
 
-    suspend fun aggregateCredits(cache: TmdbCache): TmdbAggregateCredits = tmdbGetOrDownload(
-        entryTag = "${id.toExternalId().serialize()}-$language-credits",
-        get = { cache.showAggregateCreditsCacheQueries.get(id, ::TmdbTimestampedEntry) },
-        put = { cache.showAggregateCreditsCacheQueries.put(tmdbId = id, credits = it.value, lastUpdate = it.lastUpdate) },
-        downloader = {
-            it.show.getDetails(
-                showId = id.value,
-                language = null,
-                appendResponses = listOf(AppendResponse.AGGREGATE_CREDITS),
-            ).aggregateCredits ?: error("aggregateCredits cannot be null")
-        },
-    )
+    suspend fun details(
+        cache: TmdbCache,
+        details: CompletableDeferred<TmdbShowDetail>? = null,
+        aggregateCredits: CompletableDeferred<TmdbAggregateCredits>? = null,
+        images: CompletableDeferred<TmdbImages>? = null,
+    ) {
+        tmdbGetOrDownloadBatched(
+            cache = cache,
+            requests = listOfNotNull(
+                details?.let { BatchableRequest(detailsDownloader, details) },
+                aggregateCredits?.let { BatchableRequest(aggregateCreditsDownloader, aggregateCredits) },
+                images?.let { BatchableRequest(imagesDownloader, images) },
+            ),
+            initialRequestInput = emptyList(),
+            downloader = { tmdb, appendToResponse ->
+                tmdb.show.getDetails(id.value, language.apiParameter, appendToResponse.ifEmpty { null })
+            },
+        )
+    }
+
+    suspend fun details(cache: TmdbCache): TmdbShowDetail {
+        return CompletableDeferred<TmdbShowDetail>().also {
+            details(cache, details = it)
+        }.await()
+    }
 }
 
 fun ApiTmdbShow.toInternalTmdbShow(language: TmdbLanguage) = TmdbShow(TmdbShowId(id), language)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -3,8 +3,11 @@ package io.github.couchtracker.ui.screens.movie
 import android.content.Context
 import androidx.compose.material3.ColorScheme
 import app.moviebase.tmdb.image.TmdbImageType
+import app.moviebase.tmdb.model.TmdbCredits
 import app.moviebase.tmdb.model.TmdbCrew
 import app.moviebase.tmdb.model.TmdbGenre
+import app.moviebase.tmdb.model.TmdbImages
+import app.moviebase.tmdb.model.TmdbMovieDetail
 import coil3.request.ImageRequest
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.tmdbCache.TmdbCache
@@ -27,6 +30,7 @@ import io.github.couchtracker.utils.ApiResult
 import io.github.couchtracker.utils.DeferredApiResult
 import io.github.couchtracker.utils.awaitAll
 import io.github.couchtracker.utils.runApiCatching
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -69,16 +73,21 @@ suspend fun CoroutineScope.loadMovie(
     coroutineContext: CoroutineContext = Dispatchers.Default,
 ): ApiResult<MovieScreenModel> {
     return runApiCatching(LOG_TAG) {
-        val images = async(coroutineContext) {
+        val detailsC = CompletableDeferred<TmdbMovieDetail>()
+        val credits = CompletableDeferred<TmdbCredits>()
+        val images = CompletableDeferred<TmdbImages>()
+        movie.details(cache = tmdbCache, details = detailsC, credits = credits, images = images)
+
+        val imagesModel = async(coroutineContext) {
             runApiCatching(LOG_TAG) {
-                movie.images(tmdbCache)
+                images.await()
                     .linearize()
                     .map { it.toImageModel(TmdbImageType.BACKDROP) }
             }
         }
-        val credits = async(coroutineContext) {
+        val creditsModel = async(coroutineContext) {
             runApiCatching(LOG_TAG) {
-                val credits = movie.credits(tmdbCache)
+                val credits = credits.await()
                 MovieScreenModel.Credits(
                     director = credits.crew.directors(),
                     cast = credits.cast.toCastPortraitModel(movie.language),
@@ -86,7 +95,7 @@ suspend fun CoroutineScope.loadMovie(
                 )
             }
         }
-        val details = movie.details(tmdbCache)
+        val details = detailsC.await()
         val backdrop = async(coroutineContext) {
             details.backdropImage.prepareAndExtractColorScheme(
                 ctx = ctx,
@@ -98,7 +107,7 @@ suspend fun CoroutineScope.loadMovie(
 
         // It can be disruptive to load in content at separate times.
         // If the other content loads "fast enough", I'll wait for it.
-        listOf(images, credits).awaitAll(100.milliseconds)
+        listOf(imagesModel, creditsModel).awaitAll(100.milliseconds)
 
         MovieScreenModel(
             movie = movie,
@@ -110,9 +119,9 @@ suspend fun CoroutineScope.loadMovie(
             originalLanguage = details.language(),
             rating = details.rating(),
             genres = details.genres,
-            credits = credits,
+            credits = creditsModel,
             backdrop = backdrop.await().first,
-            images = images,
+            images = imagesModel,
             colorScheme = backdrop.await().second,
         )
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
@@ -3,8 +3,11 @@ package io.github.couchtracker.ui.screens.show
 import android.content.Context
 import androidx.compose.material3.ColorScheme
 import app.moviebase.tmdb.image.TmdbImageType
+import app.moviebase.tmdb.model.TmdbAggregateCredits
 import app.moviebase.tmdb.model.TmdbGenre
+import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbShowCreatedBy
+import app.moviebase.tmdb.model.TmdbShowDetail
 import coil3.request.ImageRequest
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.tmdb.TmdbRating
@@ -24,6 +27,7 @@ import io.github.couchtracker.utils.ApiResult
 import io.github.couchtracker.utils.DeferredApiResult
 import io.github.couchtracker.utils.awaitAll
 import io.github.couchtracker.utils.runApiCatching
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -63,23 +67,28 @@ suspend fun CoroutineScope.loadShow(
     coroutineContext: CoroutineContext = Dispatchers.Default,
 ): ApiResult<ShowScreenModel> {
     return runApiCatching(LOG_TAG) {
-        val images = async(coroutineContext) {
+        val detailsC = CompletableDeferred<TmdbShowDetail>()
+        val credits = CompletableDeferred<TmdbAggregateCredits>()
+        val images = CompletableDeferred<TmdbImages>()
+        show.details(cache = tmdbCache, details = detailsC, aggregateCredits = credits, images = images)
+
+        val imagesModel = async(coroutineContext) {
             runApiCatching(LOG_TAG) {
-                show.images(tmdbCache)
+                images.await()
                     .linearize()
                     .map { it.toImageModel(TmdbImageType.BACKDROP) }
             }
         }
-        val credits = async(coroutineContext) {
+        val creditsModel = async(coroutineContext) {
             runApiCatching(LOG_TAG) {
-                val credits = show.aggregateCredits(tmdbCache)
+                val credits = credits.await()
                 ShowScreenModel.Credits(
                     cast = credits.cast.toCastPortraitModel(show.language),
                     crew = credits.crew.toCrewCompactListItemModel(show.language),
                 )
             }
         }
-        val details = show.details(tmdbCache)
+        val details = detailsC.await()
         val backdrop = async(coroutineContext) {
             details.backdropImage.prepareAndExtractColorScheme(
                 ctx = ctx,
@@ -91,7 +100,7 @@ suspend fun CoroutineScope.loadShow(
 
         // It can be disruptive to load in content at separate times.
         // If the other content loads "fast enough", I'll wait for it.
-        listOf(images, credits).awaitAll(100.milliseconds)
+        listOf(imagesModel, creditsModel).awaitAll(100.milliseconds)
 
         ShowScreenModel(
             id = show.id,
@@ -102,9 +111,9 @@ suspend fun CoroutineScope.loadShow(
             rating = details.rating(),
             genres = details.genres,
             createdBy = details.createdBy.orEmpty(),
-            credits = credits,
+            credits = creditsModel,
             backdrop = backdrop.await().first,
-            images = images,
+            images = imagesModel,
             colorScheme = backdrop.await().second,
         )
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Api.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Api.kt
@@ -32,7 +32,7 @@ sealed class ApiException(message: String?, cause: Throwable?) : Exception(messa
         override val title = Text.Resource(R.string.api_exception_io_error)
     }
 
-    class DeserializationError(message: String?, override val cause: SerializationException) : ApiException(message, cause) {
+    class DeserializationError(message: String?, override val cause: SerializationException?) : ApiException(message, cause) {
         override val title = Text.Resource(R.string.api_exception_deserialization_error)
     }
 


### PR DESCRIPTION
With this commit, API calls that could be batched together using append_to_response, are.

This is complicated because:
 - we have to support any combination of requests (e.g. with or without downloading videos, images, cast, etc.)
 - preserve type safety (no casting)
 - preserve the current caching properties (pre-fetching, stale caching, etc.)
 - keep the current independence between calls (e.g. if images are cached, they could be returned immediately, even if downloading videos failed)