### PR TITLE
Refactor ImageModel

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/Model.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/Model.kt
@@ -1,34 +1,42 @@
 package io.github.couchtracker.ui
 
-import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalContext
 import app.moviebase.tmdb.image.TmdbImage
 import app.moviebase.tmdb.image.TmdbImageType
 import app.moviebase.tmdb.image.TmdbImageUrlBuilder
 import app.moviebase.tmdb.model.TmdbFileImage
-import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
 
-sealed interface ImagePreloadOptions {
-    data object DoNotPreload : ImagePreloadOptions
-    data class Preload(val context: Context, val width: Int, val height: Int) : ImagePreloadOptions
+data class ImageModel(
+    val aspectRatio: Float?,
+    val url: ImageUrlProvider?,
+    val placeholderUrl: ImageUrlProvider? = null,
+) {
+    @Composable
+    @ReadOnlyComposable
+    fun getCoilModel(width: Int, height: Int): ImageRequest {
+        return ImageRequest.Builder(LocalContext.current)
+            .data(url?.getUrl(width, height))
+            .placeholderMemoryCacheKey(placeholderUrl?.getUrl(width, width))
+            .build()
+    }
 }
 
-sealed interface ImageModel {
-    val aspectRatio: Float?
-    fun getCoilModel(width: Int, height: Int): Any?
-
-    data class TmdbImage(override val aspectRatio: Float?, val tmdbImage: app.moviebase.tmdb.image.TmdbImage) : ImageModel {
-        override fun getCoilModel(width: Int, height: Int): Any {
+sealed interface ImageUrlProvider {
+    fun getUrl(width: Int, height: Int): String
+    data class TmdbImage(val tmdbImage: app.moviebase.tmdb.image.TmdbImage) : ImageUrlProvider {
+        override fun getUrl(width: Int, height: Int): String {
             return TmdbImageUrlBuilder.build(tmdbImage, width, height)
         }
     }
 
     data class TmdbFileImage(
-        override val aspectRatio: Float?,
         val tmdbImage: app.moviebase.tmdb.model.TmdbFileImage,
         val type: TmdbImageType,
-    ) : ImageModel {
-        override fun getCoilModel(width: Int, height: Int): Any {
+    ) : ImageUrlProvider {
+        override fun getUrl(width: Int, height: Int): String {
             return TmdbImageUrlBuilder.build(
                 imagePath = tmdbImage.filePath,
                 type = type,
@@ -38,46 +46,25 @@ sealed interface ImageModel {
         }
     }
 
-    data class Preloaded(override val aspectRatio: Float?, val coilModel: ImageRequest?) : ImageModel {
-        override fun getCoilModel(width: Int, height: Int): Any? {
-            return coilModel
+    data class Constant(val url: String) : ImageUrlProvider {
+        override fun getUrl(width: Int, height: Int): String {
+            return url
         }
     }
 }
 
-suspend fun prepareImage(
-    baseModel: ImageModel,
-    options: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): ImageModel {
-    return when (options) {
-        ImagePreloadOptions.DoNotPreload -> baseModel
-        is ImagePreloadOptions.Preload -> {
-            val request = ImageRequest.Builder(options.context)
-                .data(baseModel.getCoilModel(options.width, options.height))
-                .size(options.width, options.height)
-                .build()
-            val result = SingletonImageLoader.get(options.context).execute(request)
-            val aspectRatio = result.image?.let { it.width.toFloat() / it.height } ?: baseModel.aspectRatio
-            ImageModel.Preloaded(aspectRatio, request)
-        }
-    }
-}
-
-suspend fun TmdbImage.toImageModel(
-    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): ImageModel {
-    return prepareImage(
-        baseModel = ImageModel.TmdbImage(null, this),
-        options = imagePreloadOptions,
+fun TmdbImage.toImageModel(): ImageModel {
+    return ImageModel(
+        url = ImageUrlProvider.TmdbImage(this),
+        aspectRatio = null,
+        placeholderUrl = null,
     )
 }
 
-suspend fun TmdbFileImage.toImageModel(
-    type: TmdbImageType,
-    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): ImageModel {
-    return prepareImage(
-        baseModel = ImageModel.TmdbFileImage(aspectRation, this, type),
-        options = imagePreloadOptions,
+fun TmdbFileImage.toImageModel(type: TmdbImageType): ImageModel {
+    return ImageModel(
+        url = ImageUrlProvider.TmdbFileImage(this, type),
+        aspectRatio = aspectRation,
+        placeholderUrl = null,
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/BackgroundTopAppBar.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/BackgroundTopAppBar.kt
@@ -3,6 +3,7 @@
 package io.github.couchtracker.ui.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarColors
@@ -20,10 +21,11 @@ import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
+import io.github.couchtracker.ui.ImageModel
 import kotlin.math.pow
 import kotlin.math.roundToInt
 
@@ -37,11 +39,11 @@ private val BRUSH = createGradientBrush(Color.Black)
 @Composable
 fun BackgroundTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior,
-    image: @Composable (Modifier) -> Unit,
+    image: @Composable (Modifier, Constraints) -> Unit,
     appBar: @Composable (TopAppBarColors) -> Unit,
     backgroundColor: () -> Color,
 ) {
-    Box(
+    BoxWithConstraints(
         Modifier
             .graphicsLayer {
                 val scrollAmount = -scrollBehavior.state.contentOffset
@@ -61,6 +63,7 @@ fun BackgroundTopAppBar(
                     }
                     this.clip = true
                 },
+            this.constraints,
         )
         Box(
             Modifier.drawBehind {
@@ -80,13 +83,13 @@ fun BackgroundTopAppBar(
 @Composable
 fun BackgroundTopAppBar(
     scrollBehavior: TopAppBarScrollBehavior,
-    backdrop: ImageRequest?,
+    backdrop: ImageModel?,
     appBar: @Composable (TopAppBarColors) -> Unit,
     backgroundColor: () -> Color,
 ) {
     BackgroundTopAppBar(
         scrollBehavior = scrollBehavior,
-        image = { modifier ->
+        image = { modifier, constraints ->
             // The image fills the width of the AppBar, and it's vertically centered, with the constraint of not leaving gaps at the top
             AsyncImage(
                 modifier = modifier,
@@ -105,7 +108,7 @@ fun BackgroundTopAppBar(
                         fraction = scrollBehavior.state.collapsedFraction,
                     ).roundToInt()
                 },
-                model = backdrop,
+                model = backdrop?.getCoilModel(constraints.maxWidth, constraints.maxHeight),
                 contentDescription = null,
                 contentScale = ContentScale.FillWidth,
             )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CastPortrait.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CastPortrait.kt
@@ -17,7 +17,6 @@ import coil3.compose.AsyncImage
 import io.github.couchtracker.R
 import io.github.couchtracker.tmdb.TmdbPersonId
 import io.github.couchtracker.ui.ImageModel
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.toImageModel
@@ -87,16 +86,13 @@ data class CastPortraitModel(
 ) {
     companion object {
 
-        suspend fun fromTmdbCast(
-            cast: TmdbCast,
-            imagePreloadOptions: ImagePreloadOptions,
-        ): CastPortraitModel {
+        fun fromTmdbCast(cast: TmdbCast): CastPortraitModel {
             return CastPortraitModel(
                 id = TmdbPersonId(cast.id),
                 name = cast.name,
                 roles = listOf(cast.character),
                 posterModel = cast.profilePath?.let { path ->
-                    TmdbImage(path, TmdbImageType.PROFILE).toImageModel(imagePreloadOptions)
+                    TmdbImage(path, TmdbImageType.PROFILE).toImageModel()
                 },
             )
         }
@@ -104,7 +100,6 @@ data class CastPortraitModel(
         suspend fun fromTmdbAggregateCast(
             context: Context,
             cast: TmdbAggregateCast,
-            imagePreloadOptions: ImagePreloadOptions,
         ): CastPortraitModel {
             return withContext(Dispatchers.Default) {
                 CastPortraitModel(
@@ -112,7 +107,7 @@ data class CastPortraitModel(
                     name = cast.name,
                     roles = cast.roles.sortedByDescending { it.episodeCount }.map { it.character },
                     posterModel = cast.profilePath?.let { path ->
-                        TmdbImage(path, TmdbImageType.PROFILE).toImageModel(imagePreloadOptions)
+                        TmdbImage(path, TmdbImageType.PROFILE).toImageModel()
                     },
                     episodesCount = cast.totalEpisodeCount,
                     episodesCountString = context.resources.getQuantityString(
@@ -127,24 +122,19 @@ data class CastPortraitModel(
 }
 
 @JvmName("TmdbCast_toCastPortraitModel")
-suspend fun List<TmdbCast>.toCastPortraitModel(
-    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): List<CastPortraitModel> = coroutineScope {
+suspend fun List<TmdbCast>.toCastPortraitModel(): List<CastPortraitModel> = coroutineScope {
     map {
         async {
-            CastPortraitModel.fromTmdbCast(it, imagePreloadOptions)
+            CastPortraitModel.fromTmdbCast(it)
         }
     }.awaitAll()
 }
 
 @JvmName("TmdbAggregateCast_toCastPortraitModel")
-suspend fun List<TmdbAggregateCast>.toCastPortraitModel(
-    context: Context,
-    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): List<CastPortraitModel> = coroutineScope {
+suspend fun List<TmdbAggregateCast>.toCastPortraitModel(context: Context): List<CastPortraitModel> = coroutineScope {
     map {
         async {
-            CastPortraitModel.fromTmdbAggregateCast(context, it, imagePreloadOptions)
+            CastPortraitModel.fromTmdbAggregateCast(context, it)
         }
     }.awaitAll()
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CrewCompactListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CrewCompactListItem.kt
@@ -23,7 +23,6 @@ import io.github.couchtracker.intl.formatAndList
 import io.github.couchtracker.tmdb.TmdbPersonId
 import io.github.couchtracker.tmdb.title
 import io.github.couchtracker.ui.ImageModel
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.toImageModel
@@ -82,7 +81,6 @@ data class CrewCompactListItemModel(
         suspend fun <T : TmdbAnyPerson> fromTmdbCrew(
             context: Context,
             crew: List<T>,
-            imagePreloadOptions: ImagePreloadOptions,
             department: (T) -> TmdbDepartment?,
         ): CrewCompactListItemModel {
             return withContext(Dispatchers.Default) {
@@ -102,7 +100,7 @@ data class CrewCompactListItemModel(
                         null
                     },
                     posterModel = base.profilePath?.let { path ->
-                        TmdbImage(path, TmdbImageType.PROFILE).toImageModel(imagePreloadOptions)
+                        TmdbImage(path, TmdbImageType.PROFILE).toImageModel()
                     },
                 )
             }
@@ -111,16 +109,12 @@ data class CrewCompactListItemModel(
 }
 
 @JvmName("TmdbCrew_toCrewCompactListItemModel")
-suspend fun List<TmdbCrew>.toCrewCompactListItemModel(
-    context: Context,
-    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): List<CrewCompactListItemModel> = coroutineScope {
+suspend fun List<TmdbCrew>.toCrewCompactListItemModel(context: Context): List<CrewCompactListItemModel> = coroutineScope {
     groupBy { it.id }.map { (_, crew) ->
         async {
             CrewCompactListItemModel.fromTmdbCrew(
                 context = context,
                 crew = crew,
-                imagePreloadOptions = imagePreloadOptions,
                 department = { it.department },
             )
         }
@@ -128,16 +122,12 @@ suspend fun List<TmdbCrew>.toCrewCompactListItemModel(
 }
 
 @JvmName("TmdbAggregateCrew_toCrewCompactListItemModel")
-suspend fun List<TmdbAggregateCrew>.toCrewCompactListItemModel(
-    context: Context,
-    imagePreloadOptions: ImagePreloadOptions = ImagePreloadOptions.DoNotPreload,
-): List<CrewCompactListItemModel> = coroutineScope {
+suspend fun List<TmdbAggregateCrew>.toCrewCompactListItemModel(context: Context): List<CrewCompactListItemModel> = coroutineScope {
     groupBy { it.id }.map { (_, crew) ->
         async {
             CrewCompactListItemModel.fromTmdbCrew(
                 context = context,
                 crew = crew,
-                imagePreloadOptions = imagePreloadOptions,
                 department = { it.department },
             )
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MediaScreenScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MediaScreenScaffold.kt
@@ -15,9 +15,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import coil3.request.ImageRequest
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemType
+import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetScaffold
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetScaffoldState
 import kotlin.time.Duration
@@ -35,7 +35,7 @@ fun MediaScreenScaffold(
     mediaRuntime: () -> Duration?,
     mediaLanguages: () -> List<Bcp47Language>,
     title: String,
-    backdrop: ImageRequest?,
+    backdrop: ImageModel?,
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     floatingActionButton: @Composable () -> Unit = {},

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MoviePortrait.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MoviePortrait.kt
@@ -13,7 +13,6 @@ import io.github.couchtracker.R
 import io.github.couchtracker.tmdb.TmdbMovieId
 import io.github.couchtracker.tmdb.tmdbMovieId
 import io.github.couchtracker.ui.ImageModel
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.toImageModel
@@ -69,7 +68,6 @@ data class MoviePortraitModel(
             context: Context,
             id: TmdbMovieId,
             details: TmdbApiTmdbMovie,
-            imagePreloadOptions: ImagePreloadOptions,
         ): MoviePortraitModel {
             val year = details.releaseDate?.year
             return MoviePortraitModel(
@@ -83,20 +81,16 @@ data class MoviePortraitModel(
                         context.getString(R.string.item_tile_with_year, details.title, year)
                     }
                 },
-                posterModel = details.posterImage?.toImageModel(imagePreloadOptions),
+                posterModel = details.posterImage?.toImageModel(),
             )
         }
     }
 }
 
-suspend fun TmdbApiTmdbMovie.toMoviePortraitModels(
-    context: Context,
-    imagePreloadOptions: ImagePreloadOptions,
-): MoviePortraitModel {
+suspend fun TmdbApiTmdbMovie.toMoviePortraitModels(context: Context): MoviePortraitModel {
     return MoviePortraitModel.fromApiTmdbMovie(
         context = context,
         id = tmdbMovieId,
         details = this,
-        imagePreloadOptions = imagePreloadOptions,
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
@@ -56,7 +56,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
 import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
 import io.github.couchtracker.ui.ImageModel
@@ -88,7 +87,7 @@ object OverviewScreenComponents {
     @Composable
     fun Header(
         title: String,
-        backdrop: ImageRequest?,
+        backdrop: ImageModel?,
         scrollBehavior: TopAppBarScrollBehavior,
         backgroundColor: () -> Color,
         belowAppBar: @Composable ColumnScope.() -> Unit = {},
@@ -361,7 +360,7 @@ object OverviewScreenComponents {
         defaultAspectRatio: Float = PortraitComposableDefaults.POSTER_ASPECT_RATIO,
     ) {
         val imagesList = images.buildDefaults {
-            List(PLACEHOLDER_IMAGES_COUNT) { ImageModel.Preloaded(defaultAspectRatio, null) }
+            List(PLACEHOLDER_IMAGES_COUNT) { ImageModel(defaultAspectRatio, null) }
         }
         if (imagesList.isNotEmpty()) {
             section("images", R.string.section_images) {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ShowPortrait.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ShowPortrait.kt
@@ -12,7 +12,6 @@ import io.github.couchtracker.R
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.tmdbShowId
 import io.github.couchtracker.ui.ImageModel
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.toImageModel
@@ -67,21 +66,20 @@ data class ShowPortraitModel(
 ) {
     companion object {
 
-        suspend fun fromApiTmdbShow(
+        fun fromApiTmdbShow(
             id: TmdbShowId,
             details: TmdbApiTmdbShow,
-            imagePreloadOptions: ImagePreloadOptions,
         ): ShowPortraitModel {
             return ShowPortraitModel(
                 id = id,
                 name = details.name,
                 year = details.firstAirDate?.year,
-                posterModel = details.posterImage?.toImageModel(imagePreloadOptions),
+                posterModel = details.posterImage?.toImageModel(),
             )
         }
     }
 }
 
-suspend fun TmdbApiTmdbShow.toShowPortraitModels(imagePreloadOptions: ImagePreloadOptions): ShowPortraitModel {
-    return ShowPortraitModel.fromApiTmdbShow(tmdbShowId, this, imagePreloadOptions)
+fun TmdbApiTmdbShow.toShowPortraitModels(): ShowPortraitModel {
+    return ShowPortraitModel.fromApiTmdbShow(tmdbShowId, this)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainSection.kt
@@ -61,7 +61,7 @@ fun MainSection(
         topBar = {
             BackgroundTopAppBar(
                 scrollBehavior = scrollBehavior,
-                image = { modifier ->
+                image = { modifier, _ ->
                     AsyncImage(
                         modifier = modifier,
                         model = imageModel,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
@@ -24,7 +24,6 @@ import io.github.couchtracker.R
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.tmdb.tmdbPager
 import io.github.couchtracker.tmdb.toBaseMovie
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.components.MoviePortrait
 import io.github.couchtracker.ui.components.PaginatedGrid
 import io.github.couchtracker.ui.components.PortraitComposableDefaults
@@ -114,7 +113,7 @@ class MovieExploreTabState(context: Context, viewModelScope: CoroutineScope) {
                 },
                 mapper = { movie ->
                     val baseModel = movie.toBaseMovie(tmdbLanguage)
-                    baseModel to movie.toMoviePortraitModels(context, ImagePreloadOptions.DoNotPreload)
+                    baseModel to movie.toMoviePortraitModels(context)
                 },
             ).flow
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/SearchScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/SearchScreen.kt
@@ -79,7 +79,6 @@ import io.github.couchtracker.tmdb.toBaseMovie
 import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.ColorSchemes
 import io.github.couchtracker.ui.ImageModel
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.Screen
 import io.github.couchtracker.ui.components.MessageComposable
@@ -431,7 +430,7 @@ private suspend fun TmdbSearchableListItem.toModel(language: TmdbLanguage): Sear
         is TmdbCollection -> null
 
         is TmdbMovie -> SearchResultItem(
-            posterModel = posterImage?.toImageModel(ImagePreloadOptions.DoNotPreload),
+            posterModel = posterImage?.toImageModel(),
             title = title,
             type = SearchableMediaType.MOVIE,
             tags = listOfNotNull(
@@ -442,7 +441,7 @@ private suspend fun TmdbSearchableListItem.toModel(language: TmdbLanguage): Sear
         )
 
         is TmdbPerson -> SearchResultItem(
-            posterModel = profileImage?.toImageModel(ImagePreloadOptions.DoNotPreload),
+            posterModel = profileImage?.toImageModel(),
             title = name,
             type = SearchableMediaType.PERSON,
             tags = emptyList(),
@@ -450,7 +449,7 @@ private suspend fun TmdbSearchableListItem.toModel(language: TmdbLanguage): Sear
         )
 
         is TmdbShow -> SearchResultItem(
-            posterModel = posterImage?.toImageModel(ImagePreloadOptions.DoNotPreload),
+            posterModel = posterImage?.toImageModel(),
             title = name,
             type = SearchableMediaType.SHOW,
             tags = listOfNotNull(firstAirDate?.year?.toString()),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
@@ -25,7 +25,6 @@ import io.github.couchtracker.R
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.tmdb.tmdbPager
 import io.github.couchtracker.tmdb.toBaseShow
-import io.github.couchtracker.ui.ImagePreloadOptions
 import io.github.couchtracker.ui.components.PaginatedGrid
 import io.github.couchtracker.ui.components.PortraitComposableDefaults
 import io.github.couchtracker.ui.components.ShowPortrait
@@ -114,7 +113,7 @@ class ShowExploreTabState(viewModelScope: CoroutineScope) {
                     trending.getTrendingShows(timeWindow = TmdbTimeWindow.DAY, page = page, language = tmdbLanguage.apiParameter)
                 },
                 mapper = { show ->
-                    show.toBaseShow(tmdbLanguage) to show.toShowPortraitModels(ImagePreloadOptions.DoNotPreload)
+                    show.toBaseShow(tmdbLanguage) to show.toShowPortraitModels()
                 },
             ).flow
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -9,7 +9,6 @@ import app.moviebase.tmdb.model.TmdbCrew
 import app.moviebase.tmdb.model.TmdbGenre
 import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbMovieDetail
-import coil3.request.ImageRequest
 import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.tmdbCache.TmdbCache
@@ -54,7 +53,7 @@ data class MovieScreenModel(
     val fullDetails: DeferredApiResult<FullDetails>,
     val credits: DeferredApiResult<Credits>,
     val images: DeferredApiResult<List<ImageModel>>,
-    val backdrop: ImageRequest?,
+    val backdrop: ImageModel?,
     val colorScheme: ColorScheme,
 ) {
     val allDeferred: Set<DeferredApiResult<*>> = setOf(credits, images)
@@ -77,8 +76,6 @@ data class MovieScreenModel(
 suspend fun CoroutineScope.loadMovie(
     ctx: Context,
     movie: TmdbMovie,
-    width: Int,
-    height: Int,
     tmdbCache: TmdbCache = KoinPlatform.getKoin().get(),
     tmdbBaseMemoryCache: TmdbBaseMemoryCache = KoinPlatform.getKoin().get(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
@@ -132,12 +129,7 @@ suspend fun CoroutineScope.loadMovie(
         }.ifError { return Result.Error(it) }
     }
     val backdrop = async(coroutineContext) {
-        baseDetails.backdrop.prepareAndExtractColorScheme(
-            ctx = ctx,
-            width = width,
-            height = height,
-            fallbackColorScheme = ColorSchemes.Movie,
-        )
+        baseDetails.backdrop.prepareAndExtractColorScheme(ctx = ctx, fallbackColorScheme = ColorSchemes.Movie)
     }
     val ret = MovieScreenModel(
         movie = movie,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
@@ -96,32 +96,24 @@ private fun Content(show: TmdbShow) {
         initialPage = ShowScreenTab.entries.indexOf(ShowScreenTab.DETAILS),
         pageCount = { ShowScreenTab.entries.size },
     )
+    suspend fun load() {
+        screenModel = Loadable.Loading
+        screenModel = coroutineScope.async(Dispatchers.Default) {
+            logExecutionTime(LOG_TAG, "Loading show") {
+                Loadable.Loaded(
+                    coroutineScope.loadShow(ctx = ctx, show = show),
+                )
+            }
+        }.await()
+    }
+    LaunchedEffect(show) {
+        load()
+    }
 
     BoxWithConstraints(
         contentAlignment = Alignment.Center,
         modifier = Modifier.fillMaxSize(),
     ) {
-        val maxWidth = this.constraints.maxWidth
-        val maxHeight = this.constraints.maxHeight
-        suspend fun load() {
-            screenModel = Loadable.Loading
-            screenModel = coroutineScope.async(Dispatchers.Default) {
-                logExecutionTime(LOG_TAG, "Loading show") {
-                    Loadable.Loaded(
-                        coroutineScope.loadShow(
-                            ctx = ctx,
-                            show = show,
-                            width = maxWidth,
-                            height = maxHeight,
-                        ),
-                    )
-                }
-            }.await()
-        }
-        LaunchedEffect(show) {
-            load()
-        }
-
         LoadableScreen(
             data = screenModel,
             onError = { exception ->

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
@@ -9,7 +9,6 @@ import app.moviebase.tmdb.model.TmdbGenre
 import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbShowCreatedBy
 import app.moviebase.tmdb.model.TmdbShowDetail
-import coil3.request.ImageRequest
 import io.github.couchtracker.R
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.intl.formatAndList
@@ -50,7 +49,7 @@ data class ShowScreenModel(
     val fullDetails: DeferredApiResult<FullDetails>,
     val credits: DeferredApiResult<Credits>,
     val images: DeferredApiResult<List<ImageModel>>,
-    val backdrop: ImageRequest?,
+    val backdrop: ImageModel?,
     val colorScheme: ColorScheme,
 ) {
     val allDeferred: Set<DeferredApiResult<*>> = setOf(credits, images)
@@ -72,8 +71,6 @@ data class ShowScreenModel(
 suspend fun CoroutineScope.loadShow(
     ctx: Context,
     show: TmdbShow,
-    width: Int,
-    height: Int,
     tmdbCache: TmdbCache = KoinPlatform.getKoin().get(),
     tmdbBaseMemoryCache: TmdbBaseMemoryCache = KoinPlatform.getKoin().get(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
@@ -125,12 +122,7 @@ suspend fun CoroutineScope.loadShow(
         }.ifError { return Result.Error(it) }
     }
     val backdrop = async(coroutineContext) {
-        baseDetails.backdrop.prepareAndExtractColorScheme(
-            ctx = ctx,
-            width = width,
-            height = height,
-            fallbackColorScheme = ColorSchemes.Show,
-        )
+        baseDetails.backdrop.prepareAndExtractColorScheme(ctx = ctx, fallbackColorScheme = ColorSchemes.Show)
     }
     val ret = ShowScreenModel(
         id = show.id,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenModel.kt
@@ -2,7 +2,6 @@ package io.github.couchtracker.ui.screens.watchedItem
 
 import android.content.Context
 import androidx.compose.material3.ColorScheme
-import coil3.request.ImageRequest
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.WatchableExternalId
 import io.github.couchtracker.db.profile.asWatchable
@@ -12,6 +11,7 @@ import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.tmdb.prepareAndExtractColorScheme
 import io.github.couchtracker.tmdb.runtime
 import io.github.couchtracker.ui.ColorSchemes
+import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.utils.ApiResult
 import io.github.couchtracker.utils.map
 import kotlinx.coroutines.Dispatchers
@@ -26,7 +26,7 @@ data class WatchedItemsScreenModel(
     val title: String,
     val runtime: Duration?,
     val originalLanguage: Bcp47Language,
-    val backdrop: ImageRequest?,
+    val backdrop: ImageModel?,
     val colorScheme: ColorScheme,
 ) {
 
@@ -35,16 +35,12 @@ data class WatchedItemsScreenModel(
             context: Context,
             tmdbCache: TmdbCache,
             movie: TmdbMovie,
-            width: Int,
-            height: Int,
             coroutineContext: CoroutineContext = Dispatchers.Default,
         ): ApiResult<WatchedItemsScreenModel> = coroutineScope {
             movie.details(tmdbCache).map { details ->
                 val backdrop = async(coroutineContext) {
                     details.backdropImage.prepareAndExtractColorScheme(
                         ctx = context,
-                        width = width,
-                        height = height,
                         fallbackColorScheme = ColorSchemes.Movie,
                     )
                 }


### PR DESCRIPTION
This PR refactors ImageModel:
 - removes the ability to preload the image (which was never used)
 - adds the ability to pass a placeholder url

This will remove the need to pass around a width/height when creating various models, like the one for movie/shows.