### PR TITLE
Introduce WatchedItemDimensionSelections table

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/FullProfileData.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/FullProfileData.kt
@@ -1,6 +1,7 @@
 package io.github.couchtracker.db.profile
 
 import android.util.Log
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionSelectionsWrapper
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionWrapper
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemWrapper
 import kotlinx.coroutines.Dispatchers
@@ -23,9 +24,10 @@ data class FullProfileData(
             val (data, time) = measureTimedValue {
                 withContext(coroutineContext) {
                     val watchedItemDimensions = WatchedItemDimensionWrapper.load(db)
+                    val watchedItemDimensionSelections = WatchedItemDimensionSelectionsWrapper.load(db, watchedItemDimensions)
                     FullProfileData(
                         showCollection = db.showInCollectionQueries.selectShowCollection().executeAsList(),
-                        watchedItems = WatchedItemWrapper.load(db, watchedItemDimensions),
+                        watchedItems = WatchedItemWrapper.load(db, watchedItemDimensionSelections),
                         watchedItemDimensions = watchedItemDimensions,
                     )
                 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionSelection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionSelection.kt
@@ -2,8 +2,8 @@ package io.github.couchtracker.db.profile.model.watchedItem
 
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.ProfileData
-import io.github.couchtracker.db.profile.WatchedItem
 import io.github.couchtracker.db.profile.WatchedItemDimensionChoice
+import io.github.couchtracker.db.profile.WatchedItemDimensionSelections
 import kotlin.collections.minus
 import kotlin.collections.plus
 import kotlin.text.isBlank
@@ -30,11 +30,11 @@ sealed interface WatchedItemDimensionSelection<T> {
     fun isEmpty(): Boolean
 
     /**
-     * Saves this selection to the given [db] for the given [watchedItem], which must already exist.
+     * Saves this selection to the given [db] for the given [selections], which must already exist.
      *
      * Saving unchanged data is permitted, but might have small side effects (e.g. deleting and re-adding the same row)
      */
-    fun save(db: ProfileData, watchedItem: WatchedItem)
+    fun save(db: ProfileData, selections: WatchedItemDimensionSelections)
 
     data class Choice(
         override val dimension: WatchedItemDimensionWrapper.Choice,
@@ -52,15 +52,15 @@ sealed interface WatchedItemDimensionSelection<T> {
 
         override fun isEmpty() = value.isEmpty()
 
-        override fun save(db: ProfileData, watchedItem: WatchedItem) {
+        override fun save(db: ProfileData, selections: WatchedItemDimensionSelections) {
             db.watchedItemChoiceQueries.transaction {
                 db.watchedItemChoiceQueries.deleteForDimension(
-                    watchedItem = watchedItem.id,
+                    selections = selections.id,
                     dimension = dimension.id,
                 )
 
                 for (choice in value) {
-                    db.watchedItemChoiceQueries.insert(watchedItem = watchedItem.id, choice = choice.id)
+                    db.watchedItemChoiceQueries.insert(selections = selections.id, choice = choice.id)
                 }
             }
         }
@@ -88,16 +88,16 @@ sealed interface WatchedItemDimensionSelection<T> {
 
         override fun isEmpty() = value == null
 
-        override fun save(db: ProfileData, watchedItem: WatchedItem) {
+        override fun save(db: ProfileData, selections: WatchedItemDimensionSelections) {
             if (isEmpty()) {
                 db.watchedItemLanguageQueries.delete(
-                    watchedItem = watchedItem.id,
-                    watchedItemDimension = dimension.id,
+                    selections = selections.id,
+                    dimension = dimension.id,
                 )
             } else {
                 db.watchedItemLanguageQueries.upsert(
-                    watchedItem = watchedItem.id,
-                    watchedItemDimension = dimension.id,
+                    selections = selections.id,
+                    dimension = dimension.id,
                     language = checkNotNull(value),
                 )
             }
@@ -121,16 +121,16 @@ sealed interface WatchedItemDimensionSelection<T> {
 
         override fun isEmpty() = value.isBlank()
 
-        override fun save(db: ProfileData, watchedItem: WatchedItem) {
+        override fun save(db: ProfileData, selections: WatchedItemDimensionSelections) {
             if (isEmpty()) {
                 db.watchedItemFreeTextQueries.delete(
-                    watchedItem = watchedItem.id,
-                    watchedItemDimension = dimension.id,
+                    selections = selections.id,
+                    dimension = dimension.id,
                 )
             } else {
                 db.watchedItemFreeTextQueries.upsert(
-                    watchedItem = watchedItem.id,
-                    watchedItemDimension = dimension.id,
+                    selections = selections.id,
+                    dimension = dimension.id,
                     text = value,
                 )
             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionSelectionsWrapper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionSelectionsWrapper.kt
@@ -1,0 +1,49 @@
+package io.github.couchtracker.db.profile.model.watchedItem
+
+import io.github.couchtracker.db.profile.ProfileData
+import io.github.couchtracker.db.profile.WatchedItemChoice
+import io.github.couchtracker.db.profile.WatchedItemDimensionSelections
+import kotlin.collections.orEmpty
+
+data class WatchedItemDimensionSelectionsWrapper(
+    val watchedItemDimensionSelections: WatchedItemDimensionSelections,
+    val dimensions: List<WatchedItemDimensionSelection<*>>,
+) {
+
+    val id get() = watchedItemDimensionSelections.id
+
+    companion object {
+
+        fun load(
+            db: ProfileData,
+            dimensions: List<WatchedItemDimensionWrapper>,
+        ): List<WatchedItemDimensionSelectionsWrapper> {
+            val watchedItemDimensionSelectionsIds = db.watchedItemDimensionSelectionsQueries.selectAll().executeAsList()
+            val choices = db.watchedItemChoiceQueries.selectAllWithDimensionId().executeAsList()
+                .groupBy { it.selections to it.watchedItemDimension }
+                .mapValues { (_, list) ->
+                    list.map { WatchedItemChoice(selections = it.selections, choice = it.choice) }
+                }
+            val freeTexts = db.watchedItemFreeTextQueries.selectAll().executeAsList()
+                .associateBy { it.selections to it.dimension }
+            val languages = db.watchedItemLanguageQueries.selectAll().executeAsList()
+                .associateBy { it.selections to it.dimension }
+
+            return watchedItemDimensionSelectionsIds.map { id ->
+                val dimensions = dimensions.map { dimension ->
+                    val key = id to dimension.id
+                    when (dimension) {
+                        is WatchedItemDimensionWrapper.Choice -> dimension.selection(choices[key].orEmpty())
+                        is WatchedItemDimensionWrapper.Language -> dimension.selection(languages[key])
+                        is WatchedItemDimensionWrapper.FreeText -> dimension.selection(freeTexts[key])
+                    }
+                }.sortedBy { it.dimension.manualSortIndex }
+
+                WatchedItemDimensionSelectionsWrapper(
+                    watchedItemDimensionSelections = WatchedItemDimensionSelections(id),
+                    dimensions = dimensions,
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionWrapper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/watchedItem/WatchedItemDimensionWrapper.kt
@@ -74,7 +74,7 @@ sealed interface WatchedItemDimensionWrapper : Comparable<WatchedItemDimensionWr
             if (language == null) {
                 return emptySelection()
             }
-            require(language.watchedItemDimension == dimension.id) { "Language of another dimension" }
+            require(language.dimension == dimension.id) { "Language of another dimension" }
             return WatchedItemDimensionSelection.Language(
                 dimension = this,
                 value = language.language,
@@ -96,7 +96,7 @@ sealed interface WatchedItemDimensionWrapper : Comparable<WatchedItemDimensionWr
             if (text == null) {
                 return emptySelection()
             }
-            require(text.watchedItemDimension == dimension.id) { "Free text of another dimension" }
+            require(text.dimension == dimension.id) { "Free text of another dimension" }
             return WatchedItemDimensionSelection.FreeText(
                 dimension = this,
                 value = text.text,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemSheetScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemSheetScaffold.kt
@@ -70,9 +70,9 @@ import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionSelection
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemDimensionSelectionValidity
-import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemSelections
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemSelectionsState
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemType
-import io.github.couchtracker.db.profile.model.watchedItem.rememberWatchedItemSelections
+import io.github.couchtracker.db.profile.model.watchedItem.rememberWatchedItemSelectionsState
 import io.github.couchtracker.ui.components.BoxWithScrim
 import io.github.couchtracker.ui.components.DelayedActionLoadingIndicator
 import io.github.couchtracker.ui.components.ProfileDbErrorDialog
@@ -173,7 +173,7 @@ fun WatchedItemSheetScaffold(
             scaffoldState.mode?.let { mode ->
                 key(scaffoldState.openCounter) {
                     WatchedItemSheetContent(
-                        selections = rememberWatchedItemSelections(watchedItemType, mode = mode),
+                        selections = rememberWatchedItemSelectionsState(watchedItemType, mode = mode),
                         bottomSheetState = bottomSheetState,
                         watchedItemType = watchedItemType,
                         mediaRuntime = mediaRuntime,
@@ -203,7 +203,7 @@ fun WatchedItemSheetScaffold(
 @Composable
 @Suppress("LongMethod")
 private fun WatchedItemSheetContent(
-    selections: WatchedItemSelections,
+    selections: WatchedItemSelectionsState,
     bottomSheetState: SheetState,
     watchedItemType: WatchedItemType,
     mediaRuntime: () -> Duration?,
@@ -390,7 +390,7 @@ private fun BelowScrollLabelContainer(
 @Composable
 private fun ButtonRow(
     enabled: Boolean,
-    selections: WatchedItemSelections,
+    selections: WatchedItemSelectionsState,
     saveAction: ProfileDbActionState<Unit>,
     onDelete: () -> Unit,
     innerBottomPadding: Dp,

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItem.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItem.sq
@@ -21,15 +21,19 @@ CREATE TABLE WatchedItem (
    * This is different than what some other apps do. For instance, Trakt has a `watchedAt` field, which is the date/time
    * when a user has *finished* watching something.
    */
-  watchAt TEXT AS PartialDateTime
+  watchAt TEXT AS PartialDateTime,
+
+  dimensionSelections INTEGER NOT NULL,
+
+  FOREIGN KEY(dimensionSelections) REFERENCES WatchedItemDimensionSelections(id) ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 selectAll:
 SELECT * FROM WatchedItem;
 
 insert:
-INSERT INTO WatchedItem(watchAt)
-VALUES (:watchAt)
+INSERT INTO WatchedItem(watchAt, dimensionSelections)
+VALUES (:watchAt, :dimensionSelections)
 RETURNING *;
 
 updateWatchAt:

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemChoice.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemChoice.sq
@@ -2,10 +2,10 @@
  * Many-to-many relationship between `WatchedItem`s and `WatchedItemDimensionChoice`s.
  */
 CREATE TABLE WatchedItemChoice(
-  watchedItem INTEGER NOT NULL,
+  selections INTEGER NOT NULL,
   choice INTEGER NOT NULL,
-  PRIMARY KEY(watchedItem, choice),
-  FOREIGN KEY(watchedItem) REFERENCES WatchedItem(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  PRIMARY KEY(selections, choice),
+  FOREIGN KEY(selections) REFERENCES WatchedItemDimensionSelections(id) ON UPDATE CASCADE ON DELETE CASCADE,
   FOREIGN KEY(choice) REFERENCES WatchedItemDimensionChoice(id) ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
@@ -15,16 +15,16 @@ FROM WatchedItemChoice c
 INNER JOIN WatchedItemDimensionChoice dc ON dc.id = c.choice;
 
 delete:
-DELETE FROM WatchedItemChoice WHERE watchedItem = :watchedItem;
+DELETE FROM WatchedItemChoice WHERE selections = :selections;
 
 deleteForDimension:
 DELETE FROM WatchedItemChoice
-WHERE watchedItem = :watchedItem AND choice IN (
+WHERE selections = :selections AND choice IN (
     SELECT id
     FROM WatchedItemDimensionChoice
     WHERE dimension = :dimension
 );
 
 insert:
-INSERT INTO WatchedItemChoice(watchedItem, choice)
-VALUES (:watchedItem, :choice);
+INSERT INTO WatchedItemChoice(selections, choice)
+VALUES (:selections, :choice);

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemDimensionSelections.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemDimensionSelections.sq
@@ -1,0 +1,20 @@
+/**
+ * This table is used as "glue" to group dimension selections together.
+ *
+ * Normally these would attach to the relevant `WatchedItem` directly, but having this table is more flexible as it
+ * allows a set of values to exist also for other entity types (e.g. an episode watch session).
+ */
+CREATE TABLE WatchedItemDimensionSelections(
+  id INTEGER PRIMARY KEY NOT NULL
+);
+
+selectAll:
+SELECT * FROM WatchedItemDimensionSelections;
+
+insert:
+INSERT INTO WatchedItemDimensionSelections DEFAULT VALUES
+RETURNING *;
+
+delete:
+DELETE FROM WatchedItemDimensionSelections
+WHERE id = :id;

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemFreeText.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemFreeText.sq
@@ -2,12 +2,12 @@
  * Contains the values for the dimensions of type free text for a single `WatchedItem`.
  */
 CREATE TABLE WatchedItemFreeText(
-  watchedItem INTEGER NOT NULL,
-  watchedItemDimension INTEGER NOT NULL,
+  selections INTEGER NOT NULL,
+  dimension INTEGER NOT NULL,
   text TEXT NOT NULL,
-  PRIMARY KEY(watchedItem, watchedItemDimension),
-  FOREIGN KEY(watchedItem) REFERENCES WatchedItem(id) ON UPDATE CASCADE ON DELETE CASCADE,
-  FOREIGN KEY(watchedItemDimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
+  PRIMARY KEY(selections, dimension),
+  FOREIGN KEY(selections) REFERENCES WatchedItemDimensionSelections(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY(dimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
 selectAll:
@@ -15,9 +15,9 @@ SELECT * FROM WatchedItemFreeText;
 
 delete:
 DELETE FROM WatchedItemFreeText
-WHERE watchedItem = :watchedItem AND watchedItemDimension = :watchedItemDimension;
+WHERE selections = :selections AND dimension = :dimension;
 
 upsert:
-INSERT INTO WatchedItemFreeText(watchedItem, watchedItemDimension, text)
-VALUES(:watchedItem, :watchedItemDimension, :text)
-ON CONFLICT(watchedItem, watchedItemDimension) DO UPDATE SET text = :text;
+INSERT INTO WatchedItemFreeText(selections, dimension, text)
+VALUES(:selections, :dimension, :text)
+ON CONFLICT(selections, dimension) DO UPDATE SET text = :text;

--- a/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemLanguage.sq
+++ b/composeApp/src/main/sqldelight/profile/io/github/couchtracker/db/profile/WatchedItemLanguage.sq
@@ -4,12 +4,12 @@ import io.github.couchtracker.db.profile.Bcp47Language;
  * Contains the values for the dimensions of type language for a single `WatchedItem`.
  */
 CREATE TABLE WatchedItemLanguage(
-  watchedItem INTEGER NOT NULL,
-  watchedItemDimension INTEGER NOT NULL,
+  selections INTEGER NOT NULL,
+  dimension INTEGER NOT NULL,
   language TEXT AS Bcp47Language NOT NULL,
-  PRIMARY KEY(watchedItem, watchedItemDimension),
-  FOREIGN KEY(watchedItem) REFERENCES WatchedItem(id) ON UPDATE CASCADE ON DELETE CASCADE,
-  FOREIGN KEY(watchedItemDimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
+  PRIMARY KEY(selections, dimension),
+  FOREIGN KEY(selections) REFERENCES WatchedItemDimensionSelections(id) ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY(dimension) REFERENCES WatchedItemDimension(id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
 selectAll:
@@ -17,9 +17,9 @@ SELECT * FROM WatchedItemLanguage;
 
 delete:
 DELETE FROM WatchedItemLanguage
-WHERE watchedItem = :watchedItem AND watchedItemDimension = :watchedItemDimension;
+WHERE selections = :selections AND dimension = :dimension;
 
 upsert:
-INSERT INTO WatchedItemLanguage(watchedItem, watchedItemDimension, language)
-VALUES(:watchedItem, :watchedItemDimension, :language)
-ON CONFLICT(watchedItem, watchedItemDimension) DO UPDATE SET language = :language;
+INSERT INTO WatchedItemLanguage(selections, dimension, language)
+VALUES(:selections, :dimension, :language)
+ON CONFLICT(selections, dimension) DO UPDATE SET language = :language;


### PR DESCRIPTION
This new table only acts as "glue" to group dimensions selections together.

While it seems useless now, it will be needed to attach a set of presets to an episode watch session and opens up to the possibility of creating presets.
