### PR TITLE
Speed improvements when opening a screen

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
         allWarningsAsErrors = true
         freeCompilerArgs.add("-opt-in=kotlin.time.ExperimentalTime")
         freeCompilerArgs.add("-Xannotation-default-target=param-property")
+        freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
     }
 
     dependencies {
@@ -73,6 +74,7 @@ kotlin {
         implementation(project.dependencies.platform(libs.koin.bom))
         implementation(libs.koin.androidx.compose)
         implementation(libs.koin.compose)
+        implementation(libs.koin.coroutines)
         implementation(libs.koin.core)
 
         // Coil (image library)

--- a/composeApp/detekt.yml
+++ b/composeApp/detekt.yml
@@ -102,6 +102,8 @@ style:
       - value: com.ibm.icu.util.ULocale.getDisplayName
         reason: ULocale.getDisplayName doesn't allow to select additional options. To format a language, use Bcp47Language.getDisplayName()
           If you actually need to format a locale (and not a language), use LocaleDisplayNames.getInstance()s with the options you need.
+      - value: com.ibm.icu.util.ULocale.getAvailableLocales
+        reason: ULocale.getAvailableLocales can take a significant amount of time to load. Use the ALL_ULOCALES constant.
   MagicNumber:
     ignorePropertyDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true

--- a/composeApp/src/main/kotlin/io/github/couchtracker/AndroidApplication.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/AndroidApplication.kt
@@ -10,10 +10,12 @@ import coil3.size.Precision
 import io.github.couchtracker.db.app.AppDataModule
 import io.github.couchtracker.db.profile.ProfileDbModule
 import io.github.couchtracker.db.tmdbCache.TmdbCacheDbModule
-import kotlinx.coroutines.MainScope
+import io.github.couchtracker.tmdb.TmdbModule
+import io.github.couchtracker.utils.LocaleModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.logger.AndroidLogger
 import org.koin.core.context.startKoin
+import org.koin.core.lazyModules
 import org.koin.core.logger.Level
 
 private const val IMAGE_CACHE_PERCENT = 0.5
@@ -28,10 +30,12 @@ class AndroidApplication : Application(), SingletonImageLoader.Factory {
 
             androidContext(this@AndroidApplication)
 
-            modules(
+            lazyModules(
                 AppDataModule,
+                LocaleModule,
                 ProfileDbModule,
                 TmdbCacheDbModule,
+                TmdbModule,
             )
         }
     }
@@ -46,9 +50,5 @@ class AndroidApplication : Application(), SingletonImageLoader.Factory {
                 MemoryCache.Builder().maxSizePercent(this, IMAGE_CACHE_PERCENT).build()
             }
             .build()
-    }
-
-    companion object {
-        var scope = MainScope()
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
@@ -18,6 +18,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import io.github.couchtracker.ui.AnimationDefaults
+import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.ui.composable
 import io.github.couchtracker.ui.screens.main.MainScreen
 import io.github.couchtracker.ui.screens.main.SearchScreen
@@ -25,6 +26,9 @@ import io.github.couchtracker.ui.screens.movie.MovieScreen
 import io.github.couchtracker.ui.screens.settings.settings
 import io.github.couchtracker.ui.screens.show.ShowScreen
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemsScreen
+import io.github.couchtracker.utils.loadAll
+import io.github.couchtracker.utils.rememberComputationResult
+import org.koin.compose.getKoin
 import kotlin.math.roundToInt
 
 val LocalNavController = staticCompositionLocalOf<NavController> { error("no default nav controller") }
@@ -35,36 +39,40 @@ private val FADE_ANIMATION_SPEC = tween<Float>(AnimationDefaults.ANIMATION_DURAT
 @Composable
 fun App() {
     val navController = rememberNavController()
+    val koin = getKoin()
+    val koinLoadState = rememberComputationResult { koin.loadAll() }
     MaterialTheme(colorScheme = darkColorScheme()) {
         CompositionLocalProvider(LocalNavController provides navController) {
             Surface(color = MaterialTheme.colorScheme.background) {
-                ProfilesContext {
-                    NavHost(
-                        navController = navController,
-                        startDestination = MainScreen,
-                        enterTransition = {
-                            val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = LinearOutSlowInEasing)
-                            slideInVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
-                                fadeIn(FADE_ANIMATION_SPEC)
-                        },
-                        exitTransition = {
-                            fadeOut(FADE_ANIMATION_SPEC)
-                        },
-                        popEnterTransition = {
-                            fadeIn(FADE_ANIMATION_SPEC)
-                        },
-                        popExitTransition = {
-                            val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = FastOutLinearInEasing)
-                            slideOutVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
+                LoadableScreen(koinLoadState) {
+                    ProfilesContext {
+                        NavHost(
+                            navController = navController,
+                            startDestination = MainScreen,
+                            enterTransition = {
+                                val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = LinearOutSlowInEasing)
+                                slideInVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
+                                    fadeIn(FADE_ANIMATION_SPEC)
+                            },
+                            exitTransition = {
                                 fadeOut(FADE_ANIMATION_SPEC)
-                        },
-                    ) {
-                        composable<MainScreen>()
-                        composable<SearchScreen>()
-                        composable<MovieScreen>()
-                        composable<ShowScreen>()
-                        composable<WatchedItemsScreen>()
-                        settings()
+                            },
+                            popEnterTransition = {
+                                fadeIn(FADE_ANIMATION_SPEC)
+                            },
+                            popExitTransition = {
+                                val slideSpec = tween<IntOffset>(AnimationDefaults.ANIMATION_DURATION_MS, easing = FastOutLinearInEasing)
+                                slideOutVertically(slideSpec) { (it * ANIMATION_SLIDE).roundToInt() } +
+                                    fadeOut(FADE_ANIMATION_SPEC)
+                            },
+                        ) {
+                            composable<MainScreen>()
+                            composable<SearchScreen>()
+                            composable<MovieScreen>()
+                            composable<ShowScreen>()
+                            composable<WatchedItemsScreen>()
+                            settings()
+                        }
                     }
                 }
             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/app/AppDataModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/app/AppDataModule.kt
@@ -5,11 +5,11 @@ import io.github.couchtracker.db.common.DbPath
 import io.github.couchtracker.db.common.SqliteDriverFactory
 import io.github.couchtracker.db.common.adapters.InstantColumnAdapter
 import io.github.couchtracker.db.common.adapters.URIColumnAdapter
+import io.github.couchtracker.utils.lazyEagerModule
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
-import org.koin.dsl.module
 
-val AppDataModule = module {
+val AppDataModule = lazyEagerModule {
     single(named("AppDb")) {
         AndroidSqliteDriverFactory(schema = AppData.Schema)
     }.bind<SqliteDriverFactory>()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ProfileDbModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/ProfileDbModule.kt
@@ -2,11 +2,11 @@ package io.github.couchtracker.db.profile
 
 import io.github.couchtracker.db.common.AndroidSqliteDriverFactory
 import io.github.couchtracker.db.common.SqliteDriverFactory
+import io.github.couchtracker.utils.lazyEagerModule
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
-import org.koin.dsl.module
 
-val ProfileDbModule = module {
+val ProfileDbModule = lazyEagerModule {
     includes(ProfileDbCommonModule)
 
     factory(named("ProfileDb")) {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/tmdbCache/TmdbCacheDbModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/tmdbCache/TmdbCacheDbModule.kt
@@ -8,16 +8,16 @@ import io.github.couchtracker.db.common.adapters.jsonAdapter
 import io.github.couchtracker.tmdb.TmdbLanguage
 import io.github.couchtracker.tmdb.TmdbMovieId
 import io.github.couchtracker.tmdb.TmdbShowId
+import io.github.couchtracker.utils.lazyEagerModule
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
-import org.koin.dsl.module
 
-val TmdbCacheDbModule = module {
+val TmdbCacheDbModule = lazyEagerModule {
     factory(named("TmdbCacheDb")) {
         AndroidSqliteDriverFactory(schema = TmdbCache.Schema)
     }.bind<SqliteDriverFactory>()
 
-    single {
+    single(createdAtStart = true) {
         val driverFactory = get<SqliteDriverFactory>(named("TmdbCacheDb"))
         TmdbCache(
             driver = driverFactory.getDriver(DbPath.appCache(get(), "tmdb-cache.db")),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/Utils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/Utils.kt
@@ -4,14 +4,18 @@ import android.icu.text.ListFormatter
 import android.text.format.DateFormat
 import androidx.compose.ui.text.intl.Locale
 import io.github.couchtracker.intl.datetime.Skeleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 
-fun formatAndList(items: List<String>): String {
-    return ListFormatter.getInstance().format(items)
+suspend fun formatAndList(items: List<String>): String {
+    return withContext(Dispatchers.Default) {
+        ListFormatter.getInstance().format(items)
+    }
 }
 
 /**

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BaseTmdbMovie.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BaseTmdbMovie.kt
@@ -1,0 +1,54 @@
+package io.github.couchtracker.tmdb
+
+import app.moviebase.tmdb.image.TmdbImage
+import app.moviebase.tmdb.model.TmdbMovieDetail
+import app.moviebase.tmdb.model.TmdbRatingItem
+import kotlinx.datetime.LocalDate
+import app.moviebase.tmdb.model.TmdbMovie as ApiTmdbMovie
+
+/** Contains movie information that can be obtained from the result of any TMDB API call */
+data class BaseTmdbMovie(
+    val id: TmdbMovie,
+    val title: String,
+    val overview: String,
+    val poster: TmdbImage?,
+    val backdrop: TmdbImage?,
+    val adult: Boolean,
+    val releaseDate: LocalDate?,
+    val originalTitle: String,
+    val popularity: Float,
+    override val voteCount: Int,
+    override val voteAverage: Float,
+) : TmdbRatingItem
+
+fun ApiTmdbMovie.toBaseMovie(language: TmdbLanguage): BaseTmdbMovie {
+    return BaseTmdbMovie(
+        id = toInternalTmdbMovie(language),
+        title = title,
+        overview = overview,
+        poster = posterImage,
+        backdrop = backdropImage,
+        adult = adult,
+        releaseDate = releaseDate,
+        originalTitle = originalTitle,
+        popularity = popularity,
+        voteCount = voteCount,
+        voteAverage = voteAverage,
+    )
+}
+
+fun TmdbMovieDetail.toBaseMovie(language: TmdbLanguage): BaseTmdbMovie {
+    return BaseTmdbMovie(
+        id = toInternalTmdbMovie(language),
+        title = title,
+        overview = overview,
+        poster = posterImage,
+        backdrop = backdropImage,
+        adult = adult,
+        releaseDate = releaseDate,
+        originalTitle = originalTitle,
+        popularity = popularity,
+        voteCount = voteCount,
+        voteAverage = voteAverage,
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BaseTmdbShow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BaseTmdbShow.kt
@@ -1,0 +1,57 @@
+package io.github.couchtracker.tmdb
+
+import app.moviebase.tmdb.image.TmdbImage
+import app.moviebase.tmdb.model.TmdbRatingItem
+import app.moviebase.tmdb.model.TmdbShowDetail
+import kotlinx.datetime.LocalDate
+import app.moviebase.tmdb.model.TmdbShow as ApiTmdbShow
+
+/** Contains show information that can be obtained from the result of any TMDB API call */
+data class BaseTmdbShow(
+    val id: TmdbShow,
+    val name: String,
+    val overview: String,
+    val poster: TmdbImage?,
+    val backdrop: TmdbImage?,
+    val firstAirDate: LocalDate?,
+    val originalName: String,
+    val originCountry: List<String>,
+    val originalLanguage: String,
+    val popularity: Float,
+    override val voteCount: Int,
+    override val voteAverage: Float,
+) : TmdbRatingItem
+
+fun ApiTmdbShow.toBaseShow(language: TmdbLanguage): BaseTmdbShow {
+    return BaseTmdbShow(
+        id = toInternalTmdbShow(language),
+        name = name,
+        overview = overview,
+        poster = posterImage,
+        backdrop = backdropImage,
+        firstAirDate = firstAirDate,
+        originalName = originalName,
+        originCountry = originCountry,
+        originalLanguage = originalLanguage,
+        popularity = popularity,
+        voteCount = voteCount,
+        voteAverage = voteAverage,
+    )
+}
+
+fun TmdbShowDetail.toBaseShow(language: TmdbLanguage): BaseTmdbShow {
+    return BaseTmdbShow(
+        id = toInternalTmdbShow(language),
+        name = name,
+        overview = overview,
+        poster = posterImage,
+        backdrop = backdropImage,
+        firstAirDate = firstAirDate,
+        originalName = originalName,
+        originCountry = originCountry,
+        originalLanguage = originalLanguage,
+        popularity = popularity,
+        voteCount = voteCount,
+        voteAverage = voteAverage,
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDepartment.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDepartment.kt
@@ -4,7 +4,7 @@ import app.moviebase.tmdb.model.TmdbDepartment
 import io.github.couchtracker.R
 import io.github.couchtracker.utils.Text
 
-fun TmdbDepartment.title(): Text {
+fun TmdbDepartment.title(): Text.Resource {
     val resource = when (this) {
         TmdbDepartment.ACTING -> R.string.crew_departments_acting
         TmdbDepartment.ACTORS -> R.string.crew_departments_actors

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
 import kotlinx.serialization.SerializationException
+import org.koin.mp.KoinPlatform
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -24,12 +25,6 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 
 private const val LOG_TAG = "TmdbDownload"
-
-private val tmdb = Tmdb3 {
-    tmdbApiKey = TmdbConfig.API_KEY
-    useTimeout = true
-    maxRequestRetries = 3
-}
 
 val TMDB_CACHE_EXPIRATION_FAST = 1.hours
 val TMDB_CACHE_EXPIRATION_DEFAULT = 1.days
@@ -100,7 +95,7 @@ suspend fun <T> tmdbDownloadResult(
     return runApiCatching(logTag) {
         try {
             injectApiError()
-            val client = tmdb
+            val client = KoinPlatform.getKoin().get<Tmdb3>()
             // preparing the API call is often CPU intensive
             withContext(Dispatchers.Default) {
                 download(client)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMemoryCache.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMemoryCache.kt
@@ -1,0 +1,20 @@
+package io.github.couchtracker.tmdb
+
+import androidx.collection.LruCache
+
+class TmdbMemoryCache {
+    private val movieCache = LruCache<TmdbMovie, BaseTmdbMovie>(32)
+    private val showCache = LruCache<TmdbShow, BaseTmdbShow>(32)
+
+    fun registerItem(movie: BaseTmdbMovie) {
+        movieCache.put(movie.id, movie)
+    }
+
+    fun registerItem(show: BaseTmdbShow) {
+        showCache.put(show.id, show)
+    }
+
+    fun getMovie(id: TmdbMovie): BaseTmdbMovie? = movieCache[id]
+
+    fun getShow(id: TmdbShow): BaseTmdbShow? = showCache[id]
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbModule.kt
@@ -1,0 +1,17 @@
+package io.github.couchtracker.tmdb
+
+import app.moviebase.tmdb.Tmdb3
+import io.github.couchtracker.utils.lazyEagerModule
+
+val TmdbModule = lazyEagerModule {
+    single {
+        Tmdb3 {
+            tmdbApiKey = TmdbConfig.API_KEY
+            useTimeout = true
+            maxRequestRetries = 3
+        }
+    }
+    single {
+        TmdbMemoryCache()
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMovie.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMovie.kt
@@ -105,4 +105,5 @@ data class TmdbMovie(
     }
 }
 
+fun TmdbMovieDetail.toInternalTmdbMovie(language: TmdbLanguage) = TmdbMovie(TmdbMovieId(id), language)
 fun ApiTmdbMovie.toInternalTmdbMovie(language: TmdbLanguage) = TmdbMovie(TmdbMovieId(id), language)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbRating.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbRating.kt
@@ -1,28 +1,40 @@
 package io.github.couchtracker.tmdb
 
 import app.moviebase.tmdb.model.TmdbRatingItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.text.NumberFormat
 
-data class TmdbRating(
+data class TmdbRating private constructor(
     val average: Float,
     val count: Int,
+    val formatted: String,
 ) {
     init {
         require(count > 0)
     }
 
-    // TODO put in composable function
-    fun format() = NumberFormat.getInstance().apply {
-        minimumFractionDigits = 1
-        maximumFractionDigits = 1
-    }.format(average) + "★"
+    companion object {
+        suspend fun of(average: Float, count: Int): TmdbRating {
+            return withContext(Dispatchers.Default) {
+                TmdbRating(
+                    average = average,
+                    count = count,
+                    formatted = NumberFormat.getInstance().apply {
+                        minimumFractionDigits = 1
+                        maximumFractionDigits = 1
+                    }.format(average) + "★",
+                )
+            }
+        }
+    }
 }
 
-fun TmdbRatingItem.rating(): TmdbRating? {
+suspend fun TmdbRatingItem.rating(): TmdbRating? {
     val count = voteCount?.takeIf { it > 0 }
     val average = voteAverage
     return if (count != null && average != null) {
-        TmdbRating(average, count)
+        TmdbRating.of(average, count)
     } else {
         null
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbShow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbShow.kt
@@ -85,3 +85,4 @@ data class TmdbShow(
 }
 
 fun ApiTmdbShow.toInternalTmdbShow(language: TmdbLanguage) = TmdbShow(TmdbShowId(id), language)
+fun TmdbShowDetail.toInternalTmdbShow(language: TmdbLanguage) = TmdbShow(TmdbShowId(id), language)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/Model.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/Model.kt
@@ -18,7 +18,7 @@ sealed interface ImageModel {
     fun getCoilModel(width: Int, height: Int): Any?
 
     data class TmdbImage(override val aspectRatio: Float?, val tmdbImage: app.moviebase.tmdb.image.TmdbImage) : ImageModel {
-        override fun getCoilModel(width: Int, height: Int): Any? {
+        override fun getCoilModel(width: Int, height: Int): Any {
             return TmdbImageUrlBuilder.build(tmdbImage, width, height)
         }
     }
@@ -28,7 +28,7 @@ sealed interface ImageModel {
         val tmdbImage: app.moviebase.tmdb.model.TmdbFileImage,
         val type: TmdbImageType,
     ) : ImageModel {
-        override fun getCoilModel(width: Int, height: Int): Any? {
+        override fun getCoilModel(width: Int, height: Int): Any {
             return TmdbImageUrlBuilder.build(
                 imagePath = tmdbImage.filePath,
                 type = type,
@@ -77,7 +77,7 @@ suspend fun TmdbFileImage.toImageModel(
     imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
 ): ImageModel {
     return prepareImage(
-        baseModel = ImageModel.TmdbFileImage(null, this, type),
+        baseModel = ImageModel.TmdbFileImage(aspectRation, this, type),
         options = imagePreloadOptions,
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LanguagePickerDialog.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LanguagePickerDialog.kt
@@ -13,6 +13,7 @@ import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.utils.LanguageCategory
 import io.github.couchtracker.utils.LanguageItem
+import io.github.couchtracker.utils.LocaleData
 import io.github.couchtracker.utils.MixedValueTree
 import io.github.couchtracker.utils.allLeafs
 import io.github.couchtracker.utils.countLeafs
@@ -22,6 +23,7 @@ import io.github.couchtracker.utils.languageTree
 import io.github.couchtracker.utils.pluralStr
 import io.github.couchtracker.utils.str
 import io.github.couchtracker.utils.toULocale
+import org.koin.compose.koinInject
 
 private val CAPITALIZATION = DisplayContext.CAPITALIZATION_FOR_UI_LIST_OR_MENU
 
@@ -35,10 +37,11 @@ fun LanguagePickerDialog(
     onClose: () -> Unit,
 ) {
     val userLocale = LocalConfiguration.currentFirstLocale.toULocale()
-
+    val allLocales = koinInject<LocaleData>().allLocales
     val languagesTreeRoot = remember(userLocale) {
         Bcp47Language.languageTree(
-            compareBy {
+            allLocales = allLocales,
+            comparator = compareBy {
                 when (it) {
                     is MixedValueTree.Intermediate -> it.value.language
                     is MixedValueTree.Leaf -> it.value.language

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LoadableScreen.kt
@@ -21,10 +21,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.github.couchtracker.ui.AnimationDefaults
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
 
-private const val ANIMATION_DURATION_MS = 300
+private const val ANIMATION_DURATION_MS = AnimationDefaults.ANIMATION_DURATION_MS
 private val DEFAULT_INDICATOR_SIZE = 64.dp
 
 /**

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
@@ -334,7 +334,7 @@ object OverviewScreenComponents {
         }
     }
 
-    fun LazyListScope.paragraphSection(sectionKey: String, title: String, content: String) {
+    fun LazyListScope.paragraphSection(sectionKey: String, title: String?, content: String) {
         section(sectionKey, title) {
             item(key = "$sectionKey-content", contentType = "text-section-content") {
                 Paragraph(content, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.animateItem())

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/PortraitComposable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/PortraitComposable.kt
@@ -15,23 +15,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.github.couchtracker.ui.ImagePreloadOptions
-import kotlin.math.roundToInt
 
 object PortraitComposableDefaults {
     const val POSTER_ASPECT_RATIO = 2f / 3
     val SUGGESTED_WIDTH = 120.dp
-
-    @Composable
-    fun preloadOptions(maxW: Dp = SUGGESTED_WIDTH): ImagePreloadOptions.Preload {
-        val wPx = with(LocalDensity.current) { maxW.toPx() }
-        val hPx = wPx * LocalDensity.current.density / POSTER_ASPECT_RATIO
-        return ImagePreloadOptions.Preload(LocalContext.current, wPx.roundToInt(), hPx.roundToInt())
-    }
 }
 
 @Composable
@@ -40,7 +28,7 @@ fun PortraitComposable(
     image: @Composable (w: Int, h: Int) -> Unit,
     label: @Composable () -> Unit,
 ) {
-    Column(modifier, horizontalAlignment = Alignment.Companion.CenterHorizontally) {
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Surface(
             shape = MaterialTheme.shapes.small,
             shadowElevation = 8.dp,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/Scrim.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/Scrim.kt
@@ -19,12 +19,14 @@ fun BoxScope.Scrim(visible: Boolean, color: Color, onDismissRequest: () -> Unit)
     } else {
         Modifier
     }
-    Canvas(
-        Modifier
-            .matchParentSize()
-            .then(dismissModifier),
-    ) {
-        drawRect(color = color, alpha = alpha)
+    if (alpha > 0) {
+        Canvas(
+            Modifier
+                .matchParentSize()
+                .then(dismissModifier),
+        ) {
+            drawRect(color = color, alpha = alpha)
+        }
     }
 }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/SearchScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/SearchScreen.kt
@@ -71,6 +71,8 @@ import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
 import io.github.couchtracker.tmdb.rating
 import io.github.couchtracker.tmdb.tmdbPager
+import io.github.couchtracker.tmdb.toBaseMovie
+import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.tmdb.toInternalTmdbMovie
 import io.github.couchtracker.tmdb.toInternalTmdbShow
 import io.github.couchtracker.ui.ColorSchemes
@@ -342,7 +344,7 @@ private fun SearchResult(item: SearchResultItem?) {
                     aspectRatio = PortraitComposableDefaults.POSTER_ASPECT_RATIO,
                 ),
             ) {
-                BoxWithConstraints(contentAlignment = Alignment.Companion.BottomStart) {
+                BoxWithConstraints(contentAlignment = Alignment.BottomStart) {
                     AsyncImage(
                         model = item?.posterModel?.getCoilModel(
                             this.constraints.maxWidth,
@@ -430,9 +432,9 @@ private suspend fun TmdbSearchableListItem.toModel(): SearchResultItem? {
             type = SearchableMediaType.MOVIE,
             tags = listOfNotNull(
                 releaseDate?.year?.toString(),
-                rating()?.format(),
+                rating()?.formatted,
             ),
-            navigate = { it.navigateToMovie(toInternalTmdbMovie(TMDB_LANGUAGE)) },
+            navigate = { it.navigateToMovie(toInternalTmdbMovie(TMDB_LANGUAGE), toBaseMovie(TMDB_LANGUAGE)) },
         )
 
         is TmdbPerson -> SearchResultItem(
@@ -448,7 +450,7 @@ private suspend fun TmdbSearchableListItem.toModel(): SearchResultItem? {
             title = name,
             type = SearchableMediaType.SHOW,
             tags = listOfNotNull(firstAirDate?.year?.toString()),
-            navigate = { it.navigateToShow(toInternalTmdbShow(TMDB_LANGUAGE)) },
+            navigate = { it.navigateToShow(toInternalTmdbShow(TMDB_LANGUAGE), toBaseShow(TMDB_LANGUAGE)) },
         )
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
@@ -23,6 +23,7 @@ import app.moviebase.tmdb.model.TmdbTimeWindow
 import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
 import io.github.couchtracker.tmdb.tmdbPager
+import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.components.PaginatedGrid
 import io.github.couchtracker.ui.components.PortraitComposableDefaults
@@ -79,8 +80,8 @@ private fun ShowListComposable(
     val lazyItems = tabState.showFlow.collectAsLazyPagingItems()
     val navController = LocalNavController.current
     PaginatedGrid(lazyItems, columns = GridCells.Adaptive(minSize = PortraitComposableDefaults.SUGGESTED_WIDTH)) { show ->
-        ShowPortrait(Modifier.fillMaxWidth(), show) {
-            navController.navigateToShow(it.show)
+        ShowPortrait(Modifier.fillMaxWidth(), show?.second) {
+            navController.navigateToShow(it.show, show?.first)
         }
     }
 }
@@ -103,8 +104,8 @@ class ShowExploreTabState(viewModelScope: CoroutineScope) {
             trending.getTrendingShows(TmdbTimeWindow.DAY, page = page, TMDB_LANGUAGE.apiParameter)
         },
         mapper = { show ->
-            show.toShowPortraitModels(TMDB_LANGUAGE, ImagePreloadOptions.DoNotPreload)
+            show.toBaseShow(TMDB_LANGUAGE) to show.toShowPortraitModels(TMDB_LANGUAGE, ImagePreloadOptions.DoNotPreload)
         },
     )
-    val showFlow = pager.flow.removeDuplicates { it.show.id.value }.cachedIn(viewModelScope)
+    val showFlow = pager.flow.removeDuplicates { it.first.id.id }.cachedIn(viewModelScope)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -1,6 +1,7 @@
 package io.github.couchtracker.ui.screens.movie
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.material3.ColorScheme
 import app.moviebase.tmdb.image.TmdbImageType
 import app.moviebase.tmdb.model.TmdbCredits
@@ -9,8 +10,11 @@ import app.moviebase.tmdb.model.TmdbGenre
 import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbMovieDetail
 import coil3.request.ImageRequest
+import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.tmdbCache.TmdbCache
+import io.github.couchtracker.intl.formatAndList
+import io.github.couchtracker.tmdb.TmdbMemoryCache
 import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.tmdb.TmdbRating
 import io.github.couchtracker.tmdb.directors
@@ -19,6 +23,7 @@ import io.github.couchtracker.tmdb.linearize
 import io.github.couchtracker.tmdb.prepareAndExtractColorScheme
 import io.github.couchtracker.tmdb.rating
 import io.github.couchtracker.tmdb.runtime
+import io.github.couchtracker.tmdb.toBaseMovie
 import io.github.couchtracker.ui.ColorSchemes
 import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.components.CastPortraitModel
@@ -29,27 +34,24 @@ import io.github.couchtracker.ui.toImageModel
 import io.github.couchtracker.utils.ApiResult
 import io.github.couchtracker.utils.CompletableApiResult
 import io.github.couchtracker.utils.DeferredApiResult
-import io.github.couchtracker.utils.awaitAll
+import io.github.couchtracker.utils.Result
+import io.github.couchtracker.utils.ifError
 import io.github.couchtracker.utils.map
-import io.github.couchtracker.utils.onValue
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatform
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 data class MovieScreenModel(
     val movie: TmdbMovie,
     val title: String,
-    val tagline: String,
     val overview: String,
     val year: Int?,
-    val runtime: Duration?,
-    val originalLanguage: Bcp47Language,
     val rating: TmdbRating?,
-    val genres: List<TmdbGenre>,
+    val fullDetails: DeferredApiResult<FullDetails>,
     val credits: DeferredApiResult<Credits>,
     val images: DeferredApiResult<List<ImageModel>>,
     val backdrop: ImageRequest?,
@@ -57,21 +59,31 @@ data class MovieScreenModel(
 ) {
     val allDeferred: Set<DeferredApiResult<*>> = setOf(credits, images)
 
+    data class FullDetails(
+        val tagline: String,
+        val runtime: Duration?,
+        val originalLanguage: Bcp47Language,
+        val genres: List<TmdbGenre>,
+    )
+
     data class Credits(
-        val director: List<TmdbCrew>,
+        val directors: List<TmdbCrew>,
         val cast: List<CastPortraitModel>,
         val crew: List<CrewCompactListItemModel>,
+        val directorsString: String?,
     )
 }
 
-suspend fun loadMovie(
+suspend fun CoroutineScope.loadMovie(
     ctx: Context,
-    tmdbCache: TmdbCache,
     movie: TmdbMovie,
     width: Int,
     height: Int,
+    tmdbCache: TmdbCache = KoinPlatform.getKoin().get(),
+    tmdbMemoryCache: TmdbMemoryCache = KoinPlatform.getKoin().get(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
-): ApiResult<MovieScreenModel> = coroutineScope {
+): ApiResult<MovieScreenModel> {
+    val baseDetailsMemory = tmdbMemoryCache.getMovie(movie)
     val details = CompletableApiResult<TmdbMovieDetail>()
     val credits = CompletableApiResult<TmdbCredits>()
     val images = CompletableApiResult<TmdbImages>()
@@ -88,40 +100,56 @@ suspend fun loadMovie(
     }
     val creditsModel = async(coroutineContext) {
         credits.await().map { credits ->
+            val directors = credits.crew.directors()
             MovieScreenModel.Credits(
-                director = credits.crew.directors(),
+                directors = directors,
                 cast = credits.cast.toCastPortraitModel(movie.language),
-                crew = credits.crew.toCrewCompactListItemModel(movie.language),
+                crew = credits.crew.toCrewCompactListItemModel(ctx, movie.language),
+                directorsString = if (directors.isEmpty()) {
+                    null
+                } else {
+                    ctx.getString(R.string.movie_by_director, formatAndList(directors.map { it.name }))
+                },
             )
         }
     }
-    details.await().map { details ->
-        val backdrop = async(coroutineContext) {
-            details.backdropImage.prepareAndExtractColorScheme(
-                ctx = ctx,
-                width = width,
-                height = height,
-                fallbackColorScheme = ColorSchemes.Movie,
+    val fullDetailsModel = async(coroutineContext) {
+        details.await().map { details ->
+            MovieScreenModel.FullDetails(
+                tagline = details.tagline,
+                runtime = details.runtime(),
+                originalLanguage = details.language(),
+                genres = details.genres,
             )
         }
-        MovieScreenModel(
-            movie = movie,
-            title = details.title,
-            tagline = details.tagline,
-            overview = details.overview,
-            year = details.releaseDate?.year,
-            runtime = details.runtime(),
-            originalLanguage = details.language(),
-            rating = details.rating(),
-            genres = details.genres,
-            credits = creditsModel,
-            backdrop = backdrop.await().first,
-            images = imagesModel,
-            colorScheme = backdrop.await().second,
+    }
+    val baseDetails = if (baseDetailsMemory != null) {
+        baseDetailsMemory
+    } else {
+        Log.w("Cache miss", "Movie $movie not found in cache")
+        details.await().map { details ->
+            details.toBaseMovie(movie.language)
+        }.ifError { return Result.Error(it) }
+    }
+    val backdrop = async(coroutineContext) {
+        baseDetails.backdrop.prepareAndExtractColorScheme(
+            ctx = ctx,
+            width = width,
+            height = height,
+            fallbackColorScheme = ColorSchemes.Movie,
         )
-    }.onValue {
-        // It can be disruptive to load in content at separate times.
-        // If the other content loads "fast enough", I'll wait for it.
-        it.allDeferred.awaitAll(100.milliseconds)
     }
+    val ret = MovieScreenModel(
+        movie = movie,
+        title = baseDetails.title,
+        overview = baseDetails.overview,
+        year = baseDetails.releaseDate?.year,
+        rating = baseDetails.rating(),
+        fullDetails = fullDetailsModel,
+        credits = creditsModel,
+        backdrop = backdrop.await().first,
+        images = imagesModel,
+        colorScheme = backdrop.await().second,
+    )
+    return Result.Value(ret)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
@@ -1,6 +1,7 @@
 package io.github.couchtracker.ui.screens.show
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.material3.ColorScheme
 import app.moviebase.tmdb.image.TmdbImageType
 import app.moviebase.tmdb.model.TmdbAggregateCredits
@@ -9,13 +10,17 @@ import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbShowCreatedBy
 import app.moviebase.tmdb.model.TmdbShowDetail
 import coil3.request.ImageRequest
+import io.github.couchtracker.R
 import io.github.couchtracker.db.tmdbCache.TmdbCache
+import io.github.couchtracker.intl.formatAndList
+import io.github.couchtracker.tmdb.TmdbMemoryCache
 import io.github.couchtracker.tmdb.TmdbRating
 import io.github.couchtracker.tmdb.TmdbShow
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.linearize
 import io.github.couchtracker.tmdb.prepareAndExtractColorScheme
 import io.github.couchtracker.tmdb.rating
+import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.ColorSchemes
 import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.components.CastPortraitModel
@@ -26,25 +31,23 @@ import io.github.couchtracker.ui.toImageModel
 import io.github.couchtracker.utils.ApiResult
 import io.github.couchtracker.utils.CompletableApiResult
 import io.github.couchtracker.utils.DeferredApiResult
-import io.github.couchtracker.utils.awaitAll
+import io.github.couchtracker.utils.Result
+import io.github.couchtracker.utils.ifError
 import io.github.couchtracker.utils.map
-import io.github.couchtracker.utils.onValue
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatform
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.milliseconds
 
 data class ShowScreenModel(
     val id: TmdbShowId,
     val name: String,
-    val tagline: String,
     val overview: String,
     val year: Int?,
     val rating: TmdbRating?,
-    val genres: List<TmdbGenre>,
-    val createdBy: List<TmdbShowCreatedBy>,
+    val fullDetails: DeferredApiResult<FullDetails>,
     val credits: DeferredApiResult<Credits>,
     val images: DeferredApiResult<List<ImageModel>>,
     val backdrop: ImageRequest?,
@@ -52,20 +55,30 @@ data class ShowScreenModel(
 ) {
     val allDeferred: Set<DeferredApiResult<*>> = setOf(credits, images)
 
+    data class FullDetails(
+        val tagline: String,
+        val genres: List<TmdbGenre>,
+        val createdBy: List<TmdbShowCreatedBy>,
+        val createdByString: String?,
+    )
+
     data class Credits(
         val cast: List<CastPortraitModel>,
         val crew: List<CrewCompactListItemModel>,
     )
 }
 
-suspend fun loadShow(
+@Suppress("LongParameterList")
+suspend fun CoroutineScope.loadShow(
     ctx: Context,
-    tmdbCache: TmdbCache,
     show: TmdbShow,
     width: Int,
     height: Int,
+    tmdbCache: TmdbCache = KoinPlatform.getKoin().get(),
+    tmdbMemoryCache: TmdbMemoryCache = KoinPlatform.getKoin().get(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
-): ApiResult<ShowScreenModel> = coroutineScope {
+): ApiResult<ShowScreenModel> {
+    val baseDetailsMemory = tmdbMemoryCache.getShow(show)
     val details = CompletableApiResult<TmdbShowDetail>()
     val credits = CompletableApiResult<TmdbAggregateCredits>()
     val images = CompletableApiResult<TmdbImages>()
@@ -83,37 +96,53 @@ suspend fun loadShow(
     val creditsModel = async(coroutineContext) {
         credits.await().map { credits ->
             ShowScreenModel.Credits(
-                cast = credits.cast.toCastPortraitModel(show.language),
-                crew = credits.crew.toCrewCompactListItemModel(show.language),
+                cast = credits.cast.toCastPortraitModel(ctx, show.language),
+                crew = credits.crew.toCrewCompactListItemModel(ctx, show.language),
             )
         }
     }
-    details.await().map { details ->
-        val backdrop = async(coroutineContext) {
-            details.backdropImage.prepareAndExtractColorScheme(
-                ctx = ctx,
-                width = width,
-                height = height,
-                fallbackColorScheme = ColorSchemes.Show,
+    val fullDetailsModel = async(coroutineContext) {
+        details.await().map { details ->
+            val createdBy = details.createdBy.orEmpty()
+            ShowScreenModel.FullDetails(
+                tagline = details.tagline,
+                genres = details.genres,
+                createdBy = createdBy,
+                createdByString = if (createdBy.isEmpty()) {
+                    null
+                } else {
+                    ctx.getString(R.string.show_by_creator, formatAndList(createdBy.map { it.name }))
+                },
             )
         }
-        ShowScreenModel(
-            id = show.id,
-            name = details.name,
-            tagline = details.tagline,
-            overview = details.overview,
-            year = details.firstAirDate?.year,
-            rating = details.rating(),
-            genres = details.genres,
-            createdBy = details.createdBy.orEmpty(),
-            credits = creditsModel,
-            backdrop = backdrop.await().first,
-            images = imagesModel,
-            colorScheme = backdrop.await().second,
+    }
+    val baseDetails = if (baseDetailsMemory != null) {
+        baseDetailsMemory
+    } else {
+        Log.w("Cache miss", "Show $show not found in cache")
+        details.await().map { details ->
+            details.toBaseShow(show.language)
+        }.ifError { return Result.Error(it) }
+    }
+    val backdrop = async(coroutineContext) {
+        baseDetails.backdrop.prepareAndExtractColorScheme(
+            ctx = ctx,
+            width = width,
+            height = height,
+            fallbackColorScheme = ColorSchemes.Show,
         )
-    }.onValue {
-        // It can be disruptive to load in content at separate times.
-        // If the other content loads "fast enough", I'll wait for it.
-        it.allDeferred.awaitAll(100.milliseconds)
     }
+    val ret = ShowScreenModel(
+        id = show.id,
+        name = baseDetails.name,
+        overview = baseDetails.overview,
+        year = baseDetails.firstAirDate?.year,
+        rating = baseDetails.rating(),
+        fullDetails = fullDetailsModel,
+        credits = creditsModel,
+        backdrop = backdrop.await().first,
+        images = imagesModel,
+        colorScheme = backdrop.await().second,
+    )
+    return Result.Value(ret)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
@@ -1,8 +1,10 @@
 package io.github.couchtracker.utils
 
+import android.util.Log
 import kotlinx.coroutines.delay
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTimedValue
 
 private const val INJECT_ERRORS = false
 
@@ -29,4 +31,12 @@ fun <T : Any> T?.injectCacheMiss(): T? {
         }
     }
     return this
+}
+
+inline fun <T> logExecutionTime(logTag: String, message: String, f: () -> T): T {
+    val (value, took) = measureTimedValue {
+        f()
+    }
+    Log.d(logTag, "$message took $took")
+    return value
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Deferred.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Deferred.kt
@@ -1,25 +1,9 @@
 package io.github.couchtracker.utils
 
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeout
-import kotlin.time.Duration
-
-/**
- * Awaits for the completion of all given referred, up to [timeout].
- */
-suspend fun Collection<Deferred<*>>.awaitAll(timeout: Duration) {
-    try {
-        withTimeout(timeout) {
-            awaitAll()
-        }
-    } catch (_: TimeoutCancellationException) {
-    }
-}
 
 fun <T> Collection<Deferred<T>>.emitAsFlow(): Flow<T> {
     val deferred = this

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Koin.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Koin.kt
@@ -1,0 +1,30 @@
+package io.github.couchtracker.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.Koin
+import org.koin.core.awaitAllStartJobs
+import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.LazyModule
+import org.koin.dsl.ModuleDeclaration
+import org.koin.dsl.module
+
+/**
+ * A lazy Koin module, where all definitions are eager.
+ */
+@KoinDslMarker
+fun lazyEagerModule(moduleDefinition: ModuleDeclaration): LazyModule = LazyModule {
+    module(createdAtStart = true) {
+        moduleDefinition()
+    }
+}
+
+/**
+ * Loads all Koin modules and their eager definitions
+ */
+suspend fun Koin.loadAll() {
+    withContext(Dispatchers.Default) {
+        awaitAllStartJobs()
+        createEagerInstances()
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Language.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Language.kt
@@ -53,6 +53,7 @@ sealed interface LanguageItem {
  * Each branch is sorted according to the given [comparator].
  */
 fun Bcp47Language.Companion.languageTree(
+    allLocales: List<ULocale>,
     comparator: Comparator<MixedValueTree.NonRoot<LanguageCategory.Language, LanguageItem>>,
 ): MixedValueTree.Root<Unit, LanguageCategory, LanguageItem> {
     return MixedValueTree.Root(
@@ -63,7 +64,7 @@ fun Bcp47Language.Companion.languageTree(
                 children = LanguageItem.Special.entries.map { MixedValueTree.Leaf(it) },
             ),
         ).plus(
-            ULocale.getAvailableLocales()
+            allLocales
                 .map { Bcp47Language(it) }
                 .filter { it !in LanguageItem.Special.LANGUAGES }
                 .groupBy { it.locale.language }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Loadable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Loadable.kt
@@ -25,6 +25,14 @@ inline fun <I, O, E> Loadable<I, E>.flatMap(f: (I) -> Loadable<O, E>): Loadable<
     is Result.Value -> f(value)
 }
 
+fun <T> Loadable<T, *>.valueOrNull(): T? {
+    return when (this) {
+        is Result.Value -> value
+        is Result.Error -> null
+        Loadable.Loading -> null
+    }
+}
+
 /**
  * Applies [f] to [Result.Value.value].
  * Otherwise, [Loadable.Loading] and [Result.Error] are returned without executing [f].

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Locale.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Locale.kt
@@ -7,7 +7,17 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
 import com.ibm.icu.util.ULocale
+import org.koin.core.module.dsl.singleOf
 import java.util.Locale
+
+class LocaleData {
+    @Suppress("ForbiddenMethodCall")
+    val allLocales = ULocale.getAvailableLocales().asList()
+}
+
+val LocaleModule = lazyEagerModule {
+    singleOf(::LocaleData)
+}
 
 val CompositionLocal<Configuration>.currentLocales
     @Composable

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/Bcp47LanguageTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/Bcp47LanguageTest.kt
@@ -1,6 +1,7 @@
 package io.github.couchtracker.db.profile
 
 import com.ibm.icu.util.ULocale
+import io.github.couchtracker.utils.LocaleData
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -35,7 +36,7 @@ class Bcp47LanguageTest : FunSpec(
             context("succeeds with all available locales and special ones") {
                 withData(
                     nameFn = { it.toString().ifEmpty { "<empty>" } },
-                    ULocale.getAvailableLocales().toList() + listOf(
+                    LocaleData().allLocales + listOf(
                         ULocale("und"),
                         ULocale("mul"),
                         ULocale("zxx"),

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/MetadataQueriesTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/MetadataQueriesTest.kt
@@ -43,5 +43,5 @@ class MetadataQueriesTest : KoinTest, FunSpec() {
         }
     }
 
-    override fun extensions() = listOf(KoinExtension(module = ProfileDbModule, mode = KoinLifecycleMode.Root))
+    override fun extensions() = listOf(KoinExtension(module = ProfileDbModule.value, mode = KoinLifecycleMode.Root))
 }

--- a/composeApp/src/test/kotlin/io/github/couchtracker/tmdb/UtilsTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/tmdb/UtilsTest.kt
@@ -2,6 +2,7 @@ package io.github.couchtracker.tmdb
 
 import app.moviebase.tmdb.model.TmdbMovieDetail
 import io.github.couchtracker.db.profile.Bcp47Language
+import io.github.couchtracker.utils.LocaleData
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.tuple
 import io.kotest.datatest.withData
@@ -23,7 +24,7 @@ class UtilsTest : FunSpec(
                     every { originalLanguage } returns lang
                     every { originCountry } returns countries
                 }
-                detail.language() shouldBe expected
+                detail.language(LocaleData().allLocales) shouldBe expected
             }
         }
     },

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/ULocaleTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/ULocaleTest.kt
@@ -22,7 +22,7 @@ class ULocaleTest : FunSpec(
             context("doesn't break any existing locale") {
                 withData(
                     nameFn = { it.toString() },
-                    ULocale.getAvailableLocales().filter { it.extensionKeys.isEmpty() }.toList(),
+                    LocaleData().allLocales.filter { it.extensionKeys.isEmpty() }.toList(),
                 ) { locale ->
                     locale.stripExtensions() shouldBe locale
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin-bom" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }
+koin-coroutines = { group = "io.insert-koin", name = "koin-core-coroutines" }
 koin-core = { group = "io.insert-koin", name = "koin-core" }
 koin-test = { group = "io.insert-koin", name = "koin-test" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }


### PR DESCRIPTION
There are three areas of improvements in this commit:

1. The color palette is computed using a smaller version of the backdrop. We no longer need to wait for the download of a high-res image before a movie/show is displayed
2. Basic data about a movie/show is cached in memory. This means we have immediately some data, since it's available directly from the API call made in the explore section
3. Several small optimizations move work from the UI thread to the background thread

Before, this had to happen in sequence:
1. Download the detail
2. Download the full resolution backdrop (using the URL in the details)
3. Compute color palette
4. First piece of content is displayed

Now:
1. Download a low resolution backdrop (using the URL in the basic details, which are available immediately)
2. Compute color palette
3. First piece of content is displayed
4. Full details are loaded in parallel, and don't block the initial display (similarly to images/credit)