### PR TITLE
Fix nextTick for RelativeDurationFormatter in edge case

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/DynamicLocalDateTimeFormatter.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/DynamicLocalDateTimeFormatter.kt
@@ -11,7 +11,7 @@ import io.github.couchtracker.utils.MaybeZoned
 import io.github.couchtracker.utils.TickingValue
 import io.github.couchtracker.utils.Zoned
 import io.github.couchtracker.utils.combine
-import io.github.couchtracker.utils.map
+import io.github.couchtracker.utils.flatMap
 import io.github.couchtracker.utils.withNextTickAtMost
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.toInstant
@@ -101,8 +101,18 @@ class DynamicLocalDateTimeFormatter(
             return chooseThreshold(
                 threshold = DURATION_THRESHOLD,
                 withinThreshold = {
-                    val relDurationFormat = relativeDurationFormatter.format(diff).map {
-                        context.getString(if (diff.isNegative()) R.string.duration_x_ago else R.string.duration_in_x, it)
+                    val relDurationFormat = relativeDurationFormatter.format(diff).flatMap {
+                        if (diff.isNegative()) {
+                            TickingValue(
+                                value = context.getString(R.string.duration_x_ago, it),
+                                nextTick = null,
+                            )
+                        } else {
+                            TickingValue(
+                                value = context.getString(R.string.duration_in_x, it),
+                                nextTick = diff + 1.nanoseconds,
+                            )
+                        }
                     }
                     relAbsFormat.combine(relDurationFormat) { relAbsFormat, relDurationFormat ->
                         context.getString(R.string.parenthesize, relAbsFormat, relDurationFormat)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Duration.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Duration.kt
@@ -34,21 +34,29 @@ fun Duration.unitPart(unit: DurationUnit): Long {
  * Returns the amount of time that needs to pass for this duration's [unit] to change, assuming the duration moves backwards, i.e. a
  * positive duration means something that will happen in the future, and a negative duration something that has happened in the past.
  *
- * If the duration would change sign before the unit, that is returned instead (see last example).
+ * Note: if the duration is positive but smaller than 1 [unit], the value for the unit would remain 0 for both the remaining part of the
+ * positive part of the duration and a part of the negative part (see last example).
  *
  * For example:
  * - `-1h20m`, `HOURS` -> `40m`
  * - `-1h20m`, `MINUTES` -> `1m`
  * - `1h20m`, `HOURS` -> `20m1ns`
  * - `1h20m`, `MINUTES` -> `1ns`
- * - `20m`, `HOURS` -> `20m`
+ * - `20m`, `HOURS` -> `1h20m`
  */
 fun Duration.remainderUntilNextUnitBoundary(unit: DurationUnit): Duration {
     val durationNanos = this.absoluteValue.inWholeNanoseconds
-    val unitNanos = 1.toDuration(unit).inWholeNanoseconds
+    val oneUnit = 1.toDuration(unit)
+    val unitNanos = oneUnit.inWholeNanoseconds
     val remainderNs = durationNanos % unitNanos
     return if (isPositive()) {
-        minOf(this, (remainderNs + 1).nanoseconds)
+        if (durationNanos < unitNanos) {
+            // This means that the given unit is zero, as the duration is smaller than 1 unit
+            // So in order for this unit to change we need to get all the way to zero (this) + wait one full unit length (oneUnit)
+            this + oneUnit
+        } else {
+            remainderNs.nanoseconds + 1.nanoseconds
+        }
     } else {
         (unitNanos - remainderNs).nanoseconds
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/TickingValue.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/TickingValue.kt
@@ -76,6 +76,10 @@ fun <T, R> TickingValue<T>.map(transform: (T) -> R): TickingValue<R> {
     return TickingValue(value = transform(value), nextTick = nextTick)
 }
 
+fun <T, R> TickingValue<T>.flatMap(transform: (T) -> TickingValue<R>): TickingValue<R> {
+    return transform(value).withNextTickAtMost(nextTick)
+}
+
 fun <T1, T2, R> TickingValue<T1>.combine(
     other: TickingValue<T2>,
     transform: (T1, T2) -> R,

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/DynamicLocalDateTimeFormatterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/DynamicLocalDateTimeFormatterTest.kt
@@ -8,13 +8,12 @@ import io.github.couchtracker.R
 import io.github.couchtracker.utils.MaybeZoned
 import io.github.couchtracker.utils.TickingValue
 import io.github.couchtracker.utils.Zoned
-import io.github.couchtracker.utils.plus
-import io.github.couchtracker.utils.toLocalDateTime
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.tuple
 import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.filter
 import io.mockk.every
 import io.mockk.mockk
@@ -22,12 +21,12 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 /**
  * Current date used in tests. This is a Thursday
@@ -86,7 +85,7 @@ class DynamicLocalDateTimeFormatterTest : FunSpec(
                         TickingValue("15 jul 1980, 17:25 hora de verano de Europa central", nextTick = null),
                     ),
                 ) { (formatter, dateTime, expected) ->
-                    formatter.format(dateTime, NOW) shouldBe expected
+                    formatter.formatAndTestNextTick(dateTime, NOW) shouldBe expected
                 }
             }
             context("dates within relative threshold") {
@@ -138,7 +137,7 @@ class DynamicLocalDateTimeFormatterTest : FunSpec(
                             TickingValue("tra 9 giorni, 01:00 +01:00", nextTick = 1.days),
                         ),
                     ) { (formatter, localDateTime, expected) ->
-                        formatter.format(localDateTime, NOW) shouldBe expected
+                        formatter.formatAndTestNextTick(localDateTime, NOW) shouldBe expected
                     }
                 }
                 context("dates within duration threshold") {
@@ -151,6 +150,19 @@ class DynamicLocalDateTimeFormatterTest : FunSpec(
                                 timeZone = null,
                             ),
                             TickingValue("today, 11:00 PM (in 23h)", nextTick = 1.nanoseconds),
+                        ),
+                        tuple(
+                            DynamicLocalDateTimeFormatter(mockContext(ULocale.ENGLISH), ULocale.ENGLISH),
+                            MaybeZoned(value = NOW_DATE, timeZone = null),
+                            TickingValue("today, 12:00 AM (in 0m)", nextTick = 1.nanoseconds),
+                        ),
+                        tuple(
+                            DynamicLocalDateTimeFormatter(mockContext(ULocale.ENGLISH), ULocale.ENGLISH),
+                            MaybeZoned(
+                                value = LocalDateTime.parse("2026-01-01T00:00:05"),
+                                timeZone = null,
+                            ),
+                            TickingValue("today, 12:00 AM (in 0m)", nextTick = 5.seconds + 1.nanoseconds),
                         ),
                         tuple(
                             DynamicLocalDateTimeFormatter(
@@ -221,7 +233,7 @@ class DynamicLocalDateTimeFormatterTest : FunSpec(
                             TickingValue("yesterday, 9:00 PM -08:00 (in 5h)", nextTick = 1.nanoseconds),
                         ),
                     ) { (formatter, localDateTime, expected) ->
-                        formatter.format(localDateTime, NOW) shouldBe expected
+                        formatter.formatAndTestNextTick(localDateTime, NOW) shouldBe expected
                     }
                 }
             }
@@ -233,9 +245,9 @@ class DynamicLocalDateTimeFormatterTest : FunSpec(
                 val dateRange = LocalDateTime.parse("1950-01-01T00:00")..LocalDateTime.parse("2090-01-01T00:00:00")
                 val formatter = DynamicLocalDateTimeFormatter(mockContext(ULocale.ENGLISH), ULocale.ENGLISH)
                 nextTickPredictsChangeTestMaybeZoned(
-                    arb = Arb.maybeZoned(Arb.kotlinLocalDateTime()).filter { it.value in dateRange },
-                    valueFromInstant = { it.value.toLocalDateTime(it.timeZone) },
-                    format = { dateTime, now -> formatter.format(dateTime, now) },
+                    arbitraryArb = Arb.maybeZoned(Arb.kotlinLocalDateTime()).filter { it.value in dateRange },
+                    smallArb = { Arb.element(it.value.toLocalDateTime(it.timeZone)) },
+                    format = formatter::format,
                     nowRange = dateRange.start.toInstant(TimeZone.UTC)..dateRange.endInclusive.toInstant(TimeZone.UTC),
                 )
             }
@@ -266,6 +278,5 @@ private fun mockContext(locale: ULocale) = mockk<Context> {
     }
 }
 
-private fun DynamicLocalDateTimeFormatter.format(diff: Duration): TickingValue<String> {
-    return format(MaybeZoned((NOW + diff).toLocalDateTime(), timeZone = null), NOW)
-}
+private fun DynamicLocalDateTimeFormatter.formatAndTestNextTick(dateTime: MaybeZoned<LocalDateTime>, now: Zoned<Instant>) =
+    formatAndTestNextTick(dateTime, now, ::format)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeDateAbsoluteTimeFormatterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeDateAbsoluteTimeFormatterTest.kt
@@ -13,6 +13,7 @@ import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.enum
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.exhaustive
@@ -20,6 +21,7 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
 
 /**
  * Current date used in most tests. This is a Thursday
@@ -48,6 +50,11 @@ class RelativeDateAbsoluteTimeFormatterTest : FunSpec(
                             RelativeDateAbsoluteTimeFormatter(ULocale.ENGLISH),
                             LocalDateTime.parse("2025-12-11T19:00:00"),
                             "21 days ago at 7:00 PM",
+                        ),
+                        tuple(
+                            RelativeDateAbsoluteTimeFormatter(ULocale.ENGLISH),
+                            NOW_DATE,
+                            "today at 12:00 AM",
                         ),
                         tuple(
                             RelativeDateAbsoluteTimeFormatter(ULocale.ENGLISH, timeSkeleton = TimeSkeleton.SECONDS),
@@ -86,10 +93,10 @@ class RelativeDateAbsoluteTimeFormatterTest : FunSpec(
                         ),
                     ) { (formatter, localDateTime, expected) ->
                         withClue("null timezone") {
-                            formatter.format(MaybeZoned(localDateTime, timeZone = null), NOW).value shouldBe expected
+                            formatter.formatAndTestNextTick(MaybeZoned(localDateTime, timeZone = null), NOW).value shouldBe expected
                         }
                         withClue("with same timezone as now") {
-                            formatter.format(MaybeZoned(localDateTime, timeZone = NOW.timeZone), NOW).value shouldBe expected
+                            formatter.formatAndTestNextTick(MaybeZoned(localDateTime, timeZone = NOW.timeZone), NOW).value shouldBe expected
                         }
                     }
                 }
@@ -130,7 +137,7 @@ class RelativeDateAbsoluteTimeFormatterTest : FunSpec(
                             "in 19 days at 7:00 PM -05:00",
                         ),
                     ) { (formatter, localDateTime, expected) ->
-                        formatter.format(localDateTime, NOW).value shouldBe expected
+                        formatter.formatAndTestNextTick(localDateTime, NOW).value shouldBe expected
                     }
                 }
 
@@ -162,11 +169,14 @@ class RelativeDateAbsoluteTimeFormatterTest : FunSpec(
                 }
 
                 nextTickPredictsChangeTestMaybeZoned(
-                    arb = Arb.maybeZoned(Arb.kotlinLocalDateTime()),
-                    valueFromInstant = { it.value.toLocalDateTime(it.timeZone) },
-                    format = { dateTime, now -> formatter.format(dateTime, now) },
+                    arbitraryArb = Arb.maybeZoned(Arb.kotlinLocalDateTime()),
+                    smallArb = { Arb.element(it.value.toLocalDateTime(it.timeZone)) },
+                    format = formatter::format,
                 )
             }
         }
     },
 )
+
+private fun RelativeDateAbsoluteTimeFormatter.formatAndTestNextTick(dateTime: MaybeZoned<LocalDateTime>, now: Zoned<Instant>) =
+    formatAndTestNextTick(dateTime, now, ::format)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeDurationFormatterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeDurationFormatterTest.kt
@@ -8,13 +8,12 @@ import io.github.couchtracker.utils.TickingValue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.tuple
 import io.kotest.datatest.withTests
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.duration
 import io.kotest.property.checkAll
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.microseconds
@@ -52,8 +51,13 @@ class RelativeDurationFormatterTest : FunSpec(
                         -(4.minutes + 22.seconds + 440.milliseconds + 141.microseconds),
                         TickingValue("4m 22s", nextTick = 559.milliseconds + 859.microseconds),
                     ),
+                    tuple(
+                        RelativeDurationFormatter(ULocale.ENGLISH, FormatWidth.NARROW, minUnit = DurationUnit.MINUTES),
+                        10.seconds,
+                        TickingValue("0m", nextTick = 1.minutes + 10.seconds),
+                    ),
                 ) { (formatter, duration, expected) ->
-                    formatter.format(duration) shouldBe expected
+                    formatter.formatAndTestNextTick(duration) shouldBe expected
                 }
             }
 
@@ -61,22 +65,34 @@ class RelativeDurationFormatterTest : FunSpec(
                 test("negative duration yields same format as positive") {
                     val formatter = RelativeDurationFormatter(ULocale.ENGLISH)
                     checkAll(Arb.duration()) { duration ->
-                        formatter.format(duration).value shouldBe formatter.format(-duration).value
+                        formatter.formatAndTestNextTick(duration).value shouldBe formatter.formatAndTestNextTick(-duration).value
                     }
                 }
             }
 
             context("nextTick") {
-                test("should never be null and always non-finite positive") {
-                    val formatter = RelativeDurationFormatter(ULocale.ENGLISH)
+                val formatter = RelativeDurationFormatter(ULocale.ENGLISH)
+                test("should never be null") {
                     checkAll(Arb.duration()) { duration ->
-                        formatter.format(duration).nextTick.shouldNotBeNull() should {
-                            it.isPositive().shouldBeTrue()
-                            it.isFinite().shouldBeTrue()
-                        }
+                        formatter.format(duration).nextTick.shouldNotBeNull()
                     }
                 }
+
+                nextTickPredictsChangeTest(
+                    arbitraryArb = Arb.duration(),
+                    smallArb = { it },
+                    advanceBy = Duration::minus,
+                    format = formatter::format,
+                )
             }
         }
     },
 )
+
+private fun RelativeDurationFormatter.formatAndTestNextTick(duration: Duration): TickingValue<String> {
+    return formatAndTestNextTick(
+        params = duration,
+        advanceBy = Duration::minus, // As time advances, the duration will go backwards
+        format = ::format,
+    )
+}

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeLocalDateFormatterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeLocalDateFormatterTest.kt
@@ -13,6 +13,7 @@ import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.localDate
 import io.kotest.property.arbitrary.map
 import kotlinx.datetime.DateTimeUnit
@@ -156,7 +157,7 @@ class RelativeLocalDateFormatterTest : FunSpec(
                             2.days + 18.hours,
                         ),
                     ) { (now, expected) ->
-                        formatter.format(date, now).nextTick shouldBe expected
+                        formatter.formatAndTestNextTick(date, now).nextTick shouldBe expected
                     }
                 }
 
@@ -164,17 +165,23 @@ class RelativeLocalDateFormatterTest : FunSpec(
                     val tz = TimeZone.of("Europe/Rome")
                     test("jump forward") {
                         val date = LocalDate.parse("2025-03-30")
-                        formatter.format(localDate = date, now = Zoned(date.atStartOfDayIn(tz), tz)).nextTick shouldBe 23.hours
+                        formatter.formatAndTestNextTick(
+                            localDate = date,
+                            now = Zoned(date.atStartOfDayIn(tz), tz),
+                        ).nextTick shouldBe 23.hours
                     }
                     test("just backward") {
                         val date = LocalDate.parse("2025-10-26")
-                        formatter.format(localDate = date, now = Zoned(date.atStartOfDayIn(tz), tz)).nextTick shouldBe 25.hours
+                        formatter.formatAndTestNextTick(
+                            localDate = date,
+                            now = Zoned(date.atStartOfDayIn(tz), tz),
+                        ).nextTick shouldBe 25.hours
                     }
                 }
-                nextTickPredictsChangeTest(
-                    arb = Arb.localDate().map { it.toKotlinLocalDate() },
-                    valueFromInstant = { it.toLocalDateTime().date },
-                    format = { date, now -> formatter.format(date, now) },
+                nextTickPredictsChangeTestWithNow(
+                    arbitraryArb = Arb.localDate().map { it.toKotlinLocalDate() },
+                    smallArb = { Arb.element(it.toLocalDateTime().date) },
+                    format = formatter::format,
                 )
             }
         }
@@ -184,5 +191,8 @@ class RelativeLocalDateFormatterTest : FunSpec(
 private fun RelativeLocalDateFormatter.format(days: Int): TickingValue<String> {
     val tz = TimeZone.UTC
     val now = Zoned(CURRENT_DATE.atStartOfDayIn(tz), tz)
-    return format(CURRENT_DATE.plus(days, DateTimeUnit.DAY), now)
+    return formatAndTestNextTick(CURRENT_DATE.plus(days, DateTimeUnit.DAY), now)
 }
+
+private fun RelativeLocalDateFormatter.formatAndTestNextTick(localDate: LocalDate, now: Zoned<Instant>) =
+    formatAndTestNextTick(localDate, now, ::format)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeTestUtils.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeTestUtils.kt
@@ -17,104 +17,164 @@ import io.kotest.property.arbitrary.duration
 import io.kotest.property.arbitrary.kotlinInstant
 import io.kotest.property.arbitrary.localDateTime
 import io.kotest.property.arbitrary.map
-import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.zoneId
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.exhaustive
 import kotlinx.datetime.toKotlinLocalDateTime
 import kotlinx.datetime.toKotlinTimeZone
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Instant
+
+data class WithNowFormatParams<T>(val value: T, val now: Zoned<Instant>) {
+    operator fun plus(duration: Duration) = WithNowFormatParams(value, now + duration)
+}
+
+fun <T> Arb.Companion.withNowFormatParams(
+    value: Arb<T>,
+    nowRange: KotlinInstantRange = Instant.DISTANT_PAST..Instant.DISTANT_FUTURE,
+) = arbitrary {
+    WithNowFormatParams(
+        value = value.bind(),
+        now = Arb.zonedInstant(nowRange).bind(),
+    )
+}
 
 /**
  * Runs tests that validate that the computed [TickingValue.nextTick] is correctly predicting a change in formatting.
  *
  * Two similar but distinct fuzzy tests are performed:
- * - one using arbitrary [T] values from the given [arb]
- * - one generating [T] values by using [valueFromInstant] and passing an [Instant] close to the generated now (between -100 and +100 days)
+ * - one using arbitrary [P] values from the given [arbitraryArb]
+ * - one using an arbitrary [P] values from [smallArb], which receives a small [Duration] as input (between -100 and 100 days), to be used
+ *   to calculate the params. This duration is meant to be used as a way to create more realistic params to format.
  *
  * The second case guarantees that more realistic cases (where now and the value to format are close) are covered.
- *
- * Note: the [T] value returned by [valueFromInstant] doesn't need to be "perfect", as it's only used to generate an input to the test.
- * Technically, even returning a completely random value won't make the tests fail, but it _will_ defeat the purpose of the second case.
  */
-suspend fun <T> FunSpecContainerScope.nextTickPredictsChangeTest(
-    arb: Arb<T>,
-    valueFromInstant: (Zoned<Instant>) -> T,
-    format: (T, now: Zoned<Instant>) -> TickingValue<String>,
-    nowRange: KotlinInstantRange = Instant.DISTANT_PAST..Instant.DISTANT_FUTURE,
+suspend fun <P> FunSpecContainerScope.nextTickPredictsChangeTest(
+    arbitraryArb: Arb<P>,
+    smallArb: (Arb<Duration>) -> Arb<P>,
+    advanceBy: P.(Duration) -> P,
+    format: (P) -> TickingValue<String>,
 ) {
     context("correctly predicts date change") {
         // This first test just checks arbitrary values
         // However, these values will likely be very far apart, and wouldn't necessarily test all relevant cases
         test("arbitrary values") {
-            checkAll(
-                arb,
-                Arb.zonedInstant(nowRange),
-            ) { value, now ->
-                runNextTickPredictsChangeTest(value, now, format)
+            checkAll(arbitraryArb) { params ->
+                val formatted = format(params)
+                testNextTickPredictsChange(params, formatted, advanceBy, format)
             }
         }
 
         // This test instead computes the value from a small amount of time away from now, ensuring more realistic cases are also covered
-        test("values close to now") {
+        test("small diff value") {
             checkAll(
-                Arb.duration(-100.days..100.days),
-                Arb.zonedInstant(nowRange),
-            ) { nowDiff, now ->
-                val value = valueFromInstant(now + nowDiff)
-                runNextTickPredictsChangeTest(value, now, format)
+                smallArb(Arb.duration(-100.days..100.days)),
+            ) { params ->
+                val formatted = format(params)
+                testNextTickPredictsChange(params, formatted, advanceBy, format)
             }
         }
     }
 }
 
+/**
+ * Version of [nextTickPredictsChangeTest] to test a formatter accepting a [T] and a [Zoned]<[Instant]>.
+ */
+suspend fun <T> FunSpecContainerScope.nextTickPredictsChangeTestWithNow(
+    arbitraryArb: Arb<T>,
+    smallArb: (Zoned<Instant>) -> Arb<T>,
+    format: (T, now: Zoned<Instant>) -> TickingValue<String>,
+    nowRange: KotlinInstantRange = Instant.DISTANT_PAST..Instant.DISTANT_FUTURE,
+) = nextTickPredictsChangeTest(
+    arbitraryArb = Arb.withNowFormatParams(arbitraryArb, nowRange),
+    smallArb = { diff ->
+        arbitrary {
+            val now = Arb.zonedInstant(nowRange).bind()
+            WithNowFormatParams(
+                value = smallArb(now + diff.bind()).bind(),
+                now = now,
+            )
+        }
+    },
+    advanceBy = WithNowFormatParams<T>::plus,
+    format = { format(it.value, it.now) },
+)
+
 suspend fun <T> FunSpecContainerScope.nextTickPredictsChangeTestMaybeZoned(
-    arb: Arb<MaybeZoned<T>>,
-    valueFromInstant: (Zoned<Instant>) -> T,
+    arbitraryArb: Arb<MaybeZoned<T>>,
+    smallArb: (Zoned<Instant>) -> Arb<T>,
     format: (MaybeZoned<T>, now: Zoned<Instant>) -> TickingValue<String>,
     nowRange: KotlinInstantRange = Instant.DISTANT_PAST..Instant.DISTANT_FUTURE,
 ) {
-    nextTickPredictsChangeTest(
-        arb = arb,
-        valueFromInstant = { zonedInstant ->
-            Arb.maybeZoned(zonedInstant.value)
-                .map { (instant, tz) -> MaybeZoned(valueFromInstant(Zoned(instant, tz ?: zonedInstant.timeZone)), tz) }
-                .next()
+    nextTickPredictsChangeTestWithNow(
+        arbitraryArb = arbitraryArb,
+        smallArb = { zonedInstant ->
+            arbitrary {
+                val (instant, tz) = Arb.maybeZoned(zonedInstant.value).bind()
+                MaybeZoned(smallArb(Zoned(instant, tz ?: zonedInstant.timeZone)).bind(), tz)
+            }
         },
         format = format,
         nowRange = nowRange,
     )
 }
 
-private fun <T> runNextTickPredictsChangeTest(
-    value: T,
-    now: Zoned<Instant>,
-    format: (T, now: Zoned<Instant>) -> TickingValue<String>,
+private fun <P> testNextTickPredictsChange(
+    value: P,
+    formatted: TickingValue<String>,
+    advanceBy: P.(Duration) -> P,
+    format: (P) -> TickingValue<String>,
 ) {
-    val formatted = format(value, now)
-
     if (formatted.nextTick == null) {
         withClue("nextTick is null, so format in the very far future (100 years) should yield same value") {
-            format(value, now + (365 * 100).days) shouldBe formatted
+            format(value.advanceBy((365 * 100).days)) shouldBe formatted
         }
     } else {
-        withClue("nextTick (${formatted.nextTick}) would be @ ${now.value.plus(formatted.nextTick)}") {
+        withClue("nextTick is ${formatted.nextTick} would be @ ${value.advanceBy(formatted.nextTick - 1.nanoseconds)}") {
             withClue("format at 1 nanosecond before nextTick should yield same relative value") {
-                format(value, now + (formatted.nextTick - 1.nanoseconds)) should {
+                format(value.advanceBy(formatted.nextTick - 1.nanoseconds)) should {
                     it.value shouldBe formatted.value
                     it.nextTick shouldBe 1.nanoseconds
                 }
             }
 
             withClue("format at nextTick should yield different relative value") {
-                format(value, now + formatted.nextTick) should {
+                format(value.advanceBy(formatted.nextTick)) should {
                     it.value shouldNotBe formatted.value
                 }
             }
         }
     }
+}
+
+fun <P> formatAndTestNextTick(
+    params: P,
+    advanceBy: P.(Duration) -> P,
+    format: (P) -> TickingValue<String>,
+): TickingValue<String> {
+    return format(params).also { formatted ->
+        testNextTickPredictsChange(
+            value = params,
+            formatted = formatted,
+            advanceBy = advanceBy,
+            format = format,
+        )
+    }
+}
+
+fun <T> formatAndTestNextTick(
+    value: T,
+    now: Zoned<Instant>,
+    format: (T, now: Zoned<Instant>) -> TickingValue<String>,
+): TickingValue<String> {
+    val params = WithNowFormatParams(value, now)
+    return formatAndTestNextTick(
+        params = params,
+        advanceBy = WithNowFormatParams<T>::plus,
+        format = { format(it.value, it.now) },
+    )
 }
 
 fun Arb.Companion.kotlinTimeZone() = Arb.zoneId().map { it.toKotlinTimeZone() }

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeYearFormatterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeYearFormatterTest.kt
@@ -11,11 +11,13 @@ import io.kotest.datatest.withContexts
 import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.year
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
+import kotlin.time.Instant
 
 private val NOW_DATE = LocalDate.parse("2026-04-01")
 private val NOW = Zoned(NOW_DATE.atStartOfDayIn(TimeZone.UTC), TimeZone.UTC)
@@ -96,14 +98,15 @@ class RelativeYearFormatterTest : FunSpec(
             context("next tick") {
                 val formatter = RelativeYearFormatter(ULocale.ENGLISH)
 
-                nextTickPredictsChangeTest(
-                    arb = Arb.year().map { it.value },
-                    valueFromInstant = { it.toLocalDateTime().year },
-                    format = { year, now -> formatter.format(year, now) },
+                nextTickPredictsChangeTestWithNow(
+                    arbitraryArb = Arb.year().map { it.value },
+                    smallArb = { Arb.element(it.toLocalDateTime().year) },
+                    format = formatter::format,
                 )
             }
         }
     },
 )
 
-fun RelativeYearFormatter.format(diff: Int) = format(NOW_DATE.year + diff, NOW)
+private fun RelativeYearFormatter.format(diff: Int) = formatAndTestNextTick(NOW_DATE.year + diff, NOW)
+private fun RelativeYearFormatter.formatAndTestNextTick(year: Int, now: Zoned<Instant>) = formatAndTestNextTick(year, now, ::format)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeYearMonthFormatterTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/intl/datetime/RelativeYearMonthFormatterTest.kt
@@ -11,15 +11,18 @@ import io.kotest.datatest.withContexts
 import io.kotest.datatest.withTests
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.yearMonth
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.YearMonth
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.plus
 import kotlinx.datetime.toKotlinYearMonth
 import kotlinx.datetime.yearMonth
+import kotlin.time.Instant
 
 private val NOW_DATE = LocalDate.parse("2026-04-01")
 private val NOW = Zoned(NOW_DATE.atStartOfDayIn(TimeZone.UTC), TimeZone.UTC)
@@ -100,14 +103,16 @@ class RelativeYearMonthFormatterTest : FunSpec(
             context("next tick") {
                 val formatter = RelativeYearMonthFormatter(ULocale.ENGLISH)
 
-                nextTickPredictsChangeTest(
-                    arb = Arb.yearMonth().map { it.toKotlinYearMonth() },
-                    valueFromInstant = { it.toLocalDateTime().date.yearMonth },
-                    format = { yearMonth, now -> formatter.format(yearMonth, now) },
+                nextTickPredictsChangeTestWithNow(
+                    arbitraryArb = Arb.yearMonth().map { it.toKotlinYearMonth() },
+                    smallArb = { Arb.element(it.toLocalDateTime().date.yearMonth) },
+                    format = formatter::format,
                 )
             }
         }
     },
 )
 
-fun RelativeYearMonthFormatter.format(diff: Int) = format(NOW_DATE.yearMonth.plus(diff, DateTimeUnit.MONTH), NOW)
+private fun RelativeYearMonthFormatter.format(diff: Int) = formatAndTestNextTick(NOW_DATE.yearMonth.plus(diff, DateTimeUnit.MONTH), NOW)
+private fun RelativeYearMonthFormatter.formatAndTestNextTick(yearMonth: YearMonth, now: Zoned<Instant>) =
+    formatAndTestNextTick(yearMonth, now, ::format)

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/DurationTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/DurationTest.kt
@@ -4,7 +4,6 @@ import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.tuple
 import io.kotest.datatest.withData
-import io.kotest.inspectors.forAny
 import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -60,10 +59,10 @@ class DurationTest : FunSpec(
                     tuple(1.hours, DurationUnit.HOURS, 1.nanoseconds),
                     tuple(5.seconds + 230.milliseconds, DurationUnit.SECONDS, 230.milliseconds + 1.nanoseconds),
                     tuple(5.seconds, DurationUnit.MILLISECONDS, 1.nanoseconds),
-                    tuple(5.minutes, DurationUnit.HOURS, 5.minutes),
-                    tuple(5.minutes, DurationUnit.DAYS, 5.minutes),
+                    tuple(5.minutes, DurationUnit.HOURS, 1.hours + 5.minutes),
+                    tuple(5.minutes, DurationUnit.DAYS, 1.days + 5.minutes),
                 ) { (duration, unit, expected) ->
-                    duration.remainderUntilNextUnitBoundary(unit) shouldBe expected
+                    duration.getAndTestRemainderUntilNextUnitBoundary(unit) shouldBe expected
                 }
             }
             context("zero duration") {
@@ -76,7 +75,7 @@ class DurationTest : FunSpec(
                     DurationUnit.HOURS to 1.hours,
                     DurationUnit.DAYS to 1.days,
                 ) { (unit, expected) ->
-                    Duration.ZERO.remainderUntilNextUnitBoundary(unit) shouldBe expected
+                    Duration.ZERO.getAndTestRemainderUntilNextUnitBoundary(unit) shouldBe expected
                 }
             }
             context("negative values") {
@@ -90,21 +89,17 @@ class DurationTest : FunSpec(
                     tuple(5.minutes, DurationUnit.HOURS, 55.minutes),
                     tuple(5.minutes, DurationUnit.DAYS, 23.hours + 55.minutes),
                 ) { (duration, unit, expected) ->
-                    (-duration).remainderUntilNextUnitBoundary(unit) shouldBe expected
+                    (-duration).getAndTestRemainderUntilNextUnitBoundary(unit) shouldBe expected
                 }
             }
 
             test("check that the desired unit actually changes") {
-                checkAll(iterations = 10_000, Arb.duration(), Arb.enum<DurationUnit>()) { duration, unit ->
-                    val prevUnit = duration.unitPart(unit).absoluteValue
-                    val remainder = duration.remainderUntilNextUnitBoundary(unit)
-                    val newDuration = duration - remainder
-                    val nextUnit = newDuration.unitPart(unit).absoluteValue
-
-                    listOf(
-                        { nextUnit shouldBeIn setOfNotNull(unit.decrease(prevUnit), unit.increase(prevUnit)) },
-                        { newDuration shouldBe Duration.ZERO },
-                    ).forAny { it() }
+                checkAll(
+                    iterations = 10_000,
+                    Arb.duration(-100.days..100.days),
+                    Arb.enum<DurationUnit>(),
+                ) { duration, unit ->
+                    duration.getAndTestRemainderUntilNextUnitBoundary(unit)
                 }
             }
         }
@@ -134,4 +129,15 @@ private fun DurationUnit.decrease(value: Long): Long? {
     } else {
         prev
     }
+}
+
+private fun Duration.getAndTestRemainderUntilNextUnitBoundary(unit: DurationUnit): Duration {
+    val prevUnit = this.unitPart(unit).absoluteValue
+    val remainder = this.remainderUntilNextUnitBoundary(unit)
+    val newDuration = this - remainder
+    val nextUnit = newDuration.unitPart(unit).absoluteValue
+
+    nextUnit shouldBeIn setOfNotNull(unit.decrease(prevUnit), unit.increase(prevUnit))
+
+    return remainder
 }

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/TickingValueTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/TickingValueTest.kt
@@ -79,5 +79,33 @@ class TickingValueTest : FunSpec(
                 tickingValue.withNextTickAtMost(nextTick = nextTick) shouldBe expected
             }
         }
+
+        context("flatMap") {
+            withTests(
+                nameFn = { "${it.a}.flatMap { ${it.b} } == ${it.c}" },
+                tuple(
+                    TickingValue("ciao", 1.days),
+                    TickingValue("mondo", 50.minutes),
+                    TickingValue("mondo", 50.minutes),
+                ),
+                tuple(
+                    TickingValue("hello", null),
+                    TickingValue("world", 3.seconds),
+                    TickingValue("world", 3.seconds),
+                ),
+                tuple(
+                    TickingValue("hola", 1.seconds),
+                    TickingValue("mundo", null),
+                    TickingValue("mundo", 1.seconds),
+                ),
+                tuple(
+                    TickingValue("hallo", null),
+                    TickingValue("welt", null),
+                    TickingValue("welt", null),
+                ),
+            ) { (t1, t2, expected) ->
+                t1.flatMap { t2 } shouldBe expected
+            }
+        }
     },
 )


### PR DESCRIPTION
The problem was triggering when the duration to format was smaller than 1 min unit. In this case, the `remainderUntilNextUnitBoundary` function returned the duration itself, while the given unit still remained 0.

This actually unveiled a deeper problem: we bounded `remainderUntilNextUnitBoundary` by the sign change of the duration, while `RelativeDurationFormatter` doesn't change anything related to formatting in this case.

So I've changed `remainderUntilNextUnitBoundary` to account for this case: this also makes sense for the function name, as the unit would be still zero. This is also noticeable by the fact that we had to add a `newDuration shouldBe Duration.ZERO` case, which is now useless.

Now the bounding by duration itself is done directly in `DynamicLocalDateTimeFormatter`, as that component in responsible for adding "in x"/"x ago" strings, that change with the sign.

As part of this change, I've also split the `nextTickPredictsChangeTest` function so that `RelativeDurationFormatterTest` can also leverage it. I've also improved on never using `Arb.next()` as we did before in one case.

Finally, now all hardcoded test cases also validate the next tick validity.
