### PR TITLE
Treat TMDB downloads as Flows

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BatcheableTmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/BatcheableTmdbDownload.kt
@@ -1,5 +1,6 @@
 package io.github.couchtracker.tmdb
 
+import android.util.Log
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.db.QueryResult
 import io.github.couchtracker.db.tmdbCache.TmdbCache
@@ -10,65 +11,24 @@ import io.github.couchtracker.utils.CompletableApiResult
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.flatMap
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.yield
+import org.koin.mp.KoinPlatform
 import kotlin.reflect.KProperty1
 import kotlin.time.Duration
 import kotlin.time.Instant
 
-class BatchableDownloader<T : Any, Req, Res>(
-    val logTag: String,
-    val loadFromCache: (cache: TmdbCache) -> Query<TmdbTimestampedEntry<T>>,
-    val putInCache: (cache: TmdbCache, TmdbTimestampedEntry<T>) -> Unit,
-    val prepareRequest: (Req) -> Req,
-    val extractFromResponse: (Res) -> ApiResult<T>,
-    val expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
-    val prefetch: Duration = expiration * TMDB_CACHE_PREFETCH_THRESHOLD,
-)
+private const val LOG_TAG = "BatchableTmdbDownload"
 
 typealias LocalizedQueryBuilder<ID, T> = (ID, TmdbLanguage, (T, Instant) -> TmdbTimestampedEntry<T>) -> Query<TmdbTimestampedEntry<T>>
 typealias QueryBuilder<ID, T> = (ID, (details: T, lastUpdate: Instant) -> TmdbTimestampedEntry<T>) -> Query<TmdbTimestampedEntry<T>>
 
-class BatchableDownloaderBuilder<ID, Req, Res>(
+class BatchDownloadableFlowBuilder<ID, Req, Res>(
     val id: ID,
     val logTag: String,
     val prepareRequest: (Req) -> Req,
-    val expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
-    val prefetch: Duration = expiration * TMDB_CACHE_PREFETCH_THRESHOLD,
 ) {
-
-    inner class Step2<T : Any>(
-        val extractFromResponse: (Res) -> ApiResult<T>,
-    ) {
-        fun localized(
-            language: TmdbLanguage,
-            loadFromCacheFn: (TmdbCache) -> LocalizedQueryBuilder<ID, T>,
-            putInCacheFn: (TmdbCache) -> (ID, TmdbLanguage, T, Instant) -> QueryResult<Long>,
-        ) = BatchableDownloader(
-            logTag = "$language-$logTag",
-            loadFromCache = { cache -> loadFromCacheFn(cache)(id, language, ::TmdbTimestampedEntry) },
-            putInCache = { cache, data -> putInCacheFn(cache)(id, language, data.value, data.lastUpdate) },
-            prepareRequest = prepareRequest,
-            extractFromResponse = extractFromResponse,
-            expiration = expiration,
-            prefetch = prefetch,
-        )
-
-        fun notLocalized(
-            loadFromCacheFn: (TmdbCache) -> QueryBuilder<ID, T>,
-            putInCacheFn: (TmdbCache) -> (ID, T, Instant) -> QueryResult<Long>,
-        ) = BatchableDownloader(
-            logTag = logTag,
-            loadFromCache = { cache -> loadFromCacheFn(cache)(id, ::TmdbTimestampedEntry) },
-            putInCache = { cache, data -> putInCacheFn(cache)(id, data.value, data.lastUpdate) },
-            prepareRequest = prepareRequest,
-            extractFromResponse = extractFromResponse,
-            expiration = expiration,
-            prefetch = prefetch,
-        )
-    }
 
     fun <T : Any> extractResultFromResponse(extractFromResponse: (Res) -> ApiResult<T>): Step2<T> {
         return Step2(extractFromResponse)
@@ -94,93 +54,116 @@ class BatchableDownloaderBuilder<ID, Req, Res>(
             }
         }
     }
+
+    inner class Step2<T : Any>(
+        val extractFromResponse: (Res) -> ApiResult<T>,
+    ) {
+        fun localized(
+            language: TmdbLanguage,
+            loadFromCacheFn: (TmdbCache) -> LocalizedQueryBuilder<ID, T>,
+            putInCacheFn: (TmdbCache) -> (ID, TmdbLanguage, T, Instant) -> QueryResult<Long>,
+        ) = Step3(
+            logTag = "$language-$logTag",
+            loadFromCache = { cache -> loadFromCacheFn(cache)(id, language, ::TmdbTimestampedEntry) },
+            putInCache = { cache, data -> putInCacheFn(cache)(id, language, data.value, data.lastUpdate) },
+        )
+
+        fun notLocalized(
+            loadFromCacheFn: (TmdbCache) -> QueryBuilder<ID, T>,
+            putInCacheFn: (TmdbCache) -> (ID, T, Instant) -> QueryResult<Long>,
+        ) = Step3(
+            logTag = logTag,
+            loadFromCache = { cache -> loadFromCacheFn(cache)(id, ::TmdbTimestampedEntry) },
+            putInCache = { cache, data -> putInCacheFn(cache)(id, data.value, data.lastUpdate) },
+        )
+
+        inner class Step3(
+            val logTag: String,
+            val loadFromCache: (cache: TmdbCache) -> Query<TmdbTimestampedEntry<T>>,
+            val putInCache: (cache: TmdbCache, TmdbTimestampedEntry<T>) -> Unit,
+        ) {
+            fun flow(
+                downloader: BatchDownloader<Req, Res>,
+                expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
+                cache: TmdbCache = KoinPlatform.getKoin().get(),
+            ): Flow<ApiResult<T>> {
+                return tmdbGetOrDownload(
+                    entryTag = logTag,
+                    get = { loadFromCache(cache) },
+                    put = { putInCache(cache, it) },
+                    downloader = { downloader.download(prepareRequest, extractFromResponse) },
+                    expiration = expiration,
+                )
+            }
+        }
+    }
 }
 
