### PR TITLE
Do not rely on SQL Delight notify mechanism

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/AndroidApplication.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/AndroidApplication.kt
@@ -26,7 +26,7 @@ class AndroidApplication : Application(), SingletonImageLoader.Factory {
         super.onCreate()
 
         startKoin {
-            logger(AndroidLogger(Level.DEBUG))
+            logger(AndroidLogger(Level.INFO))
 
             androidContext(this@AndroidApplication)
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
@@ -2,13 +2,13 @@ package io.github.couchtracker.tmdb
 
 import android.util.Log
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.db.QueryResult
 import app.moviebase.tmdb.Tmdb3
 import app.moviebase.tmdb.core.TmdbException
 import io.github.couchtracker.db.tmdbCache.TmdbCache
 import io.github.couchtracker.db.tmdbCache.TmdbTimestampedEntry
 import io.github.couchtracker.settings.AppSettings
+import io.github.couchtracker.utils.EventBus
 import io.github.couchtracker.utils.FlowRetryContext
 import io.github.couchtracker.utils.FlowRetryToken
 import io.github.couchtracker.utils.Result
@@ -24,8 +24,10 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
@@ -48,9 +50,16 @@ val TMDB_CACHE_EXPIRATION_DEFAULT = 12.hours
 private const val TMDB_STATUS_CODE_RESOURCE_NOT_FOUND = 34
 
 typealias TmdbFlowRetryContext = FlowRetryContext<TmdbLanguages>
-typealias LocalizedItemQueryBuilder<ID, L, T> = (ID, L, (T, Instant) -> TmdbTimestampedEntry<T>) -> Query<TmdbTimestampedEntry<T>>
-typealias ItemQueryBuilder<ID, T> = (ID, (details: T, lastUpdate: Instant) -> TmdbTimestampedEntry<T>) -> Query<TmdbTimestampedEntry<T>>
-typealias LocalizedInfoQueryBuilder<L, T> = (L, (T, Instant) -> TmdbTimestampedEntry<T>) -> Query<TmdbTimestampedEntry<T>>
+
+typealias TmdbTimestampedEntryBuilder<T> = (T, Instant) -> TmdbTimestampedEntry<T>
+typealias LocalizedItemQueryBuilder<ID, L, T> = (ID, L, TmdbTimestampedEntryBuilder<T>) -> Query<TmdbTimestampedEntry<T>>
+typealias ItemQueryBuilder<ID, T> = (ID, TmdbTimestampedEntryBuilder<T>) -> Query<TmdbTimestampedEntry<T>>
+typealias LocalizedInfoQueryBuilder<L, T> = (L, TmdbTimestampedEntryBuilder<T>) -> Query<TmdbTimestampedEntry<T>>
+
+private data class TmdbCacheKey(val table: Query<TmdbTimestampedEntry<*>>, val key: List<Any>)
+private class TmdbCacheEvent(val key: TmdbCacheKey)
+
+private val tmdbCacheEvents = EventBus<TmdbCacheEvent>()
 
 fun tmdbFlowRetryContext(
     retryToken: FlowRetryToken = FlowRetryToken(),
@@ -68,14 +77,17 @@ fun <ID : TmdbId, T : Any> tmdbCachedDownload(
     expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
     cache: TmdbCache = KoinPlatform.getKoin().get(),
 ): Flow<ApiResult<T>> {
+    val fullLogTag = "$id-$logTag"
+    val loadFromCacheQuery = loadFromCacheFn(cache)(id, ::TmdbTimestampedEntry)
     return tmdbGetOrDownload(
-        entryTag = logTag,
-        loadFromCache = { loadFromCacheFn(cache)(id, ::TmdbTimestampedEntry) },
+        logTag = fullLogTag,
+        cacheKey = TmdbCacheKey(loadFromCacheQuery, listOf(id)),
+        loadFromCache = { loadFromCacheQuery.executeAsOneOrNull() },
         putInCache = { data -> putInCacheFn(cache)(id, data.value, data.lastUpdate) },
         downloader = {
             tmdbDownloadResult(
                 apiSubjectIdentifier = id.toExternalId().serialize(),
-                logTag = logTag,
+                logTag = fullLogTag,
                 download = download,
             )
         },
@@ -84,7 +96,7 @@ fun <ID : TmdbId, T : Any> tmdbCachedDownload(
 }
 
 @Suppress("LongParameterList")
-fun <ID : TmdbId, L, T : Any> tmdbLocalizedCachedDownload(
+fun <ID : TmdbId, L : Any, T : Any> tmdbLocalizedCachedDownload(
     id: ID,
     logTag: String,
     language: L,
@@ -94,15 +106,17 @@ fun <ID : TmdbId, L, T : Any> tmdbLocalizedCachedDownload(
     expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
     cache: TmdbCache = KoinPlatform.getKoin().get(),
 ): Flow<ApiResult<T>> {
-    val logTag = "$language-$logTag"
+    val fullLogTag = "$id-$language-$logTag"
+    val loadFromCacheQuery = loadFromCacheFn(cache)(id, language, ::TmdbTimestampedEntry)
     return tmdbGetOrDownload(
-        entryTag = logTag,
-        loadFromCache = { loadFromCacheFn(cache)(id, language, ::TmdbTimestampedEntry) },
+        logTag = "$id-$fullLogTag",
+        cacheKey = TmdbCacheKey(loadFromCacheQuery, listOf(id, language)),
+        loadFromCache = { loadFromCacheQuery.executeAsOneOrNull() },
         putInCache = { data -> putInCacheFn(cache)(id, language, data.value, data.lastUpdate) },
         downloader = {
             tmdbDownloadResult(
                 apiSubjectIdentifier = id.toExternalId().serialize(),
-                logTag = logTag,
+                logTag = fullLogTag,
                 download = { download(it) },
             )
         },
@@ -110,7 +124,7 @@ fun <ID : TmdbId, L, T : Any> tmdbLocalizedCachedDownload(
     )
 }
 
-fun <L, T : Any> tmdbLocalizedCachedDownload(
+fun <L : Any, T : Any> tmdbLocalizedCachedDownload(
     logTag: String,
     language: L,
     loadFromCacheFn: TmdbCache.() -> LocalizedInfoQueryBuilder<L, T>,
@@ -119,12 +133,20 @@ fun <L, T : Any> tmdbLocalizedCachedDownload(
     expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
     cache: TmdbCache = KoinPlatform.getKoin().get(),
 ): Flow<ApiResult<T>> {
-    val logTag = "$language-$logTag"
+    val fullLogTag = "$language-$logTag"
+    val loadFromCacheQuery = loadFromCacheFn(cache)(language, ::TmdbTimestampedEntry)
     return tmdbGetOrDownload(
-        entryTag = logTag,
-        loadFromCache = { loadFromCacheFn(cache)(language, ::TmdbTimestampedEntry) },
+        logTag = fullLogTag,
+        cacheKey = TmdbCacheKey(loadFromCacheQuery, listOf(language)),
+        loadFromCache = { loadFromCacheQuery.executeAsOneOrNull() },
         putInCache = { data -> putInCacheFn(cache)(language, data.value, data.lastUpdate) },
-        downloader = { tmdbDownloadResult(apiSubjectIdentifier = null, logTag = logTag, download = { download(it) }) },
+        downloader = {
+            tmdbDownloadResult(
+                apiSubjectIdentifier = null,
+                logTag = fullLogTag,
+                download = { download(it) },
+            )
+        },
         expiration = expiration,
     )
 }
@@ -134,31 +156,34 @@ fun <L, T : Any> tmdbLocalizedCachedDownload(
  *
  * Handles caching, stale caching, reloads if cache changes.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
-fun <T : Any> tmdbGetOrDownload(
-    entryTag: String,
-    loadFromCache: () -> Query<TmdbTimestampedEntry<T>>,
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+private fun <T : Any> tmdbGetOrDownload(
+    logTag: String,
+    cacheKey: TmdbCacheKey,
+    loadFromCache: () -> TmdbTimestampedEntry<T>?,
     putInCache: (TmdbTimestampedEntry<T>) -> Unit,
     downloader: suspend () -> ApiResult<T>,
     expiration: Duration = TMDB_CACHE_EXPIRATION_DEFAULT,
     coroutineContext: CoroutineContext = Dispatchers.IO,
 ): Flow<ApiResult<T>> {
-    return loadFromCache()
-        .asFlow()
-        .distinctUntilChanged()
+    val cacheEvent = TmdbCacheEvent(cacheKey)
+    return tmdbCacheEvents
+        .subscribe()
+        // I want to be notified immediately (the null), and when a cache event for cacheKey is published _by another downloader_
+        .filter { it == null || (it.key == cacheKey && it !== cacheEvent) }
         .transformLatest {
-            val cachedValue = it.executeAsOneOrNull().injectCacheMiss()
+            val cachedValue = loadFromCache().injectCacheMiss()
             val currentTime = Clock.System.now()
             if (cachedValue != null) {
                 emit(Result.Value(cachedValue.value))
                 val age = currentTime - cachedValue.lastUpdate
                 if (age > expiration) {
-                    Log.d(LOG_TAG, "$entryTag: Entry is old (age=$age), starting download")
-                    when (val downloaded = downloadAndSave(downloader, putInCache, coroutineContext)) {
+                    Log.d(LOG_TAG, "$logTag: Entry is old (age=$age), starting download")
+                    when (val downloaded = downloadAndSave(cacheEvent, downloader, putInCache, coroutineContext)) {
                         is Result.Error -> {
                             Log.w(
                                 LOG_TAG,
-                                "$entryTag: Download failed, using a stale entry (${downloaded.error.debugMessage})",
+                                "$logTag: Download failed, using a stale entry (${downloaded.error.debugMessage})",
                                 downloaded.error.cause,
                             )
                         }
@@ -168,8 +193,8 @@ fun <T : Any> tmdbGetOrDownload(
                     }
                 }
             } else {
-                Log.d(LOG_TAG, "$entryTag: No cached entry, performing download")
-                emit(downloadAndSave(downloader, putInCache, coroutineContext))
+                Log.d(LOG_TAG, "$logTag: No cached entry, performing download")
+                emit(downloadAndSave(cacheEvent, downloader, putInCache, coroutineContext))
             }
         }
         .flowOn(coroutineContext)
@@ -177,15 +202,17 @@ fun <T : Any> tmdbGetOrDownload(
 }
 
 private suspend fun <T : Any> downloadAndSave(
+    cacheEvent: TmdbCacheEvent,
     download: suspend () -> ApiResult<T>,
-    save: (TmdbTimestampedEntry<T>) -> Unit,
+    put: (TmdbTimestampedEntry<T>) -> Unit,
     coroutineContext: CoroutineContext,
 ): ApiResult<T> {
     val currentTime = Clock.System.now()
     val element = download()
     if (element is Result.Value) {
         withContext(coroutineContext) {
-            save(TmdbTimestampedEntry(element.value, currentTime))
+            put(TmdbTimestampedEntry(element.value, currentTime))
+            tmdbCacheEvents.publish(cacheEvent)
         }
     }
     return element
@@ -198,15 +225,10 @@ private suspend fun <T : Any> downloadAndSave(
  */
 @Suppress("ThrowsCount")
 suspend fun <T> tmdbDownloadResult(
-    logTag: String?,
+    logTag: String,
     apiSubjectIdentifier: String? = null,
     download: suspend (Tmdb3) -> T,
 ): ApiResult<T> {
-    val logTag = if (logTag != null && apiSubjectIdentifier != null) {
-        "$apiSubjectIdentifier-$logTag"
-    } else {
-        logTag ?: apiSubjectIdentifier ?: LOG_TAG
-    }
     @Suppress("TooGenericExceptionCaught")
     return try {
         injectApiError()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
@@ -55,11 +55,17 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         val following: Set<ExternalShowId>,
     )
 
+    @Suppress("EqualsOrHashCode")
     data class BookmarkedShowData(
         val showId: ExternalShowId,
         val portraitModel: ShowPortraitModel,
         val seasons: ApiLoadable<List<TmdbSeasonDetail>>,
-    )
+    ) {
+        // Computing the hascode of this class is expensive.
+        // Caching it, so it's computed on creation on a background thread
+        private val cachedHashCode = super.hashCode()
+        override fun hashCode() = cachedHashCode
+    }
 
     private val bookmarks: Flow<PartitionedBookmarkedShows> = KoinPlatform.getKoin().get<Flow<ProfilesInfo>>()
         .mapNotNull { profilesInfo ->

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/EventBus.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/EventBus.kt
@@ -1,0 +1,51 @@
+package io.github.couchtracker.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+
+/**
+ * A class to publish events and get a flow to subscribe to them
+ */
+class EventBus<T : Any>(
+    scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
+) {
+    private val pendingEvents = Channel<T>(capacity = Channel.UNLIMITED)
+    private val flow = MutableSharedFlow<T>()
+
+    init {
+        scope.launch {
+            pendingEvents.consumeEach {
+                flow.emit(it)
+            }
+        }
+    }
+
+    /**
+     * Subscribes to events of this events bus.
+     * Note: `null` is immediately emitted once, to allow for the subscriber to do something immediately
+     */
+    fun subscribe(): Flow<T?> {
+        return flow {
+            emit(null)
+            emitAll(flow)
+        }
+    }
+
+    /**
+     * Publishes an event.
+     * Importantly, this does _not_ suspend until the event is sent and received.
+     * This allows calling this function from a subscriber.
+     */
+    fun publish(event: T) {
+        check(pendingEvents.trySend(event).isSuccess) {
+            "Event $event not published"
+        }
+    }
+}

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/EventBusTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/EventBusTest.kt
@@ -1,0 +1,80 @@
+package io.github.couchtracker.utils
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.config.DefaultTestConfig
+import io.kotest.engine.coroutines.backgroundScope
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+class EventBusTest : FunSpec(
+    {
+        defaultTestConfig = DefaultTestConfig(
+            coroutineTestScope = true,
+            timeout = 1.seconds,
+        )
+        test("subscribe emits the filter value immediately") {
+            val buffer = EventBus<Int>(backgroundScope)
+            buffer.subscribe().take(1).toList() shouldBe listOf(null)
+        }
+
+        test("publish delivers matching events to subscribers") {
+            val buffer = EventBus<String>(backgroundScope)
+            val results = async {
+                buffer.subscribe().take(4).toList()
+            }
+            launch {
+                buffer.publish("event-1")
+                buffer.publish("event-2")
+                buffer.publish("event-3")
+            }
+            results.await() shouldBe listOf(null, "event-1", "event-2", "event-3")
+        }
+
+        test("publish can be called from inside a subscriber without deadlocking") {
+            val buffer = EventBus<String>(backgroundScope)
+            val results = buffer
+                .subscribe()
+                .onEach {
+                    buffer.publish("echo (prev=$it)")
+                }
+                .take(3)
+                .toList()
+
+            results shouldBe listOf(null, "echo (prev=null)", "echo (prev=echo (prev=null))")
+        }
+
+        test("multiple subscribers") {
+            val buffer = EventBus<String>(backgroundScope)
+            val results1 = async {
+                buffer.subscribe().take(3).toList()
+            }
+            val results2 = async {
+                buffer.subscribe().take(3).toList()
+            }
+            val results3 = async {
+                buffer.subscribe().take(5).toList()
+            }
+            launch {
+                buffer.publish("key-1")
+                buffer.publish("key-2")
+            }
+            results1.await() shouldBe listOf(null, "key-1", "key-2")
+            results2.await() shouldBe listOf(null, "key-1", "key-2")
+
+            val results4 = async {
+                buffer.subscribe().take(3).toList()
+            }
+            launch {
+                buffer.publish("key-3")
+                buffer.publish("key-4")
+            }
+            results3.await() shouldBe listOf(null, "key-1", "key-2", "key-3", "key-4")
+            results4.await() shouldBe listOf(null, "key-3", "key-4")
+        }
+    },
+)


### PR DESCRIPTION
SQL Delight will send a notification every time the _table_ is modified. This is too broad and can cause O(N^2) events when N listeners are also writing.

With this commit, the Tmdb cache uses an EventBus that sends notifications only for a specific element key.