### PR TITLE
Improve loading animations

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
@@ -2,9 +2,7 @@
 
 package io.github.couchtracker.ui.screens.movie
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.expandVertically
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
@@ -257,31 +255,20 @@ private fun OverviewScreenComponents.MoviePage(
     val images = model.images.awaitAsLoadable()
     val credits = model.credits.awaitAsLoadable()
     ContentList(innerPadding, modifier) {
-        section("subtitle") {
-            val directors = credits.mapResult { it.directorsString }.resultValueOrNull()
-            val tags = fullDetails.mapResult { details ->
-                listOfNotNull(
-                    model.year?.toString(),
-                    details.runtime?.toString(),
-                    model.rating?.formatted,
-                ) + details.genres.map { it.name }
-            }.resultValueOrNull().orEmpty()
-
-            val hasDirectors = directors != null
-            val hasTags = tags.isNotEmpty()
-            item("subtitle-content") {
-                if (hasDirectors || hasTags) {
-                    AnimatedVisibility(hasDirectors, enter = expandVertically()) {
-                        Paragraph(directors)
-                    }
-                    SpaceBetweenItems()
-                    AnimatedVisibility(hasTags, enter = expandVertically()) {
-                        TagsComposable(tags = tags)
-                    }
-                }
-            }
+        section(title = { textBlock("directors", credits.mapResult { it.directorsString }, placeholderLines = 2) }) {
+            tags(
+                tags = fullDetails.mapResult { details ->
+                    listOfNotNull(
+                        model.year?.toString(),
+                        details.runtime?.toString(),
+                        model.rating?.formatted,
+                    ) + details.genres.map { it.name }
+                },
+            )
         }
-        paragraphSection("overview", fullDetails.mapResult { it.tagline }.resultValueOrNull(), model.overview)
+        section(title = { tagline(fullDetails.mapResult { it.tagline }) }) {
+            overview(Loadable.value(model.overview))
+        }
         imagesSection(images, totalHeight = totalHeight)
         castSection(credits.mapResult { it.cast }, totalHeight = totalHeight)
         crewSection(credits.mapResult { it.crew }, totalHeight = totalHeight)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
@@ -2,9 +2,7 @@
 
 package io.github.couchtracker.ui.screens.show
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.expandVertically
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -51,7 +49,6 @@ import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.awaitAsLoadable
 import io.github.couchtracker.utils.logExecutionTime
 import io.github.couchtracker.utils.mapResult
-import io.github.couchtracker.utils.resultValueOrNull
 import io.github.couchtracker.utils.str
 import io.github.couchtracker.utils.valueOrNull
 import kotlinx.coroutines.Dispatchers
@@ -214,30 +211,19 @@ private fun OverviewScreenComponents.ShowDetailsContent(
     val credits = model.credits.awaitAsLoadable()
     ContentList(innerPadding) {
         topSpace()
-        section("subtitle") {
-            val creators = fullDetails.mapResult { it.createdByString }.resultValueOrNull()
-            val tags = fullDetails.mapResult { details ->
-                listOfNotNull(
-                    model.year?.toString(),
-                    model.rating?.formatted,
-                ) + details.genres.map { it.name }
-            }.resultValueOrNull().orEmpty()
-
-            val hasCreatedBy = creators != null
-            val hasTags = tags.isNotEmpty()
-            if (hasCreatedBy || hasTags) {
-                item(key = "subtitle-content") {
-                    AnimatedVisibility(hasCreatedBy, enter = expandVertically()) {
-                        Paragraph(creators)
-                    }
-                    SpaceBetweenItems()
-                    AnimatedVisibility(hasTags, enter = expandVertically()) {
-                        TagsComposable(tags)
-                    }
-                }
-            }
+        section(title = { textBlock("creators", fullDetails.mapResult { it.createdByString }, placeholderLines = 2) }) {
+            tags(
+                tags = fullDetails.mapResult { details ->
+                    listOfNotNull(
+                        model.year?.toString(),
+                        model.rating?.formatted,
+                    ) + details.genres.map { it.name }
+                },
+            )
         }
-        paragraphSection("overview", fullDetails.mapResult { it.tagline }.resultValueOrNull(), model.overview)
+        section(title = { tagline(fullDetails.mapResult { it.tagline }) }) {
+            overview(Loadable.value(model.overview))
+        }
         imagesSection(images, totalHeight = totalHeight)
         castSection(credits.mapResult { it.cast }, totalHeight = totalHeight)
         crewSection(credits.mapResult { it.crew }, totalHeight = totalHeight)


### PR DESCRIPTION
As things load faster, the current cross-fading animation becomes jankier, especially as it might happen while the screen opens. This commit makes use of LoadableText/LoadableTagsRow instead, which have better animations, since they better account for the final height


Additionally, this commit refactors the functions on OverviewScreenComponents. Now they take ApiLoadable as input, and have a more consistent behavior for handling loading and errors.

Note: this should be the last PR before the change that actually refactors the current models into ViewModels. 