### PR TITLE
Implement up next section

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
@@ -18,7 +18,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import app.moviebase.tmdb.model.TmdbEpisode
 import coil3.compose.AsyncImage
+import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
 import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime
 import io.github.couchtracker.intl.datetime.DateSkeleton
 import io.github.couchtracker.intl.datetime.DayOfMonthSkeleton
@@ -27,7 +30,10 @@ import io.github.couchtracker.intl.datetime.MonthSkeleton
 import io.github.couchtracker.intl.datetime.YearSkeleton
 import io.github.couchtracker.intl.datetime.format
 import io.github.couchtracker.intl.datetime.localized
+import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbRating
+import io.github.couchtracker.tmdb.TmdbSeasonId
+import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.runtime
 import io.github.couchtracker.tmdb.toImageModelWithPlaceholder
 import io.github.couchtracker.ui.ImageModel
@@ -35,6 +41,7 @@ import io.github.couchtracker.ui.ItemPosition
 import io.github.couchtracker.ui.ListItemShapes
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.rememberPlaceholderPainter
+import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
 
 private val STILL_WIDTH = 112.dp
 private val STILL_HEIGHT = 64.dp
@@ -43,11 +50,13 @@ private val STILL_HEIGHT = 64.dp
 @Composable
 fun EpisodeListItem(
     episode: EpisodeListItemModel,
-    onClick: () -> Unit = {},
     position: ItemPosition,
 ) {
+    val navController = LocalNavController.current
     ListItem(
-        onClick = onClick,
+        onClick = {
+            navController.navigateToEpisode(episode.episodeId)
+        },
         leadingContent = {
             Surface(shape = MaterialTheme.shapes.small) {
                 AsyncImage(
@@ -93,6 +102,7 @@ fun EpisodeListItem(
 }
 
 data class EpisodeListItemModel(
+    val episodeId: ExternalEpisodeId,
     val name: String?,
     val number: String,
     val backdrop: ImageModel?,
@@ -102,22 +112,22 @@ data class EpisodeListItemModel(
 ) {
 
     companion object {
-        suspend fun fromTmdbEpisode(context: Context, episode: TmdbEpisode): EpisodeListItemModel {
+        suspend fun fromTmdbEpisode(context: Context, show: TmdbShowId, episode: TmdbEpisode): EpisodeListItemModel {
+            val id = TmdbExternalEpisodeId(TmdbEpisodeId(TmdbSeasonId(show, episode.seasonNumber), episode.episodeNumber))
             return EpisodeListItemModel(
+                episodeId = id,
                 name = episode.name,
                 number = context.getString(R.string.episode_x, episode.episodeNumber),
                 backdrop = episode.backdropImage?.toImageModelWithPlaceholder(),
                 firstAirDate = episode.airDate?.let {
-                    PartialDateTime.Local.Date(it)
-                        .localized(
-                            DateSkeleton(
-                                year = YearSkeleton.NUMERIC,
-                                month = MonthSkeleton.ABBREVIATED,
-                                dayOfMonth = DayOfMonthSkeleton.NUMERIC,
-                                dayOfWeekSkeleton = DayOfWeekSkeleton.ABBREVIATED,
-                            ),
-                        )
-                        .localize()
+                    PartialDateTime.Local.Date(it).localized(
+                        DateSkeleton(
+                            year = YearSkeleton.NUMERIC,
+                            month = MonthSkeleton.ABBREVIATED,
+                            dayOfMonth = DayOfMonthSkeleton.NUMERIC,
+                            dayOfWeekSkeleton = DayOfWeekSkeleton.ABBREVIATED,
+                        ),
+                    ).localize()
                 },
                 runtime = episode.runtime()?.format(),
                 tmdbRating = TmdbRating.ofOrNull(episode.voteAverage, episode.voteCount),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MessageComposable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/MessageComposable.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Construction
 import androidx.compose.material.icons.filled.Error
@@ -39,10 +40,11 @@ fun MessageComposable(
     ) {
         Icon(icon, contentDescription = null, Modifier.size(40.dp))
         Spacer(Modifier.height(24.dp))
-        Text(message, textAlign = TextAlign.Center, style = MaterialTheme.typography.headlineSmall)
+        val textModifier = Modifier.widthIn(max = 320.dp)
+        Text(message, textAlign = TextAlign.Center, style = MaterialTheme.typography.headlineSmall, modifier = textModifier)
         if (details != null) {
             Spacer(Modifier.height(24.dp))
-            Text(details, textAlign = TextAlign.Center, style = MaterialTheme.typography.bodyMedium)
+            Text(details, textAlign = TextAlign.Center, style = MaterialTheme.typography.bodyMedium, modifier = textModifier)
         }
         content()
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
@@ -1,0 +1,123 @@
+package io.github.couchtracker.ui.components
+
+import android.content.Context
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import app.moviebase.tmdb.model.TmdbEpisode
+import coil3.compose.AsyncImage
+import io.github.couchtracker.LocalNavController
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.ExternalShowId
+import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.TmdbExternalShowId
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
+import io.github.couchtracker.tmdb.BaseTmdbShow
+import io.github.couchtracker.tmdb.TmdbEpisodeId
+import io.github.couchtracker.tmdb.TmdbSeasonId
+import io.github.couchtracker.ui.ImageModel
+import io.github.couchtracker.ui.ItemPosition
+import io.github.couchtracker.ui.ListItemShapes
+import io.github.couchtracker.ui.PlaceholdersDefaults
+import io.github.couchtracker.ui.rememberPlaceholderPainter
+import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
+import io.github.couchtracker.ui.screens.show.navigateToShow
+import io.github.couchtracker.ui.seasonEpisodeNumberToString
+import io.github.couchtracker.ui.toImageModel
+
+private val POSTER_HEIGHT = 64.dp
+private val POSTER_WIDTH = POSTER_HEIGHT * 2 / 3
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun UpNextListItem(
+    upNext: UpNextListItemModel,
+    position: ItemPosition,
+) {
+    val navController = LocalNavController.current
+    ListItem(
+        onClick = {
+            navController.navigateToEpisode(upNext.episodeId)
+        },
+        leadingContent = {
+            Surface(shape = MaterialTheme.shapes.small) {
+                AsyncImage(
+                    with(LocalDensity.current) {
+                        upNext.posterModel?.getCoilModel(POSTER_WIDTH.roundToPx(), POSTER_HEIGHT.roundToPx())
+                    },
+                    modifier = Modifier
+                        .size(POSTER_WIDTH, POSTER_HEIGHT)
+                        .clickable {
+                            navController.navigateToShow(upNext.showId, preloadData = upNext.showPreloadData)
+                        },
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    fallback = rememberPlaceholderPainter(PlaceholdersDefaults.SHOW.icon, isError = false),
+                    error = rememberPlaceholderPainter(PlaceholdersDefaults.SHOW.icon, isError = true),
+                )
+            }
+        },
+        overlineContent = {
+            Text(upNext.episodeLabel)
+        },
+        content = {
+            if (upNext.showName != null) {
+                Text(upNext.showName)
+            } else {
+                Text("Ops")
+            }
+        },
+        trailingContent = {
+            Icon(Icons.Default.RadioButtonUnchecked, contentDescription = null)
+        },
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp),
+        shapes = ListItemShapes(position),
+    )
+}
+
+data class UpNextListItemModel(
+    val showId: ExternalShowId,
+    val watchSession: WatchedEpisodeSessionWrapper?,
+    val showPreloadData: BaseTmdbShow,
+    val episodeId: ExternalEpisodeId,
+    val posterModel: ImageModel?,
+    val showName: String?,
+    val episodeLabel: String,
+) {
+
+    companion object {
+
+        fun withShowData(
+            context: Context,
+            showPreloadData: BaseTmdbShow,
+            watchSession: WatchedEpisodeSessionWrapper?,
+            episode: TmdbEpisode,
+        ): UpNextListItemModel {
+            val showId = showPreloadData.key.id
+            val seasonId = TmdbSeasonId(showId, episode.seasonNumber)
+            val episodeId = TmdbExternalEpisodeId(TmdbEpisodeId(seasonId, episode.episodeNumber))
+            return UpNextListItemModel(
+                showId = TmdbExternalShowId(showId),
+                watchSession = watchSession,
+                episodeId = episodeId,
+                showName = showPreloadData.name,
+                showPreloadData = showPreloadData,
+                episodeLabel = seasonEpisodeNumberToString(context, episode.seasonNumber, episode.episodeNumber),
+                posterModel = showPreloadData.poster?.toImageModel(),
+            )
+        }
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreen.kt
@@ -141,7 +141,7 @@ private fun EpisodesScreenContent(
         onRetry = onRetry,
     )
     val pagerState = rememberPagerState(
-        initialPage = seasonDetails.episodes.indexOfFirst { it.externalId == initialEpisode },
+        initialPage = seasonDetails.episodes.indexOfFirst { it.externalId == initialEpisode }.coerceAtLeast(0),
         pageCount = { seasonDetails.episodes.size },
     )
     val selectedEpisode = seasonDetails.episodes[pagerState.currentPage]

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreenViewModel.kt
@@ -2,9 +2,10 @@ package io.github.couchtracker.ui.screens.episodes
 
 import android.app.Application
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.remember
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.couchtracker.tmdb.TmdbEpisodeId
@@ -17,7 +18,9 @@ import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.collectAsLoadableInScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlin.coroutines.EmptyCoroutineContext
 
 class EpisodesScreenViewModel(
     application: Application,
@@ -46,7 +49,7 @@ class EpisodesScreenViewModel(
 
     class EpisodeViewModel(
         application: Application,
-        scope: CoroutineScope,
+        val scope: CoroutineScope,
         episodeId: TmdbEpisodeId,
         retryContext: TmdbFlowRetryContext,
     ) {
@@ -64,12 +67,19 @@ class EpisodesScreenViewModel(
 
     @Composable
     fun viewModelForEpisode(episode: TmdbEpisodeId): EpisodeViewModel {
-        return EpisodeViewModel(
-            getApplication(),
-            rememberCoroutineScope(),
-            episode,
-            retryContext,
-        ).also { childModels.put(it) }
+        val model = remember(episode) {
+            EpisodeViewModel(
+                getApplication(),
+                CoroutineScope(EmptyCoroutineContext),
+                episode,
+                retryContext,
+            )
+        }
+        DisposableEffect(model.scope) {
+            onDispose { model.scope.cancel() }
+        }
+        childModels.put(model)
+        return model
     }
 
     fun retryAll() {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.plus
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -20,18 +21,20 @@ import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.paging.cachedIn
 import androidx.paging.compose.collectAsLazyPagingItems
 import app.moviebase.tmdb.model.TmdbTimeWindow
 import io.github.couchtracker.R
-import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.tmdb.tmdbPager
+import io.github.couchtracker.ui.components.DefaultErrorScreen
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.ui.components.MessageComposable
 import io.github.couchtracker.ui.components.OverviewScreenComponents
@@ -39,12 +42,14 @@ import io.github.couchtracker.ui.components.PaginatedGrid
 import io.github.couchtracker.ui.components.PortraitComposableDefaults
 import io.github.couchtracker.ui.components.ShowPortrait
 import io.github.couchtracker.ui.components.ShowPortraitModel
+import io.github.couchtracker.ui.components.UpNextListItem
 import io.github.couchtracker.ui.components.WipMessageComposable
 import io.github.couchtracker.ui.components.toShowPortraitModels
-import io.github.couchtracker.ui.screens.main.ShowSectionViewModel.BookmarkedShowData
+import io.github.couchtracker.ui.itemsWithPosition
+import io.github.couchtracker.ui.screens.main.ShowSectionViewModel.UpNextEntry
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
-import io.github.couchtracker.utils.error.CouchTrackerResult
+import io.github.couchtracker.utils.error.CouchTrackerLoadable
 import io.github.couchtracker.utils.map
 import io.github.couchtracker.utils.removeDuplicates
 import io.github.couchtracker.utils.settings.get
@@ -63,9 +68,10 @@ fun ShowSection(
     // TODO: open up next as a first tab
     val pagerState = rememberPagerState(initialPage = ShowTab.WATCHLIST.ordinal) { ShowTab.entries.size }
     val snackbarHostState = remember { SnackbarHostState() }
+    val modelErrors by viewModel.allErrors().collectAsStateWithLifecycle(emptyList())
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { viewModel.allErrors },
+        errors = { modelErrors },
         onRetry = { viewModel.retryAll() },
     )
     MainSection(
@@ -95,11 +101,9 @@ fun ShowSection(
                         emptyMessage = R.string.tab_shows_following_empty.str(),
                         emptyDescription = R.string.tab_shows_following_empty_description.str(),
                     )
-                    ShowTab.UP_NEXT -> WipMessageComposable(
-                        gitHubIssueId = 127,
-                        description = "" +
-                            "- For each active watch session of a bookmarked show, the next unwatched episode\n" +
-                            "- For each bookmarked show, without any watch sessions, the pilot",
+                    ShowTab.UP_NEXT -> UpNext(
+                        entries = viewModel.upNext,
+                        onRetry = { viewModel.retryAll() },
                     )
                     ShowTab.EXPLORE -> ShowListComposable(viewModel.exploreState)
                     ShowTab.CALENDAR -> WipMessageComposable(
@@ -114,7 +118,7 @@ fun ShowSection(
 
 @Composable
 private fun BookmarkedShowGrid(
-    shows: Loadable<List<Pair<ExternalShowId, CouchTrackerResult<BookmarkedShowData>>>>,
+    shows: Loadable<List<ShowSectionViewModel.MaybeBookmarkedShowData>>,
     emptyMessage: String,
     emptyDescription: String,
 ) {
@@ -134,11 +138,11 @@ private fun BookmarkedShowGrid(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                items(shows) { (showId, bookmarkedShow) ->
+                items(shows) { bookmarkedShowData ->
                     ShowPortrait(
                         modifier = Modifier.fillMaxWidth(),
-                        showId = showId,
-                        showResult = bookmarkedShow.map { data ->
+                        showId = bookmarkedShowData.showId,
+                        showResult = bookmarkedShowData.data.map { data ->
                             data.portraitModel.copy(
                                 downloadState = when (val seasons = data.seasons) {
                                     is Loadable.Loaded -> when (seasons.value) {
@@ -150,6 +154,41 @@ private fun BookmarkedShowGrid(
                             )
                         },
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpNext(
+    entries: CouchTrackerLoadable<List<UpNextEntry>>,
+    onRetry: () -> Unit,
+) {
+    LoadableScreen(
+        entries,
+        onError = { apiError ->
+            DefaultErrorScreen(
+                error = apiError,
+                retry = onRetry,
+            )
+        },
+    ) { entries ->
+        if (entries.isEmpty()) {
+            MessageComposable(
+                modifier = Modifier.fillMaxSize(),
+                icon = Icons.Default.BookmarkBorder,
+                message = R.string.tab_shows_up_next_empty.str(),
+                details = R.string.tab_shows_up_next_empty_description.str(),
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(8.dp) + PaddingValues(bottom = OverviewScreenComponents.LIST_BOTTOM_SPACE),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                itemsWithPosition(entries) { position, upNextEntry ->
+                    UpNextListItem(upNextEntry.model, position)
                 }
             }
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
@@ -1,22 +1,28 @@
 package io.github.couchtracker.ui.screens.main
 
 import android.app.Application
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
+import app.moviebase.tmdb.model.TmdbEpisode
 import app.moviebase.tmdb.model.TmdbSeasonDetail
 import io.github.couchtracker.db.app.ProfilesInfo
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalShowId
 import io.github.couchtracker.db.profile.externalids.UnknownExternalShowId
+import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
+import io.github.couchtracker.tmdb.BaseTmdbShow
+import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbLanguages
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.details
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
+import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.components.ShowPortraitModel
+import io.github.couchtracker.ui.components.UpNextListItemModel
 import io.github.couchtracker.ui.components.toShowPortraitModels
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
@@ -24,6 +30,7 @@ import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.combineResults
 import io.github.couchtracker.utils.error.ApiLoadable
 import io.github.couchtracker.utils.error.CouchTrackerError
+import io.github.couchtracker.utils.error.CouchTrackerLoadable
 import io.github.couchtracker.utils.error.CouchTrackerResult
 import io.github.couchtracker.utils.error.UnsupportedItemError
 import io.github.couchtracker.utils.injectBrokenItems
@@ -40,6 +47,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.transform
@@ -47,20 +55,23 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.koin.mp.KoinPlatform
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ShowSectionViewModel(application: Application) : AndroidViewModel(application) {
     private val retryContext = tmdbFlowRetryContext()
 
     val exploreState = ShowExploreTabState(application, viewModelScope)
 
-    private data class PartitionedBookmarkedShows(
-        val watchlist: Set<ExternalShowId>,
-        val following: Set<ExternalShowId>,
+    private data class BookmarkedShows(
+        val bookmarkedShows: Set<ExternalShowId>,
+        val watchSessions: Map<ExternalShowId, List<WatchedEpisodeSessionWrapper>>,
     )
 
     @Suppress("EqualsOrHashCode")
     data class BookmarkedShowData(
-        val showId: ExternalShowId,
+        val baseShowData: BaseTmdbShow,
+        val watchSessions: List<WatchedEpisodeSessionWrapper>,
         val portraitModel: ShowPortraitModel,
+        // TODO: I should probably keep less data in RAM than literally everything
         val seasons: ApiLoadable<List<TmdbSeasonDetail>>,
     ) {
         // Computing the hashcode of this class is expensive.
@@ -69,49 +80,84 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         override fun hashCode() = cachedHashCode
     }
 
-    private val bookmarks: Flow<PartitionedBookmarkedShows> = KoinPlatform.getKoin().get<Flow<ProfilesInfo>>()
-        .mapNotNull { profilesInfo ->
-            val fullData = profilesInfo.currentFullData.resultValueOrNull()
-            if (fullData != null) {
-                val bookmarkedShows = fullData.bookmarkedShows.keys.injectBrokenItems()
-                val (following, watchlist) = bookmarkedShows.partition { showId ->
-                    fullData.watchedEpisodeSessions[showId].orEmpty().any { it.isActive }
+    data class MaybeBookmarkedShowData(
+        val showId: ExternalShowId,
+        val watchSessions: List<WatchedEpisodeSessionWrapper>,
+        val data: CouchTrackerResult<BookmarkedShowData>,
+    )
+
+    data class UpNextEntry(
+        val showId: ExternalShowId,
+        val watchSession: WatchedEpisodeSessionWrapper?,
+        val model: UpNextListItemModel,
+    )
+
+    private val bookmarks: Flow<Loadable<List<MaybeBookmarkedShowData>>> =
+        KoinPlatform.getKoin().get<Flow<ProfilesInfo>>()
+            .mapNotNull { profilesInfo ->
+                val fullData = profilesInfo.currentFullData.resultValueOrNull()
+                if (fullData != null) {
+                    BookmarkedShows(
+                        bookmarkedShows = fullData.bookmarkedShows.keys.injectBrokenItems(),
+                        watchSessions = fullData.watchedEpisodeSessions,
+                    )
+                } else {
+                    null
                 }
-                PartitionedBookmarkedShows(
-                    watchlist = watchlist.toSet(),
-                    following = following.toSet(),
-                )
-            } else {
-                null
+            }
+            .distinctUntilChanged()
+            .withShowData()
+            .distinctUntilChanged()
+            .shareIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, 1)
+
+    val watchlist: Loadable<List<MaybeBookmarkedShowData>> by bookmarks.mapLatest { bookmarks ->
+        bookmarks.map { bookmarks ->
+            bookmarks.filter { bookmarkedShowData -> bookmarkedShowData.watchSessions.none { it.isActive } }
+        }
+    }.collectAsLoadable("shows-watchlist")
+
+    val following: Loadable<List<MaybeBookmarkedShowData>> by bookmarks.mapLatest { bookmarks ->
+        bookmarks.map { bookmarks ->
+            bookmarks.filter { bookmarkedShowData -> bookmarkedShowData.watchSessions.any { it.isActive } }
+        }
+    }.collectAsLoadable("shows-following")
+
+    val upNext: CouchTrackerLoadable<List<UpNextEntry>> by bookmarks.flatMapLatest { bookmarks ->
+        when (bookmarks) {
+            Loadable.Loading -> flowOf(Loadable.Loading)
+            is Loadable.Loaded -> {
+                val allFlows = bookmarks.value.flatMap { bookmarkedShowData ->
+                    bookmarkedShowData.upNextEntries()
+                }
+                combine(allFlows) { it.toList().mergeUpNextEntries() }
             }
         }
-        .distinctUntilChanged()
-        .shareIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, 1)
+    }.collectAsLoadable("shows-up-next")
 
-    val watchlist: Loadable<List<Pair<ExternalShowId, CouchTrackerResult<BookmarkedShowData>>>> by flowDetailForShows(
-        bookmarks.map { it.watchlist },
-    ).collectAsLoadable("shows-watchlist")
-
-    val following: Loadable<List<Pair<ExternalShowId, CouchTrackerResult<BookmarkedShowData>>>> by flowDetailForShows(
-        bookmarks.map { it.following },
-    ).collectAsLoadable("shows-following")
-
-    val allErrors: List<CouchTrackerError> by derivedStateOf {
-        watchlist.allErrors() + following.allErrors()
+    fun allErrors(): Flow<List<CouchTrackerError>> {
+        // Note: all errors in this model originate from `bookmarks`, so I don't need to check errors of individual fields
+        return bookmarks.map { bookmarks ->
+            when (bookmarks) {
+                Loadable.Loading -> emptyList()
+                is Loadable.Loaded -> bookmarks.value.mapNotNull { bookmarkedShowData ->
+                    when (bookmarkedShowData.data) {
+                        is Result.Error -> bookmarkedShowData.data.error
+                        is Result.Value -> bookmarkedShowData.data.value.seasons.resultErrorOrNull()
+                    }
+                }
+            }
+        }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun flowDetailForShows(
-        shows: Flow<Collection<ExternalShowId>>,
-    ): Flow<Loadable<List<Pair<ExternalShowId, CouchTrackerResult<BookmarkedShowData>>>>> {
+    private fun Flow<BookmarkedShows>.withShowData(): Flow<Loadable<List<MaybeBookmarkedShowData>>> {
         return retryContext { languages ->
-            shows.flatMapLatest { shows ->
-                if (shows.isEmpty()) {
+            flatMapLatest { bookmarkedData ->
+                if (bookmarkedData.bookmarkedShows.isEmpty()) {
                     flowOf(emptyList())
                 } else {
                     combine(
-                        flows = shows.map { showId ->
-                            flowDetailForShow(showId, languages)
+                        flows = bookmarkedData.bookmarkedShows.map { showId ->
+                            flowDetailForShow(showId, bookmarkedData.watchSessions[showId].orEmpty(), languages)
                         },
                     ) { it.toList() }
                 }
@@ -121,30 +167,32 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
 
     private fun flowDetailForShow(
         showId: ExternalShowId,
+        watchSessions: List<WatchedEpisodeSessionWrapper>,
         languages: TmdbLanguages,
-    ): Flow<Pair<ExternalShowId, CouchTrackerResult<BookmarkedShowData>>> {
+    ): Flow<MaybeBookmarkedShowData> {
         val tmdbShowId: TmdbShowId = when (showId) {
             is TmdbExternalShowId -> showId.id
             is UnknownExternalShowId -> return flowOf(
-                showId to Result.Error(UnsupportedItemError(showId)),
+                MaybeBookmarkedShowData(showId, watchSessions, Result.Error(UnsupportedItemError(showId))),
             )
         }
         return tmdbShowId.details(languages.apiLanguage).transform { result ->
             val details = when (result) {
                 is Result.Error -> {
-                    emit(showId to result)
+                    emit(MaybeBookmarkedShowData(showId, watchSessions, result))
                     return@transform
                 }
                 is Result.Value -> result.value
             }
             val bookmarkedShow = Result.Value(
                 value = BookmarkedShowData(
-                    showId = showId,
+                    baseShowData = details.toBaseShow(languages.apiLanguage),
                     portraitModel = details.toShowPortraitModels(application, languages.apiLanguage),
                     seasons = Loadable.Loading,
+                    watchSessions = watchSessions,
                 ),
             )
-            emit(showId to bookmarkedShow)
+            emit(MaybeBookmarkedShowData(showId, watchSessions, bookmarkedShow))
             emitAll(
                 combine(
                     details.seasons.map {
@@ -152,25 +200,116 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                         seasonId.details(languages.apiLanguage)
                     },
                 ) { seasons ->
-                    showId to bookmarkedShow.map { data ->
-                        data.copy(
-                            seasons = Loadable.Loaded(seasons.asList().combineResults()),
-                        )
-                    }
+                    MaybeBookmarkedShowData(
+                        showId = showId,
+                        watchSessions = watchSessions,
+                        data = bookmarkedShow.map { data ->
+                            data.copy(
+                                seasons = Loadable.Loaded(seasons.asList().combineResults()),
+                            )
+                        },
+                    )
                 },
             )
         }
     }
 
-    private fun Loadable<List<Pair<ExternalShowId, CouchTrackerResult<BookmarkedShowData>>>>.allErrors(): List<CouchTrackerError> {
-        return when (this) {
-            Loadable.Loading -> emptyList()
-            is Loadable.Loaded -> value.mapNotNull { (_, bookmarkedShow) ->
-                when (bookmarkedShow) {
-                    is Result.Error -> bookmarkedShow.error
-                    is Result.Value -> bookmarkedShow.value.seasons.resultErrorOrNull()
+    private fun MaybeBookmarkedShowData.upNextEntries(): List<Flow<CouchTrackerLoadable<UpNextEntry?>>> {
+        return if (watchSessions.isEmpty()) {
+            listOf(upNextEntry(showId, null, this.data))
+        } else {
+            // Has watch sessions => one entry for each watch session
+            watchSessions.filter { it.isActive }.map { watchSession ->
+                upNextEntry(showId, watchSession, this.data)
+            }
+        }
+    }
+
+    private fun List<CouchTrackerLoadable<UpNextEntry?>>.mergeUpNextEntries(): CouchTrackerLoadable<List<UpNextEntry>> {
+        return if (isEmpty()) {
+            Loadable.value(emptyList())
+        } else if (any { it is Loadable.Loading }) {
+            Loadable.Loading
+        } else {
+            val loaded = mapNotNull { it.resultValueOrNull() }
+            if (loaded.isEmpty()) {
+                // Note: I'm just taking the first error; in principle they could be merged
+                Loadable.error(firstNotNullOf { it.resultErrorOrNull() })
+            } else {
+                Loadable.value(loaded)
+            }
+        }
+    }
+
+    private fun upNextEntry(
+        showId: ExternalShowId,
+        watchSession: WatchedEpisodeSessionWrapper?,
+        showData: CouchTrackerResult<BookmarkedShowData>,
+    ): Flow<CouchTrackerLoadable<UpNextEntry?>> {
+        val (showData, seasons) = when (showData) {
+            is Result.Error -> return flowOf(Loadable.Loaded(showData))
+            is Result.Value -> {
+                showData.value to when (showData.value.seasons) {
+                    Loadable.Loading -> return flowOf(Loadable.Loading)
+                    is Loadable.Loaded -> when (showData.value.seasons.value) {
+                        is Result.Error -> return flowOf(Loadable.Loaded(showData.value.seasons.value))
+                        is Result.Value -> showData.value.seasons.value.value
+                    }
                 }
             }
+        }
+
+        return findNextEpisodeToWatch(showData.baseShowData.key.id, watchSession, seasons).map {
+            Loadable.value(
+                if (it == null) {
+                    null
+                } else {
+                    UpNextEntry(
+                        showId = showId,
+                        watchSession = watchSession,
+                        model = UpNextListItemModel.withShowData(
+                            context = application,
+                            showPreloadData = showData.baseShowData,
+                            watchSession = watchSession,
+                            episode = it,
+                        ),
+                    )
+                },
+            )
+        }
+    }
+
+    private fun findNextEpisodeToWatch(
+        showId: TmdbShowId,
+        watchSession: WatchedEpisodeSessionWrapper?,
+        seasons: List<TmdbSeasonDetail>,
+    ): Flow<TmdbEpisode?> {
+        return if (watchSession == null) {
+            // No watch sessions => one entry with the pilot
+            flowOf(seasons.firstOrNull { it.seasonNumber > 0 }?.episodes?.firstOrNull())
+        } else {
+            // By design, I read the full profile data again here.
+            // While it could potentially create minor inconsistencies,
+            // it avoids the situation where each minor profile change causes for the whole up-next section to reload
+            KoinPlatform.getKoin().get<Flow<ProfilesInfo>>()
+                .map { profilesInfo ->
+                    val fullData = profilesInfo.currentFullData.resultValueOrNull()
+                    val watchedEpisodes: Set<ExternalEpisodeId> = fullData?.watchedEpisodesBySession[watchSession]
+                        .orEmpty()
+                        .mapTo(mutableSetOf()) { it.itemId }
+                    for (season in seasons) {
+                        if (season.seasonNumber > 0) {
+                            val seasonId = TmdbSeasonId(showId, season.seasonNumber)
+                            for (episode in season.episodes.orEmpty()) {
+                                val episodeId = TmdbEpisodeId(seasonId, episode.episodeNumber).toExternalId()
+                                if (episodeId !in watchedEpisodes) {
+                                    return@map episode
+                                }
+                            }
+                        }
+                    }
+                    null
+                }
         }
     }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.db.profile.externalids.ExternalSeasonId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalSeasonId
 import io.github.couchtracker.db.profile.externalids.UnknownExternalSeasonId
@@ -30,7 +29,6 @@ import io.github.couchtracker.ui.components.EpisodeListItem
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.ui.components.OverviewScreenComponents
 import io.github.couchtracker.ui.itemsWithPosition
-import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
 import io.github.couchtracker.utils.logCompositions
 import io.github.couchtracker.utils.mapResult
 import io.github.couchtracker.utils.resultValueOrNull
@@ -161,7 +159,6 @@ private fun OverviewScreenComponents.SeasonDetailsContent(
     viewModel: SeasonsScreenViewModel,
     seasonModel: SeasonsScreenViewModel.SeasonViewModel,
 ) {
-    val navController = LocalNavController.current
     val episodes = seasonModel.details.mapResult { it.episodes }
     LoadableScreen(
         episodes,
@@ -176,10 +173,9 @@ private fun OverviewScreenComponents.SeasonDetailsContent(
             innerPadding.plus(PaddingValues(vertical = 16.dp, horizontal = 8.dp)),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            itemsWithPosition(episodes) { position, (episodeId, episode) ->
+            itemsWithPosition(episodes) { position, episode ->
                 EpisodeListItem(
                     episode = episode,
-                    onClick = { navController.navigateToEpisode(episodeId) },
                     position = position,
                 )
             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModelHelper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModelHelper.kt
@@ -2,11 +2,8 @@ package io.github.couchtracker.ui.screens.seasons
 
 import android.app.Application
 import androidx.compose.material3.ColorScheme
-import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.ExternalSeasonId
-import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalSeasonId
-import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbFlowRetryContext
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
@@ -57,7 +54,7 @@ class SeasonsScreenViewModelHelper(
     )
 
     data class SeasonFullDetails(
-        val episodes: List<Pair<ExternalEpisodeId, EpisodeListItemModel>>,
+        val episodes: List<EpisodeListItemModel>,
     )
 
     val showDetails = retryContext { languages ->
@@ -104,8 +101,7 @@ class SeasonsScreenViewModelHelper(
                 result.map { tmdbSeasonDetails ->
                     SeasonFullDetails(
                         episodes = tmdbSeasonDetails.episodes.orEmpty().map { tmdbEpisode ->
-                            val id = TmdbExternalEpisodeId(TmdbEpisodeId(seasonId, tmdbEpisode.episodeNumber))
-                            id to EpisodeListItemModel.fromTmdbEpisode(application, tmdbEpisode)
+                            EpisodeListItemModel.fromTmdbEpisode(application, seasonId.showId, tmdbEpisode)
                         },
                     )
                 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Debug.kt
@@ -57,7 +57,7 @@ inline fun <T> logExecutionTime(logTag: String, message: String, f: () -> T): T 
 
 @Suppress("MagicNumber")
 @JvmName("injectBrokenShows")
-fun Collection<ExternalShowId>.injectBrokenItems(): Collection<ExternalShowId> {
+fun Set<ExternalShowId>.injectBrokenItems(): Set<ExternalShowId> {
     return if (INJECT_BROKEN_ITEMS) {
         this + listOf(
             TmdbExternalShowId(TmdbShowId(546_544)),

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -54,6 +54,8 @@
     <string name="tab_shows_following">Seguite</string>
     <string name="tab_shows_following_empty">Nessuna serie seguita</string>
     <string name="tab_shows_following_empty_description">"Questa sezione contiene serie TV salvate con sessioni di visioni attive"</string>
+    <string name="tab_shows_up_next_empty">Sei in pari!</string>
+    <string name="tab_shows_up_next_empty_description">Hai visto tutti gli episodi, è il momento di iniziare una nuova serie TV!</string>
     <string name="tab_shows_up_next">Prossimi</string>
     <string name="tab_shows_calendar">Calendario</string>
     <string name="tab_shows_explore">Esplora</string>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
     <string name="tab_shows_following">Following</string>
     <string name="tab_shows_following_empty">Empty following</string>
     <string name="tab_shows_following_empty_description">"This section contains bookmarked shows with active watch sessions"</string>
+    <string name="tab_shows_up_next_empty">"You're caught up!"</string>
+    <string name="tab_shows_up_next_empty_description">"You're caught up with all the episodes, time to start a new show!"</string>
     <string name="tab_shows_up_next">Up next</string>
     <string name="tab_shows_calendar">Calendar</string>
     <string name="tab_shows_explore">Explore</string>


### PR DESCRIPTION
This commit implements a basic up next section.
The data should be correct; however, the style and memory optimizations (all data for all episodes is loaded) are left as future work.

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/54339b08-e5a7-4ba3-9bc9-1973c453dc85" />

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/c63a33a4-1393-4354-89c1-381153b1ca18" />

