### PR TITLE
Switch to Android compose

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     // in each subproject's classloader
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
-    alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.compose.compiler) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.detekt)
     alias(libs.plugins.sqldelight)
@@ -33,6 +32,8 @@ kotlin {
     }
 
     dependencies {
+        val composeBom = platform(libs.compose.bom)
+
         detektPlugins(libs.detekt.formatting)
 
         // Kotlin stuff
@@ -45,12 +46,10 @@ kotlin {
         implementation(libs.androidx.documentfile)
 
         // Compose
-        implementation(compose.foundation)
-        implementation(compose.material)
-        implementation(compose.material3)
-        implementation(compose.materialIconsExtended)
-        implementation(compose.runtime)
-        implementation(compose.ui)
+        implementation(composeBom)
+        implementation(libs.compose.material)
+        implementation(libs.compose.material3)
+        implementation(libs.compose.materialIconsExtended)
         implementation(libs.androidx.activity.compose)
         implementation(libs.androidx.lifecycle.runtime.compose)
         implementation(libs.compose.paging)
@@ -88,10 +87,12 @@ kotlin {
         implementation(libs.preference)
         implementation(libs.reorderable)
         implementation(libs.tmdb.api)
-    }
 
-    // Test dependencies
-    dependencies {
+        // Test dependencies
+
+        // Compose
+        testImplementation(composeBom)
+
         // Kotest
         testImplementation(libs.kotest.assertions.core)
         testImplementation(libs.kotest.extensions.koin)
@@ -115,6 +116,10 @@ android {
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 1
         versionName = "1.0"
+    }
+    buildFeatures {
+        buildConfig = true
+        compose = true
     }
     packaging {
         resources {

--- a/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/text/DbTextTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/db/profile/model/text/DbTextTest.kt
@@ -8,6 +8,7 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.enum
+import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.merge
 import io.kotest.property.arbitrary.string
@@ -48,7 +49,7 @@ class DbTextTest : FunSpec(
             )
         }
         test("round trip") {
-            forAll(Arb.defaultDbText()) {
+            forAll(10_000, Arb.defaultDbText()) {
                 it == DbText.fromUri(it.toCouchTrackerUri())
             }
         }
@@ -104,7 +105,7 @@ private suspend fun FunSpecContainerScope.uriTests(
 
 private fun Arb.Companion.defaultDbText(): Arb<DbText> {
     val default = enum<DbDefaultText>().map { DbText.Default(it) }
-    val unknown = string(minSize = 1).map { DbText.UnknownDefault(it) }
+    val unknown = string(minSize = 1).filterNot { it.isBlank() }.map { DbText.UnknownDefault(it) }
     val custom = string().map { DbText.Custom(it) }
 
     return default.merge(unknown).merge(custom)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ buildConfig = "5.6.7"
 byte-size = "2.0.0"
 coil = "3.3.0"
 compose-paging = "3.3.6"
-compose-plugin = "1.9.0-alpha03"
+compose-bom = "2025.08.00"
 detekt = "1.23.8"
 icu = "77.1"
 koin-bom = "4.1.0"
@@ -37,6 +37,11 @@ androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-ru
 byteSize = { module = "me.saket.bytesize:bytesize", version.ref = "byte-size" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+# TODO: switch to stable once expressive material components are released
+compose-bom = { module = "androidx.compose:compose-bom-alpha", version.ref = "compose-bom" }
+compose-material = { module = "androidx.compose.material:material" }
+compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-materialIconsExtended = { module = "androidx.compose.material:material-icons-extended" }
 compose-paging = { module = "androidx.paging:paging-compose", version.ref = "compose-paging" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 icu4j = { module = "com.ibm.icu:icu4j", version.ref = "icu" }
@@ -76,7 +81,6 @@ androidLibrary = { id = "com.android.library", version.ref = "agp" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }


### PR DESCRIPTION
My main goal was to switch from an alpha to a stable version, since compose Android 1.9 got released. 

However, expressive components aren't included in 1.9 stable, so I still had to switch to an alpha release, which this time points to compose 1.10.


PS: in a separate commit, I'm also including a fix for a test that failed once in a while