### PR TITLE
Animate background color change

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MediaScreenScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MediaScreenScaffold.kt
@@ -29,10 +29,11 @@ import kotlin.time.Duration
 @Composable
 fun MediaScreenScaffold(
     watchedItemSheetScaffoldState: WatchedItemSheetScaffoldState,
+    backgroundColor: () -> Color,
     colorScheme: ColorScheme,
     watchedItemType: WatchedItemType,
-    mediaRuntime: Duration?,
-    mediaLanguages: List<Bcp47Language>,
+    mediaRuntime: () -> Duration?,
+    mediaLanguages: () -> List<Bcp47Language>,
     title: String,
     backdrop: ImageRequest?,
     modifier: Modifier = Modifier,
@@ -47,12 +48,13 @@ fun MediaScreenScaffold(
             watchedItemType = watchedItemType,
             mediaRuntime = mediaRuntime,
             mediaLanguages = mediaLanguages,
+            containerColor = backgroundColor,
         ) {
             Scaffold(
                 modifier = modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
                 containerColor = Color.Transparent,
                 topBar = {
-                    OverviewScreenComponents.Header(title, backdrop, topAppBarScrollBehavior)
+                    OverviewScreenComponents.Header(title, backdrop, topAppBarScrollBehavior, backgroundColor)
                 },
                 floatingActionButton = floatingActionButton,
                 snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
@@ -90,12 +90,14 @@ object OverviewScreenComponents {
         title: String,
         backdrop: ImageRequest?,
         scrollBehavior: TopAppBarScrollBehavior,
+        backgroundColor: () -> Color,
         belowAppBar: @Composable ColumnScope.() -> Unit = {},
     ) {
         val navController = LocalNavController.current
         BackgroundTopAppBar(
             scrollBehavior = scrollBehavior,
             backdrop = backdrop,
+            backgroundColor = backgroundColor,
             appBar = { colors ->
                 Column {
                     LargeTopAppBar(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
@@ -51,6 +52,7 @@ fun MainSection(
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val scrollState = rememberScrollState()
+    val bgColor = MaterialTheme.colorScheme.background
 
     Scaffold(
         modifier = Modifier
@@ -67,6 +69,7 @@ fun MainSection(
                         contentScale = ContentScale.Crop,
                     )
                 },
+                backgroundColor = { bgColor },
                 appBar = { colors ->
                     Column {
                         TopAppBar(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
@@ -3,6 +3,7 @@
 package io.github.couchtracker.ui.screens.movie
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -173,13 +174,15 @@ private fun MovieScreenContent(
         onRetry = { reloadMovie() },
     )
     val fullDetails = model.fullDetails.awaitAsLoadable()
+    val backgroundColor by animateColorAsState(model.colorScheme.background)
 
     MediaScreenScaffold(
         watchedItemSheetScaffoldState = scaffoldState,
         colorScheme = model.colorScheme,
         watchedItemType = WatchedItemType.MOVIE,
-        mediaRuntime = fullDetails.resultValueOrNull()?.runtime,
-        mediaLanguages = listOfNotNull(fullDetails.resultValueOrNull()?.originalLanguage),
+        mediaRuntime = { fullDetails.resultValueOrNull()?.runtime },
+        mediaLanguages = { listOfNotNull(fullDetails.resultValueOrNull()?.originalLanguage) },
+        backgroundColor = { backgroundColor },
         title = model.title,
         backdrop = model.backdrop,
         modifier = Modifier.nestedScroll(toolbarScrollBehavior),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
@@ -3,6 +3,7 @@
 package io.github.couchtracker.ui.screens.show
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
@@ -144,6 +145,7 @@ private fun Content(show: TmdbShow) {
                     coroutineScope.launch { load() }
                 },
             )
+            val backgroundColor by animateColorAsState(model.colorScheme.background)
             MaterialTheme(colorScheme = model.colorScheme) {
                 Scaffold(
                     modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -151,6 +153,7 @@ private fun Content(show: TmdbShow) {
                     topBar = {
                         OverviewScreenComponents.Header(
                             title = model.name,
+                            backgroundColor = { backgroundColor },
                             backdrop = model.backdrop,
                             scrollBehavior = scrollBehavior,
                             belowAppBar = {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/DateTimeSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/DateTimeSection.kt
@@ -196,7 +196,7 @@ fun WatchedItemSheetScope.DateTimeSection(
     enabled: Boolean,
     sectionState: DateTimeSectionState,
     watchedItemType: WatchedItemType,
-    mediaRuntime: Duration?,
+    mediaRuntime: () -> Duration?,
 ) {
     Section(title = Text.Resource(R.string.date_and_time), validity = WatchedItemDimensionSelectionValidity.Valid) {
         val transition = updateTransition(sectionState.dateTime)
@@ -227,7 +227,7 @@ fun WatchedItemSheetScope.DateTimeSection(
                                     DateAndTimeSectionChoices.Custom -> sectionState.customDateDialogVisibility = DATE
                                     is DateAndTimeSectionChoices.Preset -> sectionState.dateTime = DateAndTimeValue(
                                         category = category,
-                                        dateTime = category.default(runtime = mediaRuntime ?: watchedItemType.fallbackRuntime),
+                                        dateTime = category.default(runtime = mediaRuntime() ?: watchedItemType.fallbackRuntime),
                                     )
                                 }
                             },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemSheetScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemSheetScaffold.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
@@ -57,6 +58,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onPlaced
@@ -84,6 +86,7 @@ import kotlin.time.Duration
 
 object WatchedItemSheetScope
 
+@Stable
 class WatchedItemSheetScaffoldState(
     val coroutineScope: CoroutineScope,
     val scaffoldState: BottomSheetScaffoldState,
@@ -132,8 +135,9 @@ fun rememberWatchedItemSheetScaffoldState(): WatchedItemSheetScaffoldState {
 fun WatchedItemSheetScaffold(
     scaffoldState: WatchedItemSheetScaffoldState,
     watchedItemType: WatchedItemType,
-    mediaRuntime: Duration?,
-    mediaLanguages: List<Bcp47Language>,
+    mediaRuntime: () -> Duration?,
+    mediaLanguages: () -> List<Bcp47Language>,
+    containerColor: () -> Color,
     content: @Composable () -> Unit,
 ) {
     val bottomSheetState = scaffoldState.scaffoldState.bottomSheetState
@@ -152,7 +156,7 @@ fun WatchedItemSheetScaffold(
     }
 
     BottomSheetScaffold(
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = containerColor(),
         scaffoldState = scaffoldState.scaffoldState,
         modifier = Modifier.fillMaxSize(),
         sheetPeekHeight = sheetPeekHeight,
@@ -202,8 +206,8 @@ private fun WatchedItemSheetContent(
     selections: WatchedItemSelections,
     bottomSheetState: SheetState,
     watchedItemType: WatchedItemType,
-    mediaRuntime: Duration?,
-    mediaLanguages: List<Bcp47Language>,
+    mediaRuntime: () -> Duration?,
+    mediaLanguages: () -> List<Bcp47Language>,
     onDismissRequest: () -> Unit,
     onHeaderHeightChange: (Int) -> Unit,
     onScrollLabelHeightChange: (Int) -> Unit,
@@ -239,7 +243,7 @@ private fun WatchedItemSheetContent(
 
             is WatchedItemDimensionSelection.Language -> LanguageSection(
                 enabled = enabled,
-                mediaLanguages = mediaLanguages,
+                mediaLanguages = mediaLanguages(),
                 selection = selection,
                 onSelectionChange = selections::update,
             )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreen.kt
@@ -1,6 +1,7 @@
 package io.github.couchtracker.ui.screens.watchedItem
 
 import android.content.Context
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -135,13 +136,15 @@ private fun WatchedItemList(model: WatchedItemsScreenModel) {
     val scaffoldState = rememberWatchedItemSheetScaffoldState()
     var watchedItemForInfoDialog: WatchedItemWrapper? by remember { mutableStateOf(null) }
     var watchedItemForDeleteDialog: WatchedItemWrapper? by remember { mutableStateOf(null) }
+    val backgroundColor by animateColorAsState(model.colorScheme.background)
 
     MediaScreenScaffold(
         watchedItemSheetScaffoldState = scaffoldState,
         colorScheme = model.colorScheme,
         watchedItemType = model.itemType,
-        mediaRuntime = model.runtime,
-        mediaLanguages = listOf(model.originalLanguage),
+        mediaRuntime = { model.runtime },
+        mediaLanguages = { listOf(model.originalLanguage) },
+        backgroundColor = { backgroundColor },
         title = R.string.viewing_history_for_x.str(model.title),
         backdrop = model.backdrop,
         floatingActionButton = {


### PR DESCRIPTION
With this change, the background color animates when the colorScheme for the movie/show changes.

To avoid too many recompositions, the color (and other information) is passed as a lambda.

Additionally, the color is now read only during the draw phase, so when it changes no recomposition is required at all. This is almost exactly the last example from https://developer.android.com/develop/ui/compose/performance/bestpractices#defer-reads