### PR TITLE
Fix formatDateTimeSkeleton edge case and refactor skeletons

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/Utils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/Utils.kt
@@ -6,7 +6,8 @@ import com.ibm.icu.text.DateFormat
 import com.ibm.icu.text.DateTimePatternGenerator
 import com.ibm.icu.text.SimpleDateFormat
 import com.ibm.icu.util.ULocale
-import io.github.couchtracker.intl.datetime.Skeleton
+import io.github.couchtracker.intl.datetime.DateTimeSkeleton
+import io.github.couchtracker.intl.datetime.TimezoneSkeleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.TimeZone
@@ -28,10 +29,33 @@ suspend fun formatAndList(items: List<String>): String {
  * All the "local" parts used are for the given [instant] at the given [timeZone]. For instance, passing the epoch (`0`) with a timezone of
  * `GMT+05:00` will make the hour value be `5 AM`.
  */
-fun formatDateTimeSkeleton(instant: Instant, timeZone: TimeZone, skeleton: Skeleton, locale: ULocale): String {
-    val pattern = DateFormat.getInstanceForSkeleton(skeleton.value, locale)
-    val temporal = instant.toJavaInstant().atZone(timeZone.toJavaZoneId())
-    return pattern.format(temporal)
+fun formatDateTimeSkeleton(
+    instant: Instant,
+    timeZone: TimeZone,
+    dateTimeSkeleton: DateTimeSkeleton,
+    timezoneSkeleton: TimezoneSkeleton?,
+    locale: ULocale,
+): String {
+    val zonedDateTime = instant.toJavaInstant().atZone(timeZone.toJavaZoneId())
+
+    if (dateTimeSkeleton.time == null && timezoneSkeleton != null) {
+        // In this case, we need to work around a bug in ICU, so we need to combine the date/time format and the timezone separately
+
+        val dateTimePattern = DateFormat.getInstanceForSkeleton(dateTimeSkeleton.value, locale)
+        val dateTimeFormat = dateTimePattern.format(zonedDateTime)
+
+        return combineLiteralDateAndTimePattern(
+            locale = locale,
+            dateFormatStyle = DateFormat.SHORT,
+            literalDate = dateTimeFormat,
+            timePattern = { timezoneSkeleton.value },
+            value = zonedDateTime,
+        )
+    }
+
+    val skeleton = listOfNotNull(dateTimeSkeleton, timezoneSkeleton).joinToString(separator = " ") { it.value }
+    val pattern = DateFormat.getInstanceForSkeleton(skeleton, locale)
+    return pattern.format(zonedDateTime)
 }
 
 fun combineLiteralDateAndTimePattern(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/DynamicLocalDateTimeFormatter.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/DynamicLocalDateTimeFormatter.kt
@@ -51,7 +51,7 @@ class DynamicLocalDateTimeFormatter(
     private val timeSkeleton: TimeSkeleton = TimeSkeleton.MINUTES,
     private val timeZoneSkeleton: TimezoneSkeleton = TimezoneSkeleton.TIMEZONE_ID,
     relativeDateStyle: RelativeDateTimeFormatter.Style = RelativeDateTimeFormatter.Style.LONG,
-    private val absoluteDateSkeletons: List<DateSkeleton> = Skeletons.MEDIUM_DATE,
+    private val absoluteDateSkeletons: DateSkeleton = Skeletons.MEDIUM_DATE,
     relativeDurationFormatWidth: FormatWidth = FormatWidth.NARROW,
     relativeDurationOmitZeros: Boolean = true,
     relativeDurationMaxUnits: Int = 2,
@@ -114,15 +114,12 @@ class DynamicLocalDateTimeFormatter(
             thresholdEnd = instant + RELATIVE_DATE_THRESHOLD,
             withinThreshold = ::formatRelative,
             outsideThreshold = {
-                val skeletons = listOfNotNull(
-                    timeSkeleton,
-                    timeZoneSkeleton.takeIf { dateTime.timeZone != null && dateTime.timeZone != now.timeZone },
-                )
                 TickingValue(
                     value = formatDateTimeSkeleton(
                         instant = instant,
                         timeZone = tz,
-                        skeleton = (absoluteDateSkeletons + skeletons).sum(),
+                        dateTimeSkeleton = DateTimeSkeleton(absoluteDateSkeletons, timeSkeleton),
+                        timezoneSkeleton = timeZoneSkeleton.takeIf { dateTime.timeZone != null && dateTime.timeZone != now.timeZone },
                         locale = locale,
                     ),
                     nextTick = null,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/DynamicYearFormatter.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/DynamicYearFormatter.kt
@@ -62,10 +62,8 @@ class DynamicYearFormatter(
                     value = formatDateTimeSkeleton(
                         instant = LocalDate(year.value, month = Month.JANUARY, day = 1).atStartOfDayIn(tz),
                         timeZone = tz,
-                        skeleton = listOfNotNull(
-                            absoluteSkeleton,
-                            if (year.timeZone != null) timeZoneSkeleton else null,
-                        ).sum(),
+                        dateTimeSkeleton = DateTimeSkeleton(absoluteSkeleton),
+                        timezoneSkeleton = if (year.timeZone != null) timeZoneSkeleton else null,
                         locale = locale,
                     ),
                     nextTick = null,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/LocalizedSkeletonPartialDateTime.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/LocalizedSkeletonPartialDateTime.kt
@@ -12,12 +12,14 @@ import kotlinx.datetime.TimeZone
  * Specialization of [Localized] for [PartialDateTime] that are localized with a [Skeleton].
  */
 abstract class LocalizedSkeletonPartialDateTime<out PDT : PartialDateTime>(item: PDT) : Localized<PDT>(item) {
-    abstract val skeleton: Skeleton
+    abstract val dateTimeSkeleton: DateTimeSkeleton
+    abstract val timezoneSkeleton: TimezoneSkeleton?
 }
 
 private class LocalizedSkeletonPartialDateTimeImpl<out PDT : PartialDateTime>(
     item: PDT,
-    override val skeleton: Skeleton,
+    override val dateTimeSkeleton: DateTimeSkeleton,
+    override val timezoneSkeleton: TimezoneSkeleton?,
 ) : LocalizedSkeletonPartialDateTime<PDT>(item) {
 
     override fun localize(locale: ULocale): String {
@@ -33,24 +35,31 @@ private class LocalizedSkeletonPartialDateTimeImpl<out PDT : PartialDateTime>(
         return formatDateTimeSkeleton(
             instant = instant,
             timeZone = timeZone,
-            skeleton = skeleton,
+            dateTimeSkeleton = dateTimeSkeleton,
+            timezoneSkeleton = timezoneSkeleton,
             locale = locale,
         )
     }
 }
 
-/**
- * Localizes this [PartialDateTime.Local] with the given skeletons, which are concatenated together.
- */
-fun <L : Local> L.localized(skeletons: Collection<LocalSkeleton<L>>): LocalizedSkeletonPartialDateTime<L> {
-    return LocalizedSkeletonPartialDateTimeImpl(this, skeletons.sum())
+fun <L : Local.WithYear> L.localized(yearSkeleton: YearSkeleton): LocalizedSkeletonPartialDateTime<L> {
+    return LocalizedSkeletonPartialDateTimeImpl(this, DateTimeSkeleton(yearSkeleton), timezoneSkeleton = null)
 }
 
-fun <L : Local> L.localized(
-    firstSkeleton: LocalSkeleton<L>,
-    vararg otherSkeletons: LocalSkeleton<L>,
-): LocalizedSkeletonPartialDateTime<L> {
-    return LocalizedSkeletonPartialDateTimeImpl(this, (listOf(firstSkeleton) + otherSkeletons).toList().sum())
+fun <L : Local.WithYearMonth> L.localized(yearSkeleton: YearSkeleton?, monthSkeleton: MonthSkeleton?): LocalizedSkeletonPartialDateTime<L> {
+    return LocalizedSkeletonPartialDateTimeImpl(this, DateTimeSkeleton(yearSkeleton, monthSkeleton), timezoneSkeleton = null)
+}
+
+fun <L : Local.WithDate> L.localized(skeleton: DateSkeleton): LocalizedSkeletonPartialDateTime<L> {
+    return LocalizedSkeletonPartialDateTimeImpl(this, DateTimeSkeleton(skeleton, time = null), timezoneSkeleton = null)
+}
+
+fun <L : Local.WithDateTime> L.localized(skeleton: DateTimeSkeleton): LocalizedSkeletonPartialDateTime<L> {
+    return LocalizedSkeletonPartialDateTimeImpl(this, skeleton, timezoneSkeleton = null)
+}
+
+fun <L : Local.WithDateTime> L.localized(dateSkeleton: DateSkeleton?, timeSkeleton: TimeSkeleton?): LocalizedSkeletonPartialDateTime<L> {
+    return localized(DateTimeSkeleton(dateSkeleton, timeSkeleton))
 }
 
 /**
@@ -63,8 +72,7 @@ fun Zoned.localized(
     timezoneSkeleton: TimezoneSkeleton,
     localSkeletons: (Local) -> LocalizedSkeletonPartialDateTime<Local>,
 ): LocalizedSkeletonPartialDateTime<Zoned> {
-    val list = listOf(localSkeletons(this.local).skeleton, timezoneSkeleton).sum()
-    return LocalizedSkeletonPartialDateTimeImpl(this, list)
+    return LocalizedSkeletonPartialDateTimeImpl(this, localSkeletons(this.local).dateTimeSkeleton, timezoneSkeleton)
 }
 
 /**

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/PartialDateTime.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/PartialDateTime.kt
@@ -13,7 +13,7 @@ fun PartialDateTime.localizedFull(): LocalizedSkeletonPartialDateTime<PartialDat
                 is PartialDateTime.Local.Year -> it.localized(YearSkeleton.NUMERIC)
                 is PartialDateTime.Local.YearMonth -> it.localized(YearSkeleton.NUMERIC, MonthSkeleton.WIDE)
                 is PartialDateTime.Local.Date -> it.localized(Skeletons.FULL_DATE)
-                is PartialDateTime.Local.DateTime -> it.localized(Skeletons.FULL_DATE + TimeSkeleton.MINUTES)
+                is PartialDateTime.Local.DateTime -> it.localized(Skeletons.FULL_DATE, TimeSkeleton.MINUTES)
             }
         },
     )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/Skeletons.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/Skeletons.kt
@@ -1,6 +1,6 @@
 package io.github.couchtracker.intl.datetime
 
-import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime
+import kotlin.collections.setOfNotNull
 
 /**
  * Represents a Unicode CLDR Skeleton.
@@ -16,16 +16,9 @@ interface Skeleton {
 }
 
 /**
- * A specialization of [Skeleton], which has a type [L] that must be a subtype of [PartialDateTime.Local].
- *
- * This is helpful to know which component is required for this skeleton to have a meaning.
- */
-interface LocalSkeleton<in L : PartialDateTime.Local> : Skeleton
-
-/**
  * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-year).
  */
-enum class YearSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithYear> {
+enum class YearSkeleton(override val value: String) : Skeleton {
 
     /**
      * Two low-order digits of the year, e.g. `95` for 1995
@@ -41,7 +34,7 @@ enum class YearSkeleton(override val value: String) : LocalSkeleton<PartialDateT
 /**
  * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-month).
  */
-enum class MonthSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithMonth> {
+enum class MonthSkeleton(override val value: String) : Skeleton {
     /**
      * Numeric, zero-padded month, e.g. `02` for February
      */
@@ -71,7 +64,7 @@ enum class MonthSkeleton(override val value: String) : LocalSkeleton<PartialDate
 /**
  * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-day).
  */
-enum class DayOfMonthSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithDay> {
+enum class DayOfMonthSkeleton(override val value: String) : Skeleton {
     /**
      * Numeric, zero-padded day-of-month, e.g. `09`
      */
@@ -86,7 +79,7 @@ enum class DayOfMonthSkeleton(override val value: String) : LocalSkeleton<Partia
 /**
  * See [Unicode docs](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-weekday).
  */
-enum class DayOfWeekSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithDay> {
+enum class DayOfWeekSkeleton(override val value: String) : Skeleton {
     /**
      * Narrow day-of-week name, e.g. `T` for Tuesday
      */
@@ -114,7 +107,7 @@ enum class DayOfWeekSkeleton(override val value: String) : LocalSkeleton<Partial
  *  - [minute](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-minute)
  *  - [second](https://www.unicode.org/reports/tr35/tr35-dates.html#dfst-second)
  */
-enum class TimeSkeleton(override val value: String) : LocalSkeleton<PartialDateTime.Local.WithTime> {
+enum class TimeSkeleton(override val value: String) : Skeleton {
     /**
      * Time with hours and minutes, zero-padded. 12/24 hours is locale-dependent
      */
@@ -146,7 +139,45 @@ enum class TimezoneSkeleton(override val value: String) : Skeleton {
     SPECIFIC_NON_LOCATION("zzzz"),
 }
 
-private class PlusSkeleton(skeletons: Collection<Skeleton>) : Skeleton {
+interface SkeletonGroup : Skeleton {
+    val skeletons: Collection<Skeleton>
+
+    override val value: String
+        get() = skeletons.joinToString(separator = " ") { it.value }
+}
+
+data class DateSkeleton(
+    val year: YearSkeleton? = null,
+    val month: MonthSkeleton? = null,
+    val dayOfMonth: DayOfMonthSkeleton? = null,
+    val dayOfWeekSkeleton: DayOfWeekSkeleton? = null,
+) : SkeletonGroup {
+    init {
+        require(year != null || month != null || dayOfMonth != null || dayOfWeekSkeleton != null) { "At least one skeleton must be set" }
+    }
+
+    override val skeletons: Set<Skeleton>
+        get() = setOfNotNull(year, month, dayOfMonth, dayOfWeekSkeleton)
+}
+
+data class DateTimeSkeleton(
+    val date: DateSkeleton?,
+    val time: TimeSkeleton?,
+) : SkeletonGroup {
+
+    override val skeletons: Set<Skeleton>
+        get() = date?.skeletons.orEmpty() + setOfNotNull(time)
+
+    constructor(
+        year: YearSkeleton? = null,
+        month: MonthSkeleton? = null,
+        dayOfMonth: DayOfMonthSkeleton? = null,
+        dayOfWeek: DayOfWeekSkeleton? = null,
+        time: TimeSkeleton? = null,
+    ) : this(DateSkeleton(year, month, dayOfMonth, dayOfWeek), time)
+}
+
+private class PlusSkeleton(override val skeletons: Collection<Skeleton>) : SkeletonGroup {
     override val value = skeletons.joinToString(separator = " ") { it.value }
 }
 
@@ -155,12 +186,9 @@ private class PlusSkeleton(skeletons: Collection<Skeleton>) : Skeleton {
  */
 fun Collection<Skeleton>.sum(): Skeleton = PlusSkeleton(this)
 
-typealias DateSkeleton = LocalSkeleton<PartialDateTime.Local.WithDate>
-
 object Skeletons {
-    val NUMERIC_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.NUMERIC, DayOfMonthSkeleton.NUMERIC)
-    val MEDIUM_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.ABBREVIATED, DayOfMonthSkeleton.NUMERIC)
-    val LONG_DATE =
-        listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.WIDE, DayOfMonthSkeleton.NUMERIC, DayOfWeekSkeleton.ABBREVIATED)
-    val FULL_DATE = listOf<DateSkeleton>(YearSkeleton.NUMERIC, MonthSkeleton.WIDE, DayOfMonthSkeleton.NUMERIC, DayOfWeekSkeleton.WIDE)
+    val NUMERIC_DATE = DateSkeleton(YearSkeleton.NUMERIC, MonthSkeleton.NUMERIC, DayOfMonthSkeleton.NUMERIC)
+    val MEDIUM_DATE = DateSkeleton(YearSkeleton.NUMERIC, MonthSkeleton.ABBREVIATED, DayOfMonthSkeleton.NUMERIC)
+    val LONG_DATE = DateSkeleton(YearSkeleton.NUMERIC, MonthSkeleton.WIDE, DayOfMonthSkeleton.NUMERIC, DayOfWeekSkeleton.ABBREVIATED)
+    val FULL_DATE = DateSkeleton(YearSkeleton.NUMERIC, MonthSkeleton.WIDE, DayOfMonthSkeleton.NUMERIC, DayOfWeekSkeleton.WIDE)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
@@ -20,6 +20,7 @@ import app.moviebase.tmdb.model.TmdbEpisode
 import coil3.compose.AsyncImage
 import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime
+import io.github.couchtracker.intl.datetime.DateSkeleton
 import io.github.couchtracker.intl.datetime.DayOfMonthSkeleton
 import io.github.couchtracker.intl.datetime.DayOfWeekSkeleton
 import io.github.couchtracker.intl.datetime.MonthSkeleton
@@ -109,10 +110,12 @@ data class EpisodeListItemModel(
                 firstAirDate = episode.airDate?.let {
                     PartialDateTime.Local.Date(it)
                         .localized(
-                            YearSkeleton.NUMERIC,
-                            MonthSkeleton.ABBREVIATED,
-                            DayOfMonthSkeleton.NUMERIC,
-                            DayOfWeekSkeleton.ABBREVIATED,
+                            DateSkeleton(
+                                year = YearSkeleton.NUMERIC,
+                                month = MonthSkeleton.ABBREVIATED,
+                                dayOfMonth = DayOfMonthSkeleton.NUMERIC,
+                                dayOfWeekSkeleton = DayOfWeekSkeleton.ABBREVIATED,
+                            ),
                         )
                         .localize()
                 },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ProfileSwitcherDialog.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ProfileSwitcherDialog.kt
@@ -30,9 +30,9 @@ import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.LocalProfilesContext
 import io.github.couchtracker.R
 import io.github.couchtracker.db.app.ProfileInfo
+import io.github.couchtracker.intl.datetime.DateTimeSkeleton
 import io.github.couchtracker.intl.datetime.Skeletons
 import io.github.couchtracker.intl.datetime.TimeSkeleton
-import io.github.couchtracker.intl.datetime.sum
 import io.github.couchtracker.intl.formatDateTimeSkeleton
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.ui.screens.settings.ProfilesSettingsScreen
@@ -122,7 +122,8 @@ fun ProfileInfo.formattedLastModified(): String {
         else -> formatDateTimeSkeleton(
             instant = lastModified,
             timeZone = TimeZone.currentSystemDefault(),
-            skeleton = (Skeletons.MEDIUM_DATE + TimeSkeleton.SECONDS).sum(),
+            dateTimeSkeleton = DateTimeSkeleton(Skeletons.MEDIUM_DATE, TimeSkeleton.SECONDS),
+            timezoneSkeleton = null,
             locale = Locale.current.platformLocale.toULocale(),
         )
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreenViewModelHelper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreenViewModelHelper.kt
@@ -6,6 +6,7 @@ import io.github.couchtracker.R
 import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
 import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime
+import io.github.couchtracker.intl.datetime.DateSkeleton
 import io.github.couchtracker.intl.datetime.DayOfMonthSkeleton
 import io.github.couchtracker.intl.datetime.DayOfWeekSkeleton
 import io.github.couchtracker.intl.datetime.MonthSkeleton
@@ -102,10 +103,12 @@ class EpisodesScreenViewModelHelper(
                             firstAirDate = episode.airDate?.let {
                                 PartialDateTime.Local.Date(it)
                                     .localized(
-                                        YearSkeleton.NUMERIC,
-                                        MonthSkeleton.WIDE,
-                                        DayOfMonthSkeleton.NUMERIC,
-                                        DayOfWeekSkeleton.WIDE,
+                                        DateSkeleton(
+                                            YearSkeleton.NUMERIC,
+                                            MonthSkeleton.WIDE,
+                                            DayOfMonthSkeleton.NUMERIC,
+                                            DayOfWeekSkeleton.WIDE,
+                                        ),
                                     )
                                     .localize()
                             },

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/DateTimeSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/DateTimeSection.kt
@@ -256,10 +256,10 @@ private fun CustomDateTimeRow(
         is PartialDateTime.Local.Year -> localDate.localized(YearSkeleton.NUMERIC).string()
         is PartialDateTime.Local.YearMonth -> localDate.localized(YearSkeleton.NUMERIC, MonthSkeleton.WIDE).string()
         is PartialDateTime.Local.Date -> localDate.localized(Skeletons.MEDIUM_DATE).string()
-        is PartialDateTime.Local.DateTime -> localDate.localized(Skeletons.MEDIUM_DATE).string()
+        is PartialDateTime.Local.DateTime -> localDate.localized(Skeletons.MEDIUM_DATE, timeSkeleton = null).string()
     }
     val timeString = if (localDate is PartialDateTime.Local.DateTime) {
-        localDate.localized(TimeSkeleton.MINUTES).string()
+        localDate.localized(dateSkeleton = null, timeSkeleton = TimeSkeleton.MINUTES).string()
     } else {
         null
     }


### PR DESCRIPTION
ICU has an edge case when we format a date without a time but with a timezone.

The bug triggers within `DateTimePatternGenerator`, when the month pattern length is 3 or 4 (i.e. `MMM` or `MMMM`). This triggers a change in which format style to use to join the date part and the time part.

Given that in our edge case the time part consists only of a timezone, it would produce a string like `May 2026 at Europe/Rome`. The `at` part is supposed to be used when there is a time as well, as in many languages it is quite explicit (e.g. in Italian it is `alle ore`, literally `at the time`).

Hence, for this edge case, the function now only selects the best pattern for the date component, formats it and then adds the timezone using `combineLiteralDateAndTimePattern`, ensuring the date format style is always `SHORT`, which will produce something more generic (like a comma in English) and less time-oriented.

For this reason, the various skeletons had to be refactored in a way that allows `formatDateTimeSkeleton` to tell the timezone portion of the skeleton apart from the rest. This had the added benefit of removing the tight coupling the skeletons had with `PartialDateTime`.
