### PR TITLE
Improve cache generation

### DIFF
--- a/buildSrc/src/main/kotlin/io/github/couchtracker/SqlColumn.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/SqlColumn.kt
@@ -1,0 +1,20 @@
+package io.github.couchtracker
+
+internal data class SqlColumn(
+    val name: String,
+    val sqlType: String,
+    val kotlinType: String,
+    val nullable: Boolean = false,
+) {
+    fun columnDefinition() = buildString {
+        append("$name $sqlType AS $kotlinType")
+        if (!nullable) {
+            append(" NOT NULL")
+        }
+    }
+
+    companion object {
+        fun int(name: String, kotlinType: String, nullable: Boolean = false) = SqlColumn(name, "INTEGER", kotlinType, nullable)
+        fun text(name: String, kotlinType: String, nullable: Boolean = false) = SqlColumn(name, "TEXT", kotlinType, nullable)
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/couchtracker/SqlFunction.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/SqlFunction.kt
@@ -1,0 +1,16 @@
+package io.github.couchtracker
+
+import kotlin.text.appendLine
+
+internal data class SqlFunction(
+    val name: String,
+    val content: String,
+) : SqlItem {
+
+    constructor(name: String, content: StringBuilder.() -> Unit) : this(name, buildString { content() })
+
+    override fun toSql() = buildString {
+        appendLine("${name}:")
+        appendLine(content)
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/couchtracker/SqlItem.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/SqlItem.kt
@@ -1,0 +1,6 @@
+package io.github.couchtracker
+
+interface SqlItem {
+
+    fun toSql(): String
+}

--- a/buildSrc/src/main/kotlin/io/github/couchtracker/SqlTable.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/SqlTable.kt
@@ -1,0 +1,27 @@
+package io.github.couchtracker
+
+import kotlin.collections.forEach
+
+internal data class SqlTable(
+    val name: String,
+    val keys: List<SqlColumn>,
+    val columns: List<SqlColumn>,
+) : SqlItem {
+
+    init {
+        require(keys.isNotEmpty())
+        require(keys.all { !it.nullable })
+    }
+
+    override fun toSql() = buildString {
+        appendLine("CREATE TABLE $name (")
+        keys.forEach { column ->
+            appendLine("    ${column.columnDefinition()},")
+        }
+        columns.forEach { column ->
+            appendLine("    ${column.columnDefinition()},")
+        }
+        appendLine("    PRIMARY KEY(${keys.joinToString { it.name }})")
+        appendLine(");")
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/couchtracker/cache/SqlDelightTmdbCacheDefinitionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/cache/SqlDelightTmdbCacheDefinitionsGenerator.kt
@@ -1,0 +1,97 @@
+package io.github.couchtracker.cache
+
+import io.github.couchtracker.SqlColumn
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+
+/** Which caches to create */
+private val CACHES = listOf(
+    // Movie
+    SqlTmdbModelCache(
+        name = "MovieDetailsCache",
+        key = TmdbModelKey.MOVIE_ID,
+        hasLanguage = true,
+        value = SqlColumn.text("details", "app.moviebase.tmdb.model.TmdbMovieDetail"),
+    ),
+    SqlTmdbModelCache(
+        name = "MovieReleaseDatesCache",
+        key = TmdbModelKey.MOVIE_ID,
+        hasLanguage = false,
+        value = SqlColumn.text("releaseDates", "kotlin.collections.List<app.moviebase.tmdb.model.TmdbReleaseDates>"),
+    ),
+    SqlTmdbModelCache(
+        name = "MovieCreditsCache",
+        key = TmdbModelKey.MOVIE_ID,
+        hasLanguage = false,
+        value = SqlColumn.text("credits", "app.moviebase.tmdb.model.TmdbCredits"),
+    ),
+    SqlTmdbModelCache(
+        name = "MovieImagesCache",
+        key = TmdbModelKey.MOVIE_ID,
+        hasLanguage = false,
+        value = SqlColumn.text("images", "app.moviebase.tmdb.model.TmdbImages"),
+    ),
+    SqlTmdbModelCache(
+        name = "MovieVideosCache",
+        key = TmdbModelKey.MOVIE_ID,
+        hasLanguage = false,
+        value = SqlColumn.text("videos", "kotlin.collections.List<app.moviebase.tmdb.model.TmdbVideo>"),
+    ),
+    // Show
+    SqlTmdbModelCache(
+        name = "ShowDetailsCache",
+        key = TmdbModelKey.SHOW_ID,
+        hasLanguage = true,
+        value = SqlColumn.text("details", "app.moviebase.tmdb.model.TmdbShowDetail"),
+    ),
+    SqlTmdbModelCache(
+        name = "ShowImagesCache",
+        key = TmdbModelKey.SHOW_ID,
+        hasLanguage = false,
+        value = SqlColumn.text("images", "app.moviebase.tmdb.model.TmdbImages"),
+    ),
+    SqlTmdbModelCache(
+        name = "ShowAggregateCreditsCache",
+        key = TmdbModelKey.SHOW_ID,
+        hasLanguage = false,
+        value = SqlColumn.text("credits", "app.moviebase.tmdb.model.TmdbAggregateCredits"),
+    ),
+    // Season
+    SqlTmdbModelCache(
+        name = "SeasonDetailsCache",
+        key = TmdbModelKey.SEASON_ID,
+        hasLanguage = true,
+        value = SqlColumn.text("details", "app.moviebase.tmdb.model.TmdbSeasonDetail"),
+    ),
+).also { cachesDefinitions ->
+    check(cachesDefinitions.distinctBy { it.name }.size == cachesDefinitions.size){
+        "Duplicate cache names"
+    }
+}
+
+/**
+ * A Gradle Task to generate the SQLDelight definitions related to the Tmdb Cache.
+ */
+open class SqlDelightTmdbCacheDefinitionsGenerator : DefaultTask() {
+    /** Where to generate the .sq files */
+    private val sqldelightRoot =
+        project.layout.buildDirectory.dir("generated/sqldelight/tmdbCache/io/github/couchtracker/db/tmdbCache").get().asFile
+
+    init {
+        group = "io.github.couchtracker"
+        description = "Generates the SqlDelight definitions for local the Tmdb Cache"
+        outputs.dir(sqldelightRoot)
+    }
+
+    @TaskAction
+    fun run() {
+        sqldelightRoot.deleteRecursively()
+        sqldelightRoot.mkdirs()
+        for (cache in CACHES) {
+            val cacheFile = File(sqldelightRoot, "${cache.name}.sq")
+            cacheFile.writeText(cache.toSql())
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/couchtracker/cache/SqlTmdbModelCache.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/cache/SqlTmdbModelCache.kt
@@ -1,0 +1,51 @@
+package io.github.couchtracker.cache
+
+import io.github.couchtracker.SqlColumn
+import io.github.couchtracker.SqlFunction
+import io.github.couchtracker.SqlItem
+import io.github.couchtracker.SqlTable
+
+private val LANGUAGE_COLUMN = SqlColumn.text("language", "io.github.couchtracker.tmdb.TmdbLanguage")
+private val LAST_UPDATE_COLUMN = SqlColumn.text("lastUpdate", "kotlin.time.Instant")
+
+internal data class SqlTmdbModelCache(
+    val name: String,
+    val key: TmdbModelKey,
+    val hasLanguage: Boolean,
+    val value: SqlColumn,
+) : SqlItem {
+
+    private val table = SqlTable(
+        name = name,
+        keys = buildList {
+            add(key.column)
+            if (hasLanguage) {
+                add(LANGUAGE_COLUMN)
+            }
+        },
+        columns = listOf(value, LAST_UPDATE_COLUMN),
+    )
+
+    private fun getFunction() = SqlFunction("get") {
+        appendLine("SELECT ${value.name}, ${LAST_UPDATE_COLUMN.name}")
+        appendLine("FROM ${table.name}")
+        appendLine("WHERE " + table.keys.joinToString(" AND ") { "${it.name} = ?" } + ";")
+    }
+
+    private fun putFunction() = SqlFunction("put") {
+        appendLine("INSERT INTO ${table.name}")
+        appendLine("VALUES (${table.keys.joinToString { ":${it.name}" }}, :${value.name}, :${LAST_UPDATE_COLUMN.name})")
+        appendLine(
+            "ON CONFLICT DO UPDATE SET " +
+                "${value.name} = :${value.name}, " +
+                "${LAST_UPDATE_COLUMN.name} = :${LAST_UPDATE_COLUMN.name};",
+        )
+    }
+
+    override fun toSql() = buildString {
+        append(table.toSql())
+        appendLine()
+        appendLine(getFunction().toSql())
+        appendLine(putFunction().toSql())
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/couchtracker/cache/TmdbModelKey.kt
+++ b/buildSrc/src/main/kotlin/io/github/couchtracker/cache/TmdbModelKey.kt
@@ -1,0 +1,11 @@
+package io.github.couchtracker.cache
+
+import io.github.couchtracker.SqlColumn
+
+internal enum class TmdbModelKey(val column: SqlColumn) {
+
+    MOVIE_ID(SqlColumn.int("tmdbId", "io.github.couchtracker.tmdb.TmdbMovieId")),
+    SHOW_ID(SqlColumn.int("tmdbId", "io.github.couchtracker.tmdb.TmdbShowId")),
+    SEASON_ID(SqlColumn.text("tmdbId", "io.github.couchtracker.tmdb.TmdbSeasonId")),
+
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.FailOnSeverity
+import io.github.couchtracker.cache.SqlDelightTmdbCacheDefinitionsGenerator
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {


### PR DESCRIPTION
Splits the cache generation in multiple classes and puts them in the couchtracker package.

Now `SqlTable`, `SqlFunction` and `SqlColumn` are cache-agnostic.

The new `SqlTmdbModelCache` contains the responsibility to create the correct table and functions for each model cache table.


---

### Testing

```bash
diff -Bru sqldelight.old composeApp/build/generated/sqldelight/ | diffstat
 0 files changed
```

