### PR TITLE
Add basic SeasonScreen

### DIFF
--- a/buildSrc/src/main/kotlin/SqlDelightTmdbCacheDefinitionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/SqlDelightTmdbCacheDefinitionsGenerator.kt
@@ -5,6 +5,7 @@ import java.io.File
 /** Common columns */
 private val MOVIE_ID_COLUMN = SqlColumn.int("tmdbId", "io.github.couchtracker.tmdb.TmdbMovieId")
 private val SHOW_ID_COLUMN = SqlColumn.int("tmdbId", "io.github.couchtracker.tmdb.TmdbShowId")
+private val SEASON_ID_COLUMN = SqlColumn.text("tmdbId", "io.github.couchtracker.tmdb.TmdbSeasonId")
 private val LANGUAGE_COLUMN = SqlColumn.text("language", "io.github.couchtracker.tmdb.TmdbLanguage")
 
 /** Which caches to create */
@@ -51,7 +52,17 @@ private val CACHES = listOf(
         key = listOf(SHOW_ID_COLUMN),
         value = SqlColumn.text("credits", "app.moviebase.tmdb.model.TmdbAggregateCredits"),
     ),
-)
+    // Season
+    SqlTable(
+        name = "SeasonDetailsCache",
+        key = listOf(SEASON_ID_COLUMN, LANGUAGE_COLUMN),
+        value = SqlColumn.text("details", "app.moviebase.tmdb.model.TmdbSeasonDetail"),
+    ),
+).also { cachesDefinitions ->
+    check(cachesDefinitions.distinctBy { it.name }.size == cachesDefinitions.size){
+        "Duplicate cache names"
+    }
+}
 
 /** Which sql functions to generate */
 private val SQL_FUNCTIONS = listOf(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/App.kt
@@ -24,6 +24,7 @@ import io.github.couchtracker.ui.composable
 import io.github.couchtracker.ui.screens.main.MainScreen
 import io.github.couchtracker.ui.screens.main.SearchScreen
 import io.github.couchtracker.ui.screens.movie.MovieScreen
+import io.github.couchtracker.ui.screens.season.SeasonScreen
 import io.github.couchtracker.ui.screens.settings.settings
 import io.github.couchtracker.ui.screens.show.ShowScreen
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemsScreen
@@ -74,6 +75,7 @@ fun App() {
                                 composable<SearchScreen>()
                                 composable<MovieScreen>()
                                 composable<ShowScreen>()
+                                composable<SeasonScreen>()
                                 composable<WatchedItemsScreen>()
                                 settings()
                             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/episode/TmdbExternalEpisodeId.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/episode/TmdbExternalEpisodeId.kt
@@ -2,39 +2,18 @@ package io.github.couchtracker.db.profile.episode
 
 import io.github.couchtracker.db.profile.ExternalId
 import io.github.couchtracker.tmdb.TmdbEpisodeId
-import io.github.couchtracker.tmdb.TmdbSeasonId
-import io.github.couchtracker.tmdb.TmdbShowId
 
 @JvmInline
 value class TmdbExternalEpisodeId(val id: TmdbEpisodeId) : ExternalEpisodeId {
 
     override val provider get() = Companion.provider
-    override val value get() = "${id.showId.value}-${id.seasonId.number}x${id.number}"
+    override val value get() = id.toString()
 
     companion object : ExternalId.InheritorsCompanion<TmdbExternalEpisodeId> {
         override val provider = "tmdb"
 
         override fun ofValue(value: String): TmdbExternalEpisodeId {
-            val (show, rest) = value.split('-', limit = 2).also {
-                require(it.size == 2) { "Invalid serialized TMDB episode ID: $value" }
-            }
-            fun partError(what: String): Nothing {
-                throw IllegalArgumentException("Invalid $what in TMDB external episode ID: $value")
-            }
-
-            val showId = TmdbShowId(show.toIntOrNull() ?: partError("show ID"))
-            val (seasonNumber, episodeNumber) = rest.split('x', limit = 2).also {
-                require(it.size == 2) { "Invalid serialized TMDB episode ID: $value" }
-            }
-
-            val episodeIdentifier = TmdbEpisodeId(
-                seasonId = TmdbSeasonId(
-                    showId = showId,
-                    number = seasonNumber.toIntOrNull() ?: partError("season number"),
-                ),
-                number = episodeNumber.toIntOrNull() ?: partError("season number"),
-            )
-            return TmdbExternalEpisodeId(episodeIdentifier)
+            return TmdbExternalEpisodeId(TmdbEpisodeId.ofValue(value))
         }
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/season/ExternalSeasonId.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/season/ExternalSeasonId.kt
@@ -1,0 +1,18 @@
+package io.github.couchtracker.db.profile.season
+
+import io.github.couchtracker.db.profile.ExternalId
+
+/**
+ * Any external ID representing a season.
+ *
+ * TODO: create specification for "official" supported providers names and their value format, and link it here.
+ *
+ * @see ExternalId
+ */
+sealed interface ExternalSeasonId : ExternalId {
+
+    companion object : ExternalId.SealedInterfacesCompanion<ExternalSeasonId>(
+        inheritors = listOf(TmdbExternalSeasonId.Companion),
+        unknownProvider = ::UnknownExternalSeasonId,
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/season/TmdbExternalSeasonId.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/season/TmdbExternalSeasonId.kt
@@ -1,0 +1,19 @@
+package io.github.couchtracker.db.profile.season
+
+import io.github.couchtracker.db.profile.ExternalId
+import io.github.couchtracker.tmdb.TmdbSeasonId
+
+@JvmInline
+value class TmdbExternalSeasonId(val id: TmdbSeasonId) : ExternalSeasonId {
+
+    override val provider get() = Companion.provider
+    override val value get() = id.toString()
+
+    companion object : ExternalId.InheritorsCompanion<TmdbExternalSeasonId> {
+        override val provider = "tmdb"
+
+        override fun ofValue(value: String): TmdbExternalSeasonId {
+            return TmdbExternalSeasonId(TmdbSeasonId.ofValue(value))
+        }
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/season/UnknownExternalSeasonId.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/season/UnknownExternalSeasonId.kt
@@ -1,0 +1,6 @@
+package io.github.couchtracker.db.profile.season
+
+data class UnknownExternalSeasonId(
+    override val provider: String,
+    override val value: String,
+) : ExternalSeasonId

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/tmdbCache/TmdbCacheDbModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/tmdbCache/TmdbCacheDbModule.kt
@@ -7,6 +7,7 @@ import io.github.couchtracker.db.common.adapters.InstantColumnAdapter
 import io.github.couchtracker.db.common.adapters.jsonAdapter
 import io.github.couchtracker.tmdb.TmdbLanguage
 import io.github.couchtracker.tmdb.TmdbMovieId
+import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.utils.lazyEagerModule
 import org.koin.core.qualifier.named
@@ -61,6 +62,12 @@ val TmdbCacheDbModule = lazyEagerModule {
             ShowAggregateCreditsCacheAdapter = ShowAggregateCreditsCache.Adapter(
                 tmdbIdAdapter = TmdbShowId.COLUMN_ADAPTER,
                 creditsAdapter = jsonAdapter(),
+                lastUpdateAdapter = InstantColumnAdapter,
+            ),
+            SeasonDetailsCacheAdapter = SeasonDetailsCache.Adapter(
+                tmdbIdAdapter = TmdbSeasonId.COLUMN_ADAPTER,
+                languageAdapter = TmdbLanguage.COLUMN_ADAPTER,
+                detailsAdapter = jsonAdapter(),
                 lastUpdateAdapter = InstantColumnAdapter,
             ),
         )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbSeason.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbSeason.kt
@@ -1,0 +1,52 @@
+package io.github.couchtracker.tmdb
+
+import app.moviebase.tmdb.model.AppendResponse
+import app.moviebase.tmdb.model.TmdbSeasonDetail
+import io.github.couchtracker.utils.api.BatchDownloader
+
+private typealias SeasonDetailsDownloader =
+    BatchDownloadableFlowBuilder<TmdbSeasonId, List<AppendResponse>, TmdbSeasonDetail>
+
+/**
+ * Class that represents a TMDB season.
+ * It holds no data, but provides the means to get all information,
+ * either by downloading them or loading them from cache.
+ */
+data class TmdbSeason(
+    val id: TmdbSeasonId,
+    val languages: TmdbLanguages,
+) {
+
+    private val detailsBatchDownloader = BatchDownloader<List<AppendResponse>, TmdbSeasonDetail>(
+        initialRequestInput = emptyList(),
+        downloader = { appendToResponse ->
+            tmdbDownloadResult(logTag = "${id.toExternalId().serialize()}-batched-details") { tmdb ->
+                tmdb.showSeasons.getDetails(
+                    showId = id.showId.value,
+                    seasonNumber = id.number,
+                    language = languages.apiLanguage.apiParameter,
+                    appendResponses = appendToResponse.ifEmpty { null },
+                )
+            }
+        },
+    )
+    val details = detailsDownloader("details") { it }
+        .extractFromResponse { it }
+        .localized(
+            language = languages.apiLanguage,
+            loadFromCacheFn = { cache -> cache.seasonDetailsCacheQueries::get },
+            putInCacheFn = { cache -> cache.seasonDetailsCacheQueries::put },
+        )
+        .flow(detailsBatchDownloader)
+
+    private fun detailsDownloader(
+        logTag: String,
+        prepareRequest: (List<AppendResponse>) -> List<AppendResponse>,
+    ): SeasonDetailsDownloader {
+        return SeasonDetailsDownloader(
+            id = id,
+            logTag = "${id.toExternalId().serialize()}-$logTag",
+            prepareRequest = prepareRequest,
+        )
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/season/SeasonScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/season/SeasonScreenViewModel.kt
@@ -1,0 +1,41 @@
+package io.github.couchtracker.ui.screens.season
+
+import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.couchtracker.db.profile.season.ExternalSeasonId
+import io.github.couchtracker.tmdb.TmdbSeasonId
+import io.github.couchtracker.ui.screens.show.ShowScreenViewModelHelper
+import io.github.couchtracker.utils.api.ApiLoadable
+
+class SeasonScreenViewModel(
+    application: Application,
+    val externalSeasonId: ExternalSeasonId,
+    val seasonId: TmdbSeasonId,
+) : AndroidViewModel(
+    application = application,
+) {
+    private val baseViewModel = SeasonScreenViewModelHelper(
+        application = application,
+        scope = viewModelScope,
+        seasonId = seasonId,
+    )
+    private val showViewModel = ShowScreenViewModelHelper(
+        application = application,
+        scope = viewModelScope,
+        showId = seasonId.showId,
+    )
+
+    val details by baseViewModel.details()
+    val showBaseDetails by showViewModel.baseDetails()
+    val colorScheme by showViewModel.colorScheme()
+
+    val allLoadables: List<ApiLoadable<*>>
+        get() = baseViewModel.flowCollector.currentValues + showViewModel.flowCollector.currentValues
+
+    fun retryAll() {
+        baseViewModel.apiCallHelper.retryAll()
+        showViewModel.apiCallHelper.retryAll()
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/season/SeasonScreenViewModelHelper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/season/SeasonScreenViewModelHelper.kt
@@ -1,0 +1,52 @@
+package io.github.couchtracker.ui.screens.season
+
+import android.app.Application
+import androidx.compose.runtime.State
+import io.github.couchtracker.settings.AppSettings
+import io.github.couchtracker.tmdb.TmdbSeason
+import io.github.couchtracker.tmdb.TmdbSeasonId
+import io.github.couchtracker.utils.FlowToStateCollector
+import io.github.couchtracker.utils.api.ApiCallHelper
+import io.github.couchtracker.utils.api.ApiLoadable
+import io.github.couchtracker.utils.collectFlow
+import io.github.couchtracker.utils.mapResult
+import io.github.couchtracker.utils.settings.get
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.map
+import kotlinx.datetime.LocalDate
+
+/**
+ * A utility class to create your own model for a season screen.
+ */
+class SeasonScreenViewModelHelper(
+    val application: Application,
+    scope: CoroutineScope,
+    seasonId: TmdbSeasonId,
+    val apiCallHelper: ApiCallHelper<TmdbSeason> = ApiCallHelper(
+        scope = scope,
+        item = AppSettings.get { Tmdb.Languages }
+            .map { languages -> TmdbSeason(seasonId, languages.current) },
+    ),
+    val flowCollector: FlowToStateCollector<ApiLoadable<*>> = FlowToStateCollector(scope),
+) {
+
+    data class Details(
+        val name: String,
+        val overview: String?,
+        val airDate: LocalDate?,
+    )
+
+    fun details(): State<ApiLoadable<Details>> {
+        return flowCollector.collectFlow(
+            flow = apiCallHelper.callApi { it.details }.map { result ->
+                result.mapResult { tmdbSeasonDetails ->
+                    Details(
+                        name = tmdbSeasonDetails.name,
+                        overview = tmdbSeasonDetails.overview,
+                        airDate = tmdbSeasonDetails.airDate,
+                    )
+                }
+            },
+        )
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.show.ExternalShowId
 import io.github.couchtracker.db.profile.show.TmdbExternalShowId
@@ -44,6 +45,7 @@ import io.github.couchtracker.ui.components.OverviewScreenComponents
 import io.github.couchtracker.ui.components.ResultScreen
 import io.github.couchtracker.ui.components.SeasonListItem
 import io.github.couchtracker.ui.components.WipMessageComposable
+import io.github.couchtracker.ui.screens.season.navigateToSeason
 import io.github.couchtracker.utils.logCompositions
 import io.github.couchtracker.utils.mapResult
 import io.github.couchtracker.utils.resultErrorOrNull
@@ -227,6 +229,7 @@ private fun OverviewScreenComponents.SeasonsContent(
     modifier: Modifier = Modifier,
 ) {
     val seasons = viewModel.fullDetails.mapResult { it.seasons }
+    val navController = LocalNavController.current
     LoadableScreen(
         seasons,
         onError = { exception ->
@@ -243,8 +246,13 @@ private fun OverviewScreenComponents.SeasonsContent(
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
             items(seasons.size) { index ->
-                val season = seasons[index]
-                SeasonListItem(season, isFirstInList = index == 0, isLastInList = index == seasons.size - 1)
+                val (id, season) = seasons[index]
+                SeasonListItem(
+                    season,
+                    onClick = { navController.navigateToSeason(id) },
+                    isFirstInList = index == 0,
+                    isLastInList = index == seasons.size - 1,
+                )
             }
         }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenViewModel.kt
@@ -18,7 +18,7 @@ class ShowScreenViewModel(
     private val baseViewModel = ShowScreenViewModelHelper(
         application = application,
         scope = viewModelScope,
-        movieId = showId,
+        showId = showId,
     )
 
     val baseDetails by baseViewModel.baseDetails()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenViewModelHelper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenViewModelHelper.kt
@@ -9,11 +9,14 @@ import app.moviebase.tmdb.model.TmdbShowCreatedBy
 import app.moviebase.tmdb.model.TmdbShowDetail
 import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.Bcp47Language
+import io.github.couchtracker.db.profile.season.ExternalSeasonId
+import io.github.couchtracker.db.profile.season.TmdbExternalSeasonId
 import io.github.couchtracker.intl.formatAndList
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.tmdb.BaseTmdbShow
 import io.github.couchtracker.tmdb.TmdbBaseMemoryCache
 import io.github.couchtracker.tmdb.TmdbRating
+import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShow
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.extractColorScheme
@@ -54,11 +57,11 @@ import org.koin.mp.KoinPlatform
 class ShowScreenViewModelHelper(
     val application: Application,
     scope: CoroutineScope,
-    movieId: TmdbShowId,
+    val showId: TmdbShowId,
     val apiCallHelper: ApiCallHelper<TmdbShow> = ApiCallHelper(
         scope = scope,
         item = AppSettings.get { Tmdb.Languages }
-            .map { languages -> TmdbShow(movieId, languages.current) },
+            .map { languages -> TmdbShow(showId, languages.current) },
     ),
     val flowCollector: FlowToStateCollector<ApiLoadable<*>> = FlowToStateCollector(scope),
 ) {
@@ -78,7 +81,7 @@ class ShowScreenViewModelHelper(
         val originalLanguage: Bcp47Language?,
         val rating: TmdbRating?,
         val tagline: String,
-        val seasons: List<SeasonListItemModel>,
+        val seasons: List<Pair<ExternalSeasonId, SeasonListItemModel>>,
     )
 
     data class Credits(
@@ -161,7 +164,8 @@ class ShowScreenViewModelHelper(
                 application.getString(R.string.show_by_creator, formatAndList(createdBy.map { it.name }))
             },
             seasons = seasons.map { season ->
-                SeasonListItemModel.fromTmdbSeason(application, season)
+                val id = TmdbExternalSeasonId(TmdbSeasonId(showId, season.seasonNumber))
+                id to SeasonListItemModel.fromTmdbSeason(application, season)
             },
         )
         return base to full


### PR DESCRIPTION
This commit adds all the classes necessary to support a screen for the season: external ID, various serializers, the various classes to call TMDB's APIs, and the view models etc.

Additionally, a very basic implementation of SeasonScreen is provided, for the main purpose of making sure everything fits together.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/c701b972-a2c3-486f-aa57-91cff19613e4" />