-class BatchableRequest<T : Any, Req, Res>(
-    val downloader: BatchableDownloader<T, Req, Res>,
-    val completable: CompletableApiResult<T> = CompletableDeferred(),
-)
+class BatchDownloader<Req, Res>(
+    val initialRequestInput: Req,
+    val downloader: suspend (Req) -> ApiResult<Res>,
+) {
+    private val requestsQueue = Channel<Request<*, Req, Res>>(Int.MAX_VALUE)
 
-private fun <T : Any, Req, Res> BatchableRequest<T, Req, Res>.complete(downloadResult: ApiResult<Res>) {
-    val result = downloadResult.flatMap {
-        downloader.extractFromResponse(it)
-    }
-    check(completable.complete(result))
-}
+    private class Request<T : Any, Req, Res>(
+        val prepareRequest: (Req) -> Req,
+        val extractFromResponse: (Res) -> ApiResult<T>,
+        val completable: CompletableApiResult<T> = CompletableDeferred(),
+    )
 
-/**
- * Fulfills the given requests, prioritising data from the cache (see [tmdbGetOrDownload]).
- * Requests that have to be downloaded will be downloaded together using [downloader].
- */
-suspend fun <Req, Res> tmdbGetOrDownloadBatched(
-    cache: TmdbCache,
-    requests: List<BatchableRequest<*, Req, Res>>,
-    initialRequestInput: Req,
-    downloader: suspend (Req) -> ApiResult<Res>,
-) = coroutineScope {
-    val requestsToDownload = requests.map { request ->
-        request.getOrRequestDownload(
-            scope = this,
-            cache = cache,
-        )
+    /**
+     * Collects all requests currently in the queue
+     */
+    private fun collectQueuedRequests(): List<Request<*, Req, Res>> {
+        return buildList {
+            while (true) {
+                val immediateRequest = requestsQueue.tryReceive()
+                if (immediateRequest.isSuccess) {
+                    add(immediateRequest.getOrThrow())
+                } else {
+                    break
+                }
+            }
+        }
     }
-    val toDownload = requestsToDownload.awaitAll().filterNotNull()
-    if (toDownload.isNotEmpty()) {
-        batchDownload(
-            requests = toDownload,
-            initialRequestInput = initialRequestInput,
-            downloader = downloader,
-        )
-    }
-}
 
-/**
- * Loads the item using [tmdbGetOrDownload].
- * The caller has to perform the download if the returned value completes with a non-null request.
- */
-private fun <T : Any, Req, Res> BatchableRequest<T, Req, Res>.getOrRequestDownload(
-    scope: CoroutineScope,
-    cache: TmdbCache,
-): CompletableDeferred<BatchableRequest<T, Req, Res>?> {
-    val toDownload = CompletableDeferred<BatchableRequest<T, Req, Res>?>()
-    scope.launch {
-        val result = tmdbGetOrDownload(
-            entryTag = downloader.logTag,
-            get = { downloader.loadFromCache(cache) },
-            put = { downloader.putInCache(cache, it) },
-            downloader = {
-                val downloadResult = CompletableApiResult<T>()
-                check(toDownload.complete(BatchableRequest(downloader, downloadResult)))
-                downloadResult.await()
-            },
-            backgroundDownloader = {
-                val downloadResult = CompletableApiResult<T>()
-                check(toDownload.complete(BatchableRequest(downloader, downloadResult)))
-            },
-            expiration = downloader.expiration,
-            prefetch = downloader.prefetch,
-        )
-        toDownload.complete(null)
+    /**
+     * Downloads all requests in batch.
+     * the input for [downloader] is computed by folding [initialRequestInput] with [BatchableDownloadable.prepareRequest].
+     */
+    private suspend fun batchDownload(requests: List<Request<*, Req, Res>>) {
+        require(requests.isNotEmpty())
+        val request: Req = requests.fold(initialRequestInput) { acc, request ->
+            request.prepareRequest(acc)
+        }
+        val download = downloader(request)
+        for (request in requests) {
+            request.complete(download)
+        }
+    }
+
+    private fun <T : Any, Req, Res> Request<T, Req, Res>.complete(downloadResult: ApiResult<Res>) {
+        val result = downloadResult.flatMap {
+            extractFromResponse(it)
+        }
         check(completable.complete(result))
     }
-    return toDownload
-}
 
-/**
- * Downloads all requests in batch.
- * the input for [downloader] is computed by folding [initialRequestInput] with [BatchableDownloader.prepareRequest].
- */
-private suspend fun <Req, Res> batchDownload(
-    requests: List<BatchableRequest<*, Req, Res>>,
-    initialRequestInput: Req,
-    downloader: suspend (Req) -> ApiResult<Res>,
-) {
-    require(requests.isNotEmpty())
-    val request: Req = requests.fold(initialRequestInput) { acc, request ->
-        request.downloader.prepareRequest(acc)
-    }
-    val download = downloader(request)
-    for (request in requests) {
-        request.complete(download)
+    /**
+     * Downloads the given request, possibly batching it with other enqueued requests
+     */
+    suspend fun <T : Any> download(prepareRequest: (Req) -> Req, extractFromResponse: (Res) -> ApiResult<T>): ApiResult<T> {
+        val completable = CompletableApiResult<T>()
+        requestsQueue.send(Request(prepareRequest, extractFromResponse, completable))
+        // Let's give some time for other requests to arrive
+        yield()
+
+        val requests = collectQueuedRequests()
+        if (requests.isNotEmpty()) {
+            Log.d(LOG_TAG, "Processing ${requests.size} requests in batch")
+            batchDownload(requests)
+        }
+
+        return completable.await()
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMovie.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbMovie.kt
@@ -1,18 +1,10 @@
 package io.github.couchtracker.tmdb
 
 import app.moviebase.tmdb.model.AppendResponse
-import app.moviebase.tmdb.model.TmdbCredits
-import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbMovieDetail
-import app.moviebase.tmdb.model.TmdbReleaseDates
-import app.moviebase.tmdb.model.TmdbVideo
-import io.github.couchtracker.db.tmdbCache.TmdbCache
-import io.github.couchtracker.utils.ApiResult
-import io.github.couchtracker.utils.CompletableApiResult
-import kotlin.time.Duration
 import app.moviebase.tmdb.model.TmdbMovie as ApiTmdbMovie
 
-private typealias MovieDetailsDownloader = BatchableDownloaderBuilder<TmdbMovieId, List<AppendResponse>, TmdbMovieDetail>
+private typealias MovieDetailsDownloader = BatchDownloadableFlowBuilder<TmdbMovieId, List<AppendResponse>, TmdbMovieDetail>
 
 /**
  * Class that represents a TMDB movie.
@@ -24,84 +16,62 @@ data class TmdbMovie(
     val languages: TmdbLanguages,
 ) {
 
-    private val detailsDownloader = detailsDownloader("details") { it }
+    private val detailsBatchDownloader = BatchDownloader<List<AppendResponse>, TmdbMovieDetail>(
+        initialRequestInput = emptyList(),
+        downloader = { appendToResponse ->
+            tmdbDownloadResult(logTag = "${id.toExternalId().serialize()}-batched-details") { tmdb ->
+                tmdb.movies.getDetails(id.value, languages.apiLanguage.apiParameter, appendToResponse.ifEmpty { null })
+            }
+        },
+    )
+    val details = detailsDownloader("details") { it }
         .extractFromResponse { it }
         .localized(
             language = languages.apiLanguage,
             loadFromCacheFn = { cache -> cache.movieDetailsCacheQueries::get },
             putInCacheFn = { cache -> cache.movieDetailsCacheQueries::put },
         )
-    private val creditsDownloader = detailsDownloader("credits") { it + AppendResponse.CREDITS }
+        .flow(detailsBatchDownloader)
+    val credits = detailsDownloader("credits") { it + AppendResponse.CREDITS }
         .extractNonNullFromResponse(TmdbMovieDetail::credits)
         .notLocalized(
             loadFromCacheFn = { cache -> cache.movieCreditsCacheQueries::get },
             putInCacheFn = { cache -> cache.movieCreditsCacheQueries::put },
         )
-    private val imagesDownloader = detailsDownloader("images") { it + AppendResponse.IMAGES }
+        .flow(detailsBatchDownloader)
+    val images = detailsDownloader("images") { it + AppendResponse.IMAGES }
         .extractNonNullFromResponse(TmdbMovieDetail::images)
         .notLocalized(
             loadFromCacheFn = { cache -> cache.movieImagesCacheQueries::get },
             putInCacheFn = { cache -> cache.movieImagesCacheQueries::put },
         )
-    private val videosDownloader = detailsDownloader("videos") { it + AppendResponse.VIDEOS }
+        .flow(detailsBatchDownloader)
+    val videos = detailsDownloader("videos") { it + AppendResponse.VIDEOS }
         .extractNonNullFromResponse("videos") { it.videos?.results }
         .notLocalized(
             loadFromCacheFn = { cache -> cache.movieVideosCacheQueries::get },
             putInCacheFn = { cache -> cache.movieVideosCacheQueries::put },
         )
-    private val releaseDatesDownloader = detailsDownloader(
+        .flow(detailsBatchDownloader)
+    val releaseDates = detailsDownloader(
         logTag = "release_dates",
-        expiration = TMDB_CACHE_EXPIRATION_FAST,
     ) { it + AppendResponse.RELEASES_DATES }
         .extractNonNullFromResponse("release_dates") { it.releaseDates?.results }
         .notLocalized(
             loadFromCacheFn = { cache -> cache.movieReleaseDatesCacheQueries::get },
             putInCacheFn = { cache -> cache.movieReleaseDatesCacheQueries::put },
         )
+        .flow(detailsBatchDownloader, expiration = TMDB_CACHE_EXPIRATION_FAST)
 
     private fun detailsDownloader(
         logTag: String,
-        expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
         prepareRequest: (List<AppendResponse>) -> List<AppendResponse>,
     ): MovieDetailsDownloader {
         return MovieDetailsDownloader(
             id = id,
             logTag = "${id.toExternalId().serialize()}-$logTag",
             prepareRequest = prepareRequest,
-            expiration = expiration,
         )
-    }
-
-    suspend fun details(
-        cache: TmdbCache,
-        details: CompletableApiResult<TmdbMovieDetail>? = null,
-        credits: CompletableApiResult<TmdbCredits>? = null,
-        images: CompletableApiResult<TmdbImages>? = null,
-        videos: CompletableApiResult<List<TmdbVideo>>? = null,
-        releaseDates: CompletableApiResult<List<TmdbReleaseDates>>? = null,
-    ) {
-        tmdbGetOrDownloadBatched(
-            cache = cache,
-            requests = listOfNotNull(
-                details?.let { BatchableRequest(detailsDownloader, details) },
-                credits?.let { BatchableRequest(creditsDownloader, credits) },
-                images?.let { BatchableRequest(imagesDownloader, images) },
-                videos?.let { BatchableRequest(videosDownloader, videos) },
-                releaseDates?.let { BatchableRequest(releaseDatesDownloader, releaseDates) },
-            ),
-            initialRequestInput = emptyList(),
-            downloader = { appendToResponse ->
-                tmdbDownloadResult(logTag = "${id.toExternalId().serialize()}-batched-details") { tmdb ->
-                    tmdb.movies.getDetails(id.value, languages.apiLanguage.apiParameter, appendToResponse.ifEmpty { null })
-                }
-            },
-        )
-    }
-
-    suspend fun details(cache: TmdbCache): ApiResult<TmdbMovieDetail> {
-        return CompletableApiResult<TmdbMovieDetail>().also {
-            details(cache, details = it)
-        }.await()
     }
 }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbShow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbShow.kt
@@ -1,16 +1,10 @@
 package io.github.couchtracker.tmdb
 
 import app.moviebase.tmdb.model.AppendResponse
-import app.moviebase.tmdb.model.TmdbAggregateCredits
-import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbShowDetail
-import io.github.couchtracker.db.tmdbCache.TmdbCache
-import io.github.couchtracker.utils.ApiResult
-import io.github.couchtracker.utils.CompletableApiResult
-import kotlin.time.Duration
 import app.moviebase.tmdb.model.TmdbShow as ApiTmdbShow
 
-private typealias ShowDetailsDownloader = BatchableDownloaderBuilder<TmdbShowId, List<AppendResponse>, TmdbShowDetail>
+private typealias ShowDetailsDownloader = BatchDownloadableFlowBuilder<TmdbShowId, List<AppendResponse>, TmdbShowDetail>
 
 /**
  * Class that represents a TMDB show.
@@ -22,65 +16,46 @@ data class TmdbShow(
     val languages: TmdbLanguages,
 ) {
 
-    private val detailsDownloader = detailsDownloader("details") { it }
+    private val detailsBatchDownloader = BatchDownloader<List<AppendResponse>, TmdbShowDetail>(
+        initialRequestInput = emptyList(),
+        downloader = { appendToResponse ->
+            tmdbDownloadResult(logTag = "${id.toExternalId().serialize()}-batched-details") { tmdb ->
+                tmdb.show.getDetails(id.value, languages.apiLanguage.apiParameter, appendToResponse.ifEmpty { null })
+            }
+        },
+    )
+    val details = detailsDownloader("details") { it }
         .extractFromResponse { it }
         .localized(
             language = languages.apiLanguage,
             loadFromCacheFn = { cache -> cache.showDetailsCacheQueries::get },
             putInCacheFn = { cache -> cache.showDetailsCacheQueries::put },
         )
-    private val aggregateCreditsDownloader = detailsDownloader("credits") { it + AppendResponse.AGGREGATE_CREDITS }
+        .flow(detailsBatchDownloader)
+    val aggregateCredits = detailsDownloader("credits") { it + AppendResponse.AGGREGATE_CREDITS }
         .extractNonNullFromResponse(TmdbShowDetail::aggregateCredits)
         .notLocalized(
             loadFromCacheFn = { cache -> cache.showAggregateCreditsCacheQueries::get },
             putInCacheFn = { cache -> cache.showAggregateCreditsCacheQueries::put },
         )
-    private val imagesDownloader = detailsDownloader("images") { it + AppendResponse.IMAGES }
+        .flow(detailsBatchDownloader)
+    val images = detailsDownloader("images") { it + AppendResponse.IMAGES }
         .extractNonNullFromResponse(TmdbShowDetail::images)
         .notLocalized(
             loadFromCacheFn = { cache -> cache.showImagesCacheQueries::get },
             putInCacheFn = { cache -> cache.showImagesCacheQueries::put },
         )
+        .flow(detailsBatchDownloader)
 
     private fun detailsDownloader(
         logTag: String,
-        expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
         prepareRequest: (List<AppendResponse>) -> List<AppendResponse>,
     ): ShowDetailsDownloader {
         return ShowDetailsDownloader(
             id = id,
             logTag = "${id.toExternalId().serialize()}-$logTag",
             prepareRequest = prepareRequest,
-            expiration = expiration,
         )
-    }
-
-    suspend fun details(
-        cache: TmdbCache,
-        details: CompletableApiResult<TmdbShowDetail>? = null,
-        aggregateCredits: CompletableApiResult<TmdbAggregateCredits>? = null,
-        images: CompletableApiResult<TmdbImages>? = null,
-    ) {
-        tmdbGetOrDownloadBatched(
-            cache = cache,
-            requests = listOfNotNull(
-                details?.let { BatchableRequest(detailsDownloader, details) },
-                aggregateCredits?.let { BatchableRequest(aggregateCreditsDownloader, aggregateCredits) },
-                images?.let { BatchableRequest(imagesDownloader, images) },
-            ),
-            initialRequestInput = emptyList(),
-            downloader = { appendToResponse ->
-                tmdbDownloadResult(logTag = "${id.toExternalId().serialize()}-batched-details") { tmdb ->
-                    tmdb.show.getDetails(id.value, languages.apiLanguage.apiParameter, appendToResponse.ifEmpty { null })
-                }
-            },
-        )
-    }
-
-    suspend fun details(cache: TmdbCache): ApiResult<TmdbShowDetail> {
-        return CompletableApiResult<TmdbShowDetail>().also {
-            details(cache, details = it)
-        }.await()
     }
 }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenModel.kt
@@ -4,15 +4,11 @@ import android.content.Context
 import android.util.Log
 import androidx.compose.material3.ColorScheme
 import app.moviebase.tmdb.image.TmdbImageType
-import app.moviebase.tmdb.model.TmdbCredits
 import app.moviebase.tmdb.model.TmdbCrew
 import app.moviebase.tmdb.model.TmdbGenre
-import app.moviebase.tmdb.model.TmdbImages
-import app.moviebase.tmdb.model.TmdbMovieDetail
 import coil3.request.ImageRequest
 import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.Bcp47Language
-import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.intl.formatAndList
 import io.github.couchtracker.tmdb.TmdbBaseMemoryCache
 import io.github.couchtracker.tmdb.TmdbMovie
@@ -32,7 +28,6 @@ import io.github.couchtracker.ui.components.toCastPortraitModel
 import io.github.couchtracker.ui.components.toCrewCompactListItemModel
 import io.github.couchtracker.ui.toImageModel
 import io.github.couchtracker.utils.ApiResult
-import io.github.couchtracker.utils.CompletableApiResult
 import io.github.couchtracker.utils.DeferredApiResult
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.ifError
@@ -40,7 +35,7 @@ import io.github.couchtracker.utils.map
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
 import org.koin.mp.KoinPlatform
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
@@ -79,27 +74,20 @@ suspend fun CoroutineScope.loadMovie(
     movie: TmdbMovie,
     width: Int,
     height: Int,
-    tmdbCache: TmdbCache = KoinPlatform.getKoin().get(),
     tmdbBaseMemoryCache: TmdbBaseMemoryCache = KoinPlatform.getKoin().get(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
 ): ApiResult<MovieScreenModel> {
     val baseDetailsMemory = tmdbBaseMemoryCache.getMovie(movie)
-    val details = CompletableApiResult<TmdbMovieDetail>()
-    val credits = CompletableApiResult<TmdbCredits>()
-    val images = CompletableApiResult<TmdbImages>()
-    launch(coroutineContext) {
-        movie.details(cache = tmdbCache, details = details, credits = credits, images = images)
-    }
 
     val imagesModel = async(coroutineContext) {
-        images.await().map { images ->
+        movie.images.first().map { images ->
             images
                 .linearize()
                 .map { it.toImageModel(TmdbImageType.BACKDROP) }
         }
     }
     val creditsModel = async(coroutineContext) {
-        credits.await().map { credits ->
+        movie.credits.first().map { credits ->
             val directors = credits.crew.directors()
             MovieScreenModel.Credits(
                 directors = directors,
@@ -113,8 +101,9 @@ suspend fun CoroutineScope.loadMovie(
             )
         }
     }
+    val fullDetails = async(coroutineContext) { movie.details.first() }
     val fullDetailsModel = async(coroutineContext) {
-        details.await().map { details ->
+        fullDetails.await().map { details ->
             MovieScreenModel.FullDetails(
                 tagline = details.tagline,
                 runtime = details.runtime(),
@@ -127,7 +116,7 @@ suspend fun CoroutineScope.loadMovie(
         baseDetailsMemory
     } else {
         Log.w("Cache miss", "Movie $movie not found in cache")
-        details.await().map { details ->
+        fullDetails.await().map { details ->
             details.toBaseMovie(movie.languages.apiLanguage)
         }.ifError { return Result.Error(it) }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenModel.kt
@@ -4,14 +4,10 @@ import android.content.Context
 import android.util.Log
 import androidx.compose.material3.ColorScheme
 import app.moviebase.tmdb.image.TmdbImageType
-import app.moviebase.tmdb.model.TmdbAggregateCredits
 import app.moviebase.tmdb.model.TmdbGenre
-import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbShowCreatedBy
-import app.moviebase.tmdb.model.TmdbShowDetail
 import coil3.request.ImageRequest
 import io.github.couchtracker.R
-import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.intl.formatAndList
 import io.github.couchtracker.tmdb.TmdbBaseMemoryCache
 import io.github.couchtracker.tmdb.TmdbRating
@@ -29,7 +25,6 @@ import io.github.couchtracker.ui.components.toCastPortraitModel
 import io.github.couchtracker.ui.components.toCrewCompactListItemModel
 import io.github.couchtracker.ui.toImageModel
 import io.github.couchtracker.utils.ApiResult
-import io.github.couchtracker.utils.CompletableApiResult
 import io.github.couchtracker.utils.DeferredApiResult
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.ifError
@@ -37,7 +32,7 @@ import io.github.couchtracker.utils.map
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
 import org.koin.mp.KoinPlatform
 import kotlin.coroutines.CoroutineContext
 
@@ -74,35 +69,29 @@ suspend fun CoroutineScope.loadShow(
     show: TmdbShow,
     width: Int,
     height: Int,
-    tmdbCache: TmdbCache = KoinPlatform.getKoin().get(),
     tmdbBaseMemoryCache: TmdbBaseMemoryCache = KoinPlatform.getKoin().get(),
     coroutineContext: CoroutineContext = Dispatchers.Default,
 ): ApiResult<ShowScreenModel> {
     val baseDetailsMemory = tmdbBaseMemoryCache.getShow(show)
-    val details = CompletableApiResult<TmdbShowDetail>()
-    val credits = CompletableApiResult<TmdbAggregateCredits>()
-    val images = CompletableApiResult<TmdbImages>()
-    launch(coroutineContext) {
-        show.details(cache = tmdbCache, details = details, aggregateCredits = credits, images = images)
-    }
 
     val imagesModel = async(coroutineContext) {
-        images.await().map { images ->
+        show.images.first().map { images ->
             images
                 .linearize()
                 .map { img -> img.toImageModel(TmdbImageType.BACKDROP) }
         }
     }
     val creditsModel = async(coroutineContext) {
-        credits.await().map { credits ->
+        show.aggregateCredits.first().map { credits ->
             ShowScreenModel.Credits(
                 cast = credits.cast.toCastPortraitModel(ctx),
                 crew = credits.crew.toCrewCompactListItemModel(ctx),
             )
         }
     }
+    val fullDetails = async(coroutineContext) { show.details.first() }
     val fullDetailsModel = async(coroutineContext) {
-        details.await().map { details ->
+        fullDetails.await().map { details ->
             val createdBy = details.createdBy.orEmpty()
             ShowScreenModel.FullDetails(
                 tagline = details.tagline,
@@ -120,7 +109,7 @@ suspend fun CoroutineScope.loadShow(
         baseDetailsMemory
     } else {
         Log.w("Cache miss", "Show $show not found in cache")
-        details.await().map { details ->
+        fullDetails.await().map { details ->
             details.toBaseShow(show.languages.apiLanguage)
         }.ifError { return Result.Error(it) }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreen.kt
@@ -41,7 +41,6 @@ import io.github.couchtracker.db.profile.model.watchedItem.sortDescending
 import io.github.couchtracker.db.profile.movie.TmdbExternalMovieId
 import io.github.couchtracker.db.profile.movie.UnknownExternalMovieId
 import io.github.couchtracker.db.profile.type
-import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.settings.LocalAppSettingsContext
 import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.ui.Screen
@@ -84,7 +83,6 @@ fun NavController.navigateToWatchedItems(id: WatchableExternalId) {
 private fun Content(movie: TmdbMovie) {
     val coroutineScope = rememberCoroutineScope()
     val context = koinInject<Context>()
-    val tmdbCache = koinInject<TmdbCache>()
     var screenModel by remember { mutableStateOf<ApiLoadable<WatchedItemsScreenModel>>(Loadable.Loading) }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
@@ -93,7 +91,6 @@ private fun Content(movie: TmdbMovie) {
             screenModel = Loadable.Loaded(
                 WatchedItemsScreenModel.loadTmdbMovie(
                     context = context,
-                    tmdbCache = tmdbCache,
                     movie = movie,
                     width = this.constraints.maxWidth,
                     height = this.constraints.maxHeight,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenModel.kt
@@ -7,7 +7,6 @@ import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.WatchableExternalId
 import io.github.couchtracker.db.profile.asWatchable
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemType
-import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.tmdb.TmdbMovie
 import io.github.couchtracker.tmdb.prepareAndExtractColorScheme
 import io.github.couchtracker.tmdb.runtime
@@ -17,6 +16,7 @@ import io.github.couchtracker.utils.map
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 
@@ -33,13 +33,13 @@ data class WatchedItemsScreenModel(
     companion object {
         suspend fun loadTmdbMovie(
             context: Context,
-            tmdbCache: TmdbCache,
             movie: TmdbMovie,
             width: Int,
             height: Int,
             coroutineContext: CoroutineContext = Dispatchers.Default,
         ): ApiResult<WatchedItemsScreenModel> = coroutineScope {
-            movie.details(tmdbCache).map { details ->
+            val details = movie.details.first()
+            details.map { details ->
                 val backdrop = async(coroutineContext) {
                     details.backdropImage.prepareAndExtractColorScheme(
                         ctx = context,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Api.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Api.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.Deferred
 import kotlinx.io.IOException
 import kotlinx.serialization.SerializationException
 
-typealias ApiLoadable<T> = Loadable<Result<T, ApiException>>
 typealias ApiResult<T> = Result<T, ApiException>
+typealias ApiLoadable<T> = Loadable<ApiResult<T>>
 typealias DeferredApiResult<T> = Deferred<ApiResult<T>>
 typealias CompletableApiResult<T> = CompletableDeferred<ApiResult<T>>
 


### PR DESCRIPTION
TMDB downloads will now return a FLow. This will allow to respond to changes in the local sqlite cache.

Currently, only the first emitted value is used, but this is a first step to have responsive models.

Since expire/prefetch have effectively the same behavior now (first emit the value in the cache, then try to download), I've removed the concept of prefetching