### PR TITLE
Add Loadable compose components

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LoadableContainer.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/LoadableContainer.kt
@@ -1,0 +1,136 @@
+package io.github.couchtracker.ui.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.couchtracker.ui.AnimationDefaults
+import io.github.couchtracker.utils.Loadable
+
+private const val TEXT_LOADING_INDICATOR_DELAY_MS = 500
+private const val TEXT_LOADING_INDICATOR_ALPHA = 0.1f
+private val TEXT_LOADING_INDICATOR_PADDING = 2.dp
+
+@Composable
+fun <T> LoadableContainer(
+    data: Loadable<T>,
+    modifier: Modifier = Modifier,
+    crossFadeDurationMillis: Int = AnimationDefaults.ANIMATION_DURATION_MS,
+    loadingDelayMillis: Int = 0,
+    onLoading: @Composable () -> Unit,
+    content: @Composable (T) -> Unit,
+) {
+    // Animating the appearance of the Loading state
+    val state = remember {
+        MutableTransitionState(
+            initialState = when (data) {
+                is Loadable.Loading -> null
+                else -> data
+            },
+        )
+    }
+    state.targetState = data
+    val transition = rememberTransition(state)
+    transition.AnimatedContent(
+        modifier = modifier.fillMaxWidth(),
+        transitionSpec = {
+            val fadeInDelay = when (targetState) {
+                is Loadable.Loading -> loadingDelayMillis
+                else -> 0
+            }
+            fadeIn(tween(crossFadeDurationMillis + fadeInDelay, delayMillis = fadeInDelay)) togetherWith fadeOut(
+                tween(
+                    crossFadeDurationMillis,
+                ),
+            )
+        },
+    ) { text ->
+        when (text) {
+            null -> {}
+            is Loadable.Loaded -> content(text.value)
+            Loadable.Loading -> onLoading()
+        }
+    }
+}
+
+@Composable
+fun <T : Any> LoadableContainerWithOverlay(
+    data: Loadable<T>,
+    modifier: Modifier = Modifier,
+    crossFadeDurationMillis: Int = AnimationDefaults.ANIMATION_DURATION_MS,
+    placeholderDelayMillis: Int = 0,
+    loadingOverlay: @Composable BoxScope.() -> Unit,
+    content: @Composable (T?) -> Unit,
+) {
+    LoadableContainer(
+        data = data,
+        modifier = modifier,
+        content = content,
+        crossFadeDurationMillis = crossFadeDurationMillis,
+        loadingDelayMillis = placeholderDelayMillis,
+        onLoading = {
+            Box {
+                content(null)
+                loadingOverlay()
+            }
+        },
+    )
+}
+
+@Composable
+fun LoadableText(
+    text: Loadable<String>,
+    modifier: Modifier = Modifier,
+    placeholderLines: Int = 1,
+    maxLines: Int = Int.MAX_VALUE,
+    style: TextStyle = LocalTextStyle.current,
+    overflow: TextOverflow = TextOverflow.Clip,
+) {
+    LoadableContainerWithOverlay(
+        data = text,
+        modifier = modifier,
+        content = { text ->
+            Text(
+                text.orEmpty(),
+                minLines = if (text == null) placeholderLines else 1,
+                maxLines = maxLines,
+                style = style,
+                overflow = overflow,
+            )
+        },
+        placeholderDelayMillis = TEXT_LOADING_INDICATOR_DELAY_MS,
+        loadingOverlay = {
+            val color = LocalContentColor.current.copy(alpha = TEXT_LOADING_INDICATOR_ALPHA)
+            Canvas(modifier = Modifier.matchParentSize()) {
+                val padding = TEXT_LOADING_INDICATOR_PADDING.toPx()
+                val lineHeight = (this.size.height - padding) / placeholderLines - padding
+                val lineSize = Size(this.size.width, lineHeight)
+                repeat(placeholderLines) { line ->
+                    drawRect(
+                        color,
+                        Offset(padding, padding + line * (lineHeight + padding)),
+                        size = lineSize,
+                    )
+                }
+            }
+        },
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/TagsRow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/TagsRow.kt
@@ -1,18 +1,24 @@
 package io.github.couchtracker.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.github.couchtracker.utils.Loadable
+
+object TagsRowComposableDefaults {
+    val TAG_STYLE = @Composable {
+        MaterialTheme.typography.labelLarge
+    }
+}
 
 @Composable
-@OptIn(ExperimentalLayoutApi::class)
 fun TagsRow(
-    tags: List<String?>,
+    tags: List<String>,
     modifier: Modifier = Modifier,
 ) {
     FlowRow(
@@ -20,9 +26,27 @@ fun TagsRow(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         for (tag in tags) {
-            if (tag != null) {
-                Text(tag, style = MaterialTheme.typography.labelLarge)
-            }
+            Text(tag, style = TagsRowComposableDefaults.TAG_STYLE())
         }
     }
+}
+
+@Composable
+fun LoadableTagsRow(
+    tags: Loadable<List<String>>,
+    placeholderLines: Int,
+    modifier: Modifier = Modifier,
+) {
+    LoadableContainer(
+        tags,
+        modifier = modifier,
+        content = { TagsRow(tags = it) },
+        onLoading = {
+            Column {
+                repeat(placeholderLines) {
+                    LoadableText(Loadable.Loading, placeholderLines = 1, style = TagsRowComposableDefaults.TAG_STYLE())
+                }
+            }
+        },
+    )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Loadable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Loadable.kt
@@ -54,6 +54,16 @@ fun <T> Loadable<T>.valueOrNull(): T? = when (this) {
     Loadable.Loading -> null
 }
 
+/**
+ * Runs [f] when it's loaded.
+ */
+inline fun <T> Loadable<T>.onValue(f: (T) -> Unit): Loadable<T> {
+    if (this is Loadable.Loaded<T>) {
+        f(this.value)
+    }
+    return this
+}
+
 @Composable
 fun <T> Flow<T>.collectAsLoadableWithLifecycle(): State<Loadable<T>> {
     return remember { map { Loadable.Loaded(it) } }.collectAsStateWithLifecycle(Loadable.Loading)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package io.github.couchtracker.utils
 
 /**
@@ -28,10 +30,23 @@ inline fun <I, O, E> Result<I, E>.map(f: (I) -> O): Result<O, E> = flatMap {
 }
 
 /**
+ * [Result.Value.value], or the result of [f] when in error.
+ */
+inline fun <O, T : O, E> Result<T, E>.mapError(f: (E) -> O): O = when (this) {
+    is Result.Error -> f(error)
+    is Result.Value -> value
+}
+
+/**
  * Applies [f] to [Result.Value.value].
  * Otherwise, [Loadable.Loading] and [Result.Error] are returned without executing [f].
  */
 inline fun <I, O, E> Loadable<Result<I, E>>.mapResult(f: (I) -> O): Loadable<Result<O, E>> = map { it.map(f) }
+
+/**
+ * A new [Loadable] where errors are mapped to a value using [f].
+ */
+inline fun <O, T : O, E> Loadable<Result<T, E>>.mapError(f: (E) -> O): Loadable<O> = map { it.mapError(f) }
 
 /**
  * Returns [Result.Value.value], or `null` in other cases.


### PR DESCRIPTION
This commit adds components to display loadable content with a placeholder indicator.

In particular, this includes two generic containers, one implementation specific for Text, and one for TagsRow.

----

These components aren't used yet, but will look like:

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/2deb8595-7dd4-4bdf-b21d-1472c5b15c64" />
