### PR TITLE
Bugfix: currentLoadedSetting Flow remains stuck to default Flow

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettingsFlow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettingsFlow.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 
@@ -38,5 +38,5 @@ inline fun <S : AbstractSettings, reified V : D, reified D> LoadedSettingsGetter
 inline fun <S : AbstractSettings, reified V : D, reified D> LoadedSettingsGetter<S>.getWithDefault(
     crossinline setting: S.() -> Setting<*, *, V, D>,
 ): Flow<LoadedSettingWithDefault<V, D>> {
-    return loadedSettingsFlow.settings.flatMapConcat { it.getWithDefault(setting) }
+    return loadedSettingsFlow.settings.flatMapLatest { it.getWithDefault(setting) }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/Setting.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/Setting.kt
@@ -4,7 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
@@ -51,7 +51,7 @@ abstract class Setting<DS, K, V : D, D> {
     @OptIn(ExperimentalCoroutinesApi::class)
     @UseLoadedSetting
     val currentLoadedSetting: Flow<LoadedSetting<V, D>> by lazy {
-        actual.flatMapConcat { value ->
+        actual.flatMapLatest { value ->
             if (value != null) {
                 flowOf(LoadedSetting.Value(setting = this, actual = value))
             } else {


### PR DESCRIPTION
When the default Flow never terminates (i.e. the Flow of system languages), `currentLoadedSetting` never had a chance to change its value to actual. Now, using `flatMapLatest`, collection of the default Flow is cancelled, so actual can be used instead when it changes.

How to reproduce bug: change Tmdb languages to the default, then to a fixed value. Close and re-open the settings, they will still be stuck to the default value (the write through cache masks the bug when you're inside the language settings screen, so you have to go back and re-open it).

PS: I think also `getWithDefault` had the same bug, although it's never called, so IDK for sure