### PR TITLE
Improve episode list item style

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/FullProfileData.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/FullProfileData.kt
@@ -2,6 +2,7 @@ package io.github.couchtracker.db.profile
 
 import android.util.Log
 import io.github.couchtracker.db.profile.externalids.BookmarkableExternalId
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.ExternalMovieId
 import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
@@ -23,9 +24,12 @@ data class FullProfileData(
     val watchedItemDimensions: List<WatchedItemDimensionWrapper>,
 ) {
 
-    val watchedEpisodesBySession: Map<WatchedEpisodeSessionWrapper, List<WatchedItemWrapper.Episode>> = watchedItems
-        .filterIsInstance<WatchedItemWrapper.Episode>()
+    private val watchedItemsEpisode = watchedItems.filterIsInstance<WatchedItemWrapper.Episode>()
+    private val watchedItemsMovie = watchedItems.filterIsInstance<WatchedItemWrapper.Movie>()
+    val watchedEpisodesBySession: Map<WatchedEpisodeSessionWrapper, List<WatchedItemWrapper.Episode>> = watchedItemsEpisode
         .groupBy { it.session }
+    val watchedItemsByMovie: Map<ExternalMovieId, List<WatchedItemWrapper.Movie>> = watchedItemsMovie.groupBy { it.itemId }
+    val watchedItemsByEpisode: Map<ExternalEpisodeId, List<WatchedItemWrapper.Episode>> = watchedItemsEpisode.groupBy { it.itemId }
 
     val bookmarkedShows: Map<ExternalShowId, BookmarkedItem> = bookmarkedItems.filterKeysOfInstance()
     val bookmarkedMovies: Map<ExternalMovieId, BookmarkedItem> = bookmarkedItems.filterKeysOfInstance()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/FullProfileData.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/FullProfileData.kt
@@ -24,12 +24,12 @@ data class FullProfileData(
     val watchedItemDimensions: List<WatchedItemDimensionWrapper>,
 ) {
 
-    private val watchedItemsEpisode = watchedItems.filterIsInstance<WatchedItemWrapper.Episode>()
-    private val watchedItemsMovie = watchedItems.filterIsInstance<WatchedItemWrapper.Movie>()
-    val watchedEpisodesBySession: Map<WatchedEpisodeSessionWrapper, List<WatchedItemWrapper.Episode>> = watchedItemsEpisode
+    private val watchedEpisodes = watchedItems.filterIsInstance<WatchedItemWrapper.Episode>()
+    private val watchedMovies = watchedItems.filterIsInstance<WatchedItemWrapper.Movie>()
+    val watchedEpisodesBySession: Map<WatchedEpisodeSessionWrapper, List<WatchedItemWrapper.Episode>> = watchedEpisodes
         .groupBy { it.session }
-    val watchedItemsByMovie: Map<ExternalMovieId, List<WatchedItemWrapper.Movie>> = watchedItemsMovie.groupBy { it.itemId }
-    val watchedItemsByEpisode: Map<ExternalEpisodeId, List<WatchedItemWrapper.Episode>> = watchedItemsEpisode.groupBy { it.itemId }
+    val watchedItemsByMovie: Map<ExternalMovieId, List<WatchedItemWrapper.Movie>> = watchedMovies.groupBy { it.itemId }
+    val watchedItemsByEpisode: Map<ExternalEpisodeId, List<WatchedItemWrapper.Episode>> = watchedEpisodes.groupBy { it.itemId }
 
     val bookmarkedShows: Map<ExternalShowId, BookmarkedItem> = bookmarkedItems.filterKeysOfInstance()
     val bookmarkedMovies: Map<ExternalMovieId, BookmarkedItem> = bookmarkedItems.filterKeysOfInstance()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/CommonOptions.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/intl/datetime/CommonOptions.kt
@@ -1,9 +1,12 @@
 package io.github.couchtracker.intl.datetime
 
+import dev.mmauro.datetimepolyglot.localizers.absolute.DateComponents
 import dev.mmauro.datetimepolyglot.localizers.absolute.DateStyle
 import dev.mmauro.datetimepolyglot.localizers.absolute.DurationOptions
 import dev.mmauro.datetimepolyglot.localizers.absolute.LocalDateTimeOptions
 import dev.mmauro.datetimepolyglot.localizers.absolute.TimeStyle
+import dev.mmauro.datetimepolyglot.localizers.dynamic.DynamicLocalDateOptions
+import dev.mmauro.datetimepolyglot.styles.DayOfMonthStyle
 import dev.mmauro.datetimepolyglot.styles.DayOfWeekStyle
 import dev.mmauro.datetimepolyglot.styles.DurationStyle
 import dev.mmauro.datetimepolyglot.styles.MonthStyle
@@ -20,4 +23,12 @@ val PDT_FULL_LOCALIZER_OPTIONS = PartialDateTimeOptions(
 val LOCAL_DATE_TIME_FULL_LOCALIZER_OPTIONS = LocalDateTimeOptions(
     dateOptions = DateStyle.FULL,
     timeOptions = TimeStyle.Local.MEDIUM,
+)
+
+val EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS = DynamicLocalDateOptions(
+    absoluteOptions = DateComponents(
+        monthStyle = MonthStyle.ABBREVIATED,
+        dayOfMonthStyle = DayOfMonthStyle.NUMERIC,
+        dayOfWeekStyle = DayOfWeekStyle.ABBREVIATED,
+    ),
 )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/ColorUtils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/ColorUtils.kt
@@ -13,8 +13,7 @@ import android.graphics.Color as AndroidColor
 private const val MAIN_COLOR_SATURATION = 0.1f
 private const val MAIN_COLOR_VALUE = 1f
 private const val OUTLINE_VALUE = 0.6f
-private const val OUTLINE_VARIANT_MULTIPLIER = 0.8f
-private const val OUTLINE_VARIANT_MAX = 0.8f
+private const val OUTLINE_VARIANT_VALUE = 0.3f
 private const val CONTAINER_VALUE = 0.4f
 private const val SURFACE_VALUE = 0.30f
 private const val SURFACE_CONTAINER_VALUE_INCREMENT = 1.2f
@@ -66,6 +65,7 @@ fun Color.generateColorScheme(): ColorScheme {
     return DEFAULT_COLOR_SCHEME.copy(
         primary = primary,
         onPrimary = primary.toForeground(),
+        // FAB
         primaryContainer = primaryContainer,
         onPrimaryContainer = primaryContainer.toForeground(),
         inversePrimary = DEFAULT_COLOR_SCHEME.inversePrimary.withHue(primaryHue),
@@ -91,7 +91,7 @@ fun Color.generateColorScheme(): ColorScheme {
         surfaceVariant = surfaceVariant,
         onSurfaceVariant = surfaceVariant.toForeground(),
         outline = primaryBase.changeValue(OUTLINE_VALUE, OUTLINE_VALUE),
-        outlineVariant = primaryBase.changeValue(OUTLINE_VARIANT_MULTIPLIER, 0f, OUTLINE_VARIANT_MAX),
+        outlineVariant = primaryBase.changeValue(OUTLINE_VARIANT_VALUE, OUTLINE_VARIANT_VALUE),
     )
 }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/Action.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/Action.kt
@@ -7,6 +7,7 @@ import io.github.couchtracker.utils.ActionState
 data class Action(
     val name: String,
     val icon: ImageVector,
+    val active: Boolean = false,
     val state: ActionState<*, *, *, *>? = null,
     val badgeLabel: String? = null,
     val companionComposable: @Composable () -> Unit = {},

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/ActionsComposables.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/ActionsComposables.kt
@@ -1,16 +1,22 @@
 package io.github.couchtracker.ui.actions
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
@@ -18,6 +24,11 @@ import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.unit.dp
 import io.github.couchtracker.ui.ItemPosition
 import io.github.couchtracker.ui.ListItemShapes
@@ -54,6 +65,8 @@ fun ActionsHorizontalFloatingToolbar(actions: Actions, expanded: Boolean) {
                 mainAction.companionComposable()
                 ActionBadge(mainAction) {
                     FloatingToolbarDefaults.StandardFloatingActionButton(
+                        containerColor = MaterialTheme.colorScheme.actionContainerColor(mainAction) { primaryContainer },
+                        contentColor = MaterialTheme.colorScheme.actionContentColor(mainAction) { onPrimaryContainer },
                         onClick = {
                             // FloatingActionButton cannot be disabled, so we do this to avoid double clicks while loading
                             if (mainAction.state?.isLoading != true) {
@@ -80,11 +93,12 @@ fun ActionsHorizontalFloatingToolbar(actions: Actions, expanded: Boolean) {
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 fun ActionFloatingActionButton(action: Action) {
     action.companionComposable()
     ActionBadge(action) {
         FloatingActionButton(
+            containerColor = MaterialTheme.colorScheme.actionContainerColor(action) { primaryContainer },
+            contentColor = MaterialTheme.colorScheme.actionContentColor(action) { onPrimaryContainer },
             onClick = {
                 // FloatingActionButton cannot be disabled, so we do this to avoid double clicks while loading
                 if (action.state?.isLoading != true) {
@@ -102,6 +116,34 @@ fun ActionsVerticalMenu(actions: Actions) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         ActionsVerticalMenu(listOfNotNull(actions.mainAction))
         ActionsVerticalMenu(actions.otherActions)
+    }
+}
+
+@Composable
+fun ActionButton(action: Action, modifier: Modifier = Modifier) {
+    action.companionComposable()
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+        tooltip = {
+            PlainTooltip { Text(action.name) }
+        },
+        state = rememberTooltipState(),
+    ) {
+        Box(
+            modifier = modifier
+                .background(MaterialTheme.colorScheme.actionContainerColor(action) { Color.Transparent })
+                .clickable(enabled = action.state?.isLoading != true) {
+                    action.onClick()
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            val contentColor = MaterialTheme.colorScheme.actionContentColor(action) { LocalContentColor.current }
+            CompositionLocalProvider(LocalContentColor provides contentColor) {
+                ActionBadge(action) {
+                    DelayedActionIconLoadingIndicator(action.icon, contentDescription = action.name, action = action.state)
+                }
+            }
+        }
     }
 }
 
@@ -135,10 +177,33 @@ private fun ActionBadge(action: Action, content: @Composable () -> Unit) {
     BadgedBox(
         badge = {
             if (action.badgeLabel != null) {
-                Badge { Text(action.badgeLabel) }
+                Badge(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.primaryContainer,
+                ) { Text(action.badgeLabel) }
             }
         },
     ) {
         content()
+    }
+}
+
+// onPrimaryContainer is very bright. Blending it down a bit to make it easier on the eye.
+private val ColorScheme.activeContainerColor get() = lerp(onPrimaryContainer, primaryContainer, 0.25f)
+private val ColorScheme.activeContentColor get() = primaryContainer
+
+private inline fun ColorScheme.actionContainerColor(action: Action, inactiveColor: ColorScheme.() -> Color): Color {
+    return if (action.active) {
+        activeContainerColor
+    } else {
+        inactiveColor()
+    }
+}
+
+private inline fun ColorScheme.actionContentColor(action: Action, inactiveColor: ColorScheme.() -> Color): Color {
+    return if (action.active) {
+        activeContentColor
+    } else {
+        inactiveColor()
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/BookmarkAction.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/BookmarkAction.kt
@@ -28,6 +28,7 @@ fun BookmarkAction(id: BookmarkableExternalId): Action {
         } else {
             Icons.Outlined.BookmarkAdd
         },
+        active = isBookmarked,
         state = bookmarkAction,
         companionComposable = {
             ProfileDbErrorDialog(bookmarkAction)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/EpisodeActions.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/EpisodeActions.kt
@@ -12,7 +12,7 @@ fun episodeActions(
     watchedItemSheetModel: (WatchedItemSheetMode.New.Episode.WatchedSession) -> WatchedItemSheetMode.New.Episode,
 ): Actions {
     return Actions(
-        mainAction = showId?.let { markEpisodeAsWatchedAction(it, watchedItemSheetModel) },
+        mainAction = showId?.let { markEpisodeAsWatchedAction(it, episodeId, watchedItemSheetModel) },
         otherActions = listOf(
             ViewingsListAction(episodeId),
         ),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/MarkAsWatchedAction.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/MarkAsWatchedAction.kt
@@ -5,6 +5,8 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import io.github.couchtracker.LocalFullProfileDataContext
 import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.ExternalMovieId
 import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.model.watchedItem.ModalWatchedEpisodeSessionSelectorBottomSheet
 import io.github.couchtracker.db.profile.model.watchedItem.rememberModalWatchedEpisodeSessionSelectorBottomSheetState
@@ -13,11 +15,14 @@ import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetMode
 import io.github.couchtracker.utils.str
 
 @Composable
-fun markMovieAsWatchedAction(watchedItemSheetModel: () -> WatchedItemSheetMode.New.Movie): Action {
+fun markMovieAsWatchedAction(movieId: ExternalMovieId, watchedItemSheetModel: () -> WatchedItemSheetMode.New.Movie): Action {
     val state = LocalWatchedItemSheetScaffoldState.current
+    val fullProfileData = LocalFullProfileDataContext.current
+    val isWatched = movieId in fullProfileData.watchedItemsByMovie
     return Action(
         name = R.string.mark_movie_as_watched.str(),
         icon = Icons.Filled.Check,
+        active = isWatched,
         onClick = {
             state.open(watchedItemSheetModel())
         },
@@ -27,15 +32,18 @@ fun markMovieAsWatchedAction(watchedItemSheetModel: () -> WatchedItemSheetMode.N
 @Composable
 fun markEpisodeAsWatchedAction(
     showId: ExternalShowId,
+    episodeId: ExternalEpisodeId,
     watchedItemSheetModel: (WatchedItemSheetMode.New.Episode.WatchedSession) -> WatchedItemSheetMode.New.Episode,
 ): Action {
     val fullProfileData = LocalFullProfileDataContext.current
     val sessionSelectorSheetState = rememberModalWatchedEpisodeSessionSelectorBottomSheetState()
     val watchedItemSheetState = LocalWatchedItemSheetScaffoldState.current
+    val isWatched = fullProfileData.watchedItemsByEpisode[episodeId].orEmpty().any { it.session.isActive }
 
     return Action(
         name = R.string.mark_episode_as_watched.str(),
         icon = Icons.Filled.Check,
+        active = isWatched,
         onClick = {
             val activeSessions = fullProfileData.watchedEpisodeSessions[showId].orEmpty().filter { it.isActive }
             if (activeSessions.size > 1) {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/MovieActions.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/MovieActions.kt
@@ -11,7 +11,7 @@ import io.github.couchtracker.utils.str
 @Composable
 fun movieActions(movieId: ExternalMovieId, watchedItemSheetModel: () -> WatchedItemSheetMode.New.Movie): Actions {
     return Actions(
-        mainAction = markMovieAsWatchedAction(watchedItemSheetModel),
+        mainAction = markMovieAsWatchedAction(movieId, watchedItemSheetModel),
         otherActions = listOf(
             Action(R.string.action_lists.str(), Icons.AutoMirrored.Default.List) { /* TODO */ },
             ViewingsListAction(movieId),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
@@ -1,13 +1,9 @@
 package io.github.couchtracker.ui.components
 
 import android.content.Context
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -18,16 +14,19 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import app.moviebase.tmdb.model.TmdbEpisode
 import coil3.compose.AsyncImage
-import dev.mmauro.datetimepolyglot.localizers.absolute.DateComponents
+import dev.mmauro.datetimepolyglot.TickingValue
 import dev.mmauro.datetimepolyglot.localizers.absolute.localize
-import dev.mmauro.datetimepolyglot.styles.DayOfMonthStyle
-import dev.mmauro.datetimepolyglot.styles.DayOfWeekStyle
-import dev.mmauro.datetimepolyglot.styles.MonthStyle
+import dev.mmauro.datetimepolyglot.localizers.dynamic.DynamicLocalDateLocalizer
+import dev.mmauro.datetimepolyglot.localizers.localize
 import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
+import io.github.couchtracker.intl.datetime.EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS
 import io.github.couchtracker.intl.datetime.RUNTIME_LOCALIZER_OPTIONS
+import io.github.couchtracker.intl.datetime.rememberLocalizer
 import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbRating
 import io.github.couchtracker.tmdb.TmdbSeasonId
@@ -36,10 +35,14 @@ import io.github.couchtracker.tmdb.runtime
 import io.github.couchtracker.tmdb.toImageModelWithPlaceholder
 import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.ItemPosition
-import io.github.couchtracker.ui.ListItemShapes
 import io.github.couchtracker.ui.PlaceholdersDefaults
+import io.github.couchtracker.ui.actions.markEpisodeAsWatchedAction
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
+import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetMode
+import io.github.couchtracker.utils.rememberTickingValue
+import kotlinx.datetime.LocalDate
+import kotlin.time.Duration
 
 private val STILL_WIDTH = 112.dp
 private val STILL_HEIGHT = 64.dp
@@ -51,10 +54,31 @@ fun EpisodeListItem(
     position: ItemPosition,
 ) {
     val navController = LocalNavController.current
-    ListItem(
+
+    val dateTimeLocalizer = rememberLocalizer(EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS, ::DynamicLocalDateLocalizer)
+    val dateTimeText = rememberTickingValue(dateTimeLocalizer, episode.firstAirDate) {
+        if (episode.firstAirDate == null) {
+            TickingValue(null, null)
+        } else {
+            dateTimeLocalizer.localize(episode.firstAirDate)
+        }
+    }
+
+    val markEpisodeAsWatchedAction = markEpisodeAsWatchedAction(episode.showId, episode.episodeId) { watchedSession ->
+        WatchedItemSheetMode.New.Episode(
+            itemId = episode.episodeId,
+            watchedSession = watchedSession,
+            mediaRuntime = episode.runtimeDuration,
+            mediaLanguages = listOfNotNull(episode.showOriginalLanguage()),
+        )
+    }
+    ListItemWithAction(
+        action = markEpisodeAsWatchedAction,
         onClick = {
             navController.navigateToEpisode(episode.episodeId)
         },
+        leadingContentHeight = STILL_HEIGHT,
+        position = position,
         leadingContent = {
             Surface(shape = MaterialTheme.shapes.small) {
                 AsyncImage(
@@ -69,63 +93,65 @@ fun EpisodeListItem(
                 )
             }
         },
-        overlineContent = {
+    ) {
+        Column {
             if (episode.name != null) {
-                Text(episode.number)
+                Text(episode.number, style = MaterialTheme.typography.labelSmall)
             }
-        },
-        content = {
+
             if (episode.name != null) {
                 Text(episode.name, style = MaterialTheme.typography.titleMedium)
             } else {
                 Text(episode.number)
             }
-        },
-        supportingContent = {
+
             TagsRow(
                 tags = listOfNotNull(
-                    episode.firstAirDate,
+                    dateTimeText,
                     episode.tmdbRating?.formatted,
                     episode.runtime,
                 ),
                 tagStyle = MaterialTheme.typography.labelSmall,
             )
-        },
-        trailingContent = {
-            Icon(Icons.Default.RadioButtonUnchecked, contentDescription = null)
-        },
-        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp),
-        shapes = ListItemShapes(position),
-    )
+        }
+    }
 }
 
 data class EpisodeListItemModel(
+    val showId: ExternalShowId,
     val episodeId: ExternalEpisodeId,
     val name: String?,
     val number: String,
     val backdrop: ImageModel?,
-    val firstAirDate: String?,
+    val firstAirDate: LocalDate?,
     val runtime: String?,
     val tmdbRating: TmdbRating?,
+    // For the marked as watched dialog.
+    // This data will be read when opening the dialog to mark as watched
+    val showOriginalLanguage: () -> Bcp47Language?,
+    val runtimeDuration: Duration?,
 ) {
 
     companion object {
-        private val FIRST_AIR_DATE_OPTIONS = DateComponents(
-            monthStyle = MonthStyle.ABBREVIATED,
-            dayOfMonthStyle = DayOfMonthStyle.NUMERIC,
-            dayOfWeekStyle = DayOfWeekStyle.ABBREVIATED,
-        )
-
-        suspend fun fromTmdbEpisode(context: Context, show: TmdbShowId, episode: TmdbEpisode): EpisodeListItemModel {
+        suspend fun fromTmdbEpisode(
+            context: Context,
+            show: TmdbShowId,
+            episode: TmdbEpisode,
+            showOriginalLanguage: () -> Bcp47Language?,
+        ): EpisodeListItemModel {
             val id = TmdbExternalEpisodeId(TmdbEpisodeId(TmdbSeasonId(show, episode.seasonNumber), episode.episodeNumber))
+            val runtime = episode.runtime()
             return EpisodeListItemModel(
+                showId = show.toExternalId(),
                 episodeId = id,
                 name = episode.name,
                 number = context.getString(R.string.episode_x, episode.episodeNumber),
                 backdrop = episode.backdropImage?.toImageModelWithPlaceholder(),
-                firstAirDate = episode.airDate?.localize(FIRST_AIR_DATE_OPTIONS),
-                runtime = episode.runtime()?.localize(RUNTIME_LOCALIZER_OPTIONS),
+                firstAirDate = episode.airDate,
+                runtime = runtime?.localize(RUNTIME_LOCALIZER_OPTIONS),
                 tmdbRating = TmdbRating.ofOrNull(episode.voteAverage, episode.voteCount),
+                runtimeDuration = runtime,
+                showOriginalLanguage = showOriginalLanguage,
             )
         }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ListItemWithAction.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ListItemWithAction.kt
@@ -1,0 +1,79 @@
+package io.github.couchtracker.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.github.couchtracker.ui.ItemPosition
+import io.github.couchtracker.ui.ListItemShapes
+import io.github.couchtracker.ui.actions.Action
+import io.github.couchtracker.ui.actions.ActionButton
+
+private val LIST_ITEM_VERTICAL_PADDING = 10.dp
+private val LIST_ITEM_HORIZONTAL_PADDING = 12.dp
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ListItemWithAction(
+    action: Action,
+    onClick: () -> Unit,
+    leadingContentHeight: Dp,
+    position: ItemPosition,
+    modifier: Modifier = Modifier,
+    leadingContent: @Composable (() -> Unit)? = null,
+    content: @Composable () -> Unit,
+) {
+    ListItem(
+        modifier = modifier,
+        onClick = onClick,
+        leadingContent = leadingContent?.let {
+            {
+                Box(
+                    modifier = Modifier
+                        .padding(vertical = LIST_ITEM_VERTICAL_PADDING)
+                        .padding(start = LIST_ITEM_HORIZONTAL_PADDING),
+                ) {
+                    leadingContent()
+                }
+            }
+        },
+        content = {
+            Row(
+                Modifier
+                    .height(intrinsicSize = IntrinsicSize.Max)
+                    // Needs to be at least as tall as the poster. I cannot just "fill the height" unfortunately.
+                    .heightIn(min = leadingContentHeight + LIST_ITEM_VERTICAL_PADDING * 2),
+            ) {
+                Box(
+                    Modifier
+                        .weight(1f)
+                        .padding(vertical = LIST_ITEM_VERTICAL_PADDING)
+                        .padding(end = LIST_ITEM_HORIZONTAL_PADDING),
+                ) {
+                    content()
+                }
+                VerticalDivider()
+                ActionButton(
+                    action = action,
+                    modifier = Modifier
+                        .width(56.dp)
+                        .fillMaxSize(),
+                )
+            }
+        },
+        contentPadding = PaddingValues(),
+        shapes = ListItemShapes(position),
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
@@ -3,76 +3,83 @@ package io.github.couchtracker.ui.components
 import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.RadioButtonUnchecked
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import dev.mmauro.datetimepolyglot.TickingValue
+import dev.mmauro.datetimepolyglot.localizers.dynamic.DynamicLocalDateLocalizer
 import dev.mmauro.datetimepolyglot.localizers.localize
 import io.github.couchtracker.LocalNavController
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.ExternalSeasonId
 import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
-import io.github.couchtracker.db.profile.externalids.TmdbExternalShowId
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
-import io.github.couchtracker.intl.datetime.DynamicDateAbsoluteTimeWithDurationLocalizer
-import io.github.couchtracker.intl.datetime.DynamicDateAbsoluteTimeWithDurationOptions
+import io.github.couchtracker.intl.datetime.EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS
 import io.github.couchtracker.intl.datetime.rememberLocalizer
 import io.github.couchtracker.tmdb.BaseTmdbShow
 import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.ItemPosition
-import io.github.couchtracker.ui.ListItemShapes
 import io.github.couchtracker.ui.PlaceholdersDefaults
+import io.github.couchtracker.ui.actions.markEpisodeAsWatchedAction
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
+import io.github.couchtracker.ui.screens.main.ShowSectionViewModel
 import io.github.couchtracker.ui.screens.show.navigateToShow
+import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetMode
 import io.github.couchtracker.ui.seasonEpisodeNumberToString
 import io.github.couchtracker.ui.toImageModel
 import io.github.couchtracker.utils.rememberTickingValue
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import kotlin.random.Random
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.LocalDate
+import kotlin.time.Duration
 
 private val POSTER_HEIGHT = 64.dp
 private val POSTER_WIDTH = POSTER_HEIGHT * 2 / 3
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun UpNextListItem(
     upNext: UpNextListItemModel,
     position: ItemPosition,
+    modifier: Modifier = Modifier,
 ) {
-    val dateTimeLocalizer = rememberLocalizer(DynamicDateAbsoluteTimeWithDurationOptions(), ::DynamicDateAbsoluteTimeWithDurationLocalizer)
     val navController = LocalNavController.current
 
-    val airInstant = remember {
-        Clock.System.now() + Random.nextLong(-14.days.inWholeMinutes, 14.days.inWholeMinutes).minutes
-    }
-    val dateTimeText = rememberTickingValue(dateTimeLocalizer, airInstant) {
-        dateTimeLocalizer.localize(airInstant.toLocalDateTime(TimeZone.currentSystemDefault()))
+    val dateTimeLocalizer = rememberLocalizer(EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS, ::DynamicLocalDateLocalizer)
+    val dateTimeText = rememberTickingValue(dateTimeLocalizer, upNext.episodeAirDate) {
+        if (upNext.episodeAirDate == null) {
+            TickingValue(null, null)
+        } else {
+            dateTimeLocalizer.localize(upNext.episodeAirDate)
+        }
     }
 
-    ListItem(
+    val markEpisodeAsWatchedAction = markEpisodeAsWatchedAction(upNext.showId, upNext.episodeId) { watchedSession ->
+        WatchedItemSheetMode.New.Episode(
+            itemId = upNext.episodeId,
+            watchedSession = watchedSession,
+            mediaRuntime = upNext.episodeRuntime,
+            mediaLanguages = listOfNotNull(upNext.showOriginalLanguage),
+        )
+    }
+    ListItemWithAction(
+        modifier = modifier,
+        action = markEpisodeAsWatchedAction,
         onClick = {
             navController.navigateToEpisode(upNext.episodeId)
         },
+        leadingContentHeight = POSTER_HEIGHT,
+        position = position,
         leadingContent = {
             Surface(shape = MaterialTheme.shapes.small) {
                 AsyncImage(
@@ -91,57 +98,60 @@ fun UpNextListItem(
                 )
             }
         },
-        overlineContent = {
-            Text(upNext.episodeLabel)
-        },
-        content = {
-            Column {
-                if (upNext.showName != null) {
-                    Text(upNext.showName)
-                } else {
-                    Text("Ops")
-                }
-                Text(dateTimeText, style = MaterialTheme.typography.labelMedium)
+    ) {
+        Column {
+            if (upNext.showName != null) {
+                Text(upNext.showName, style = MaterialTheme.typography.titleSmall)
             }
-        },
-        trailingContent = {
-            Icon(Icons.Default.RadioButtonUnchecked, contentDescription = null)
-        },
-        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp),
-        shapes = ListItemShapes(position),
-    )
+            Text(upNext.episodeLabel, style = MaterialTheme.typography.titleMedium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            if (dateTimeText != null) {
+                Text(dateTimeText, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
 }
 
 data class UpNextListItemModel(
     val showId: ExternalShowId,
     val watchSession: WatchedEpisodeSessionWrapper?,
     val showPreloadData: BaseTmdbShow,
+    val seasonId: ExternalSeasonId,
     val episodeId: ExternalEpisodeId,
     val posterModel: ImageModel?,
     val showName: String?,
     val episodeLabel: String,
+    val episodeAirDate: LocalDate?,
+    // For the marked as watched dialog
+    val showOriginalLanguage: Bcp47Language?,
+    val episodeRuntime: Duration?,
 ) {
 
     companion object {
 
         fun withShowData(
             context: Context,
-            showPreloadData: BaseTmdbShow,
             watchSession: WatchedEpisodeSessionWrapper?,
-            seasonNumber: Int,
-            episodeNumber: Int,
+            show: ShowSectionViewModel.BookmarkedShowData,
+            season: ShowSectionViewModel.BookmarkedSeasonData,
+            episode: ShowSectionViewModel.BookmarkedEpisodeData,
         ): UpNextListItemModel {
-            val showId = showPreloadData.key.id
-            val seasonId = TmdbSeasonId(showId, seasonNumber)
-            val episodeId = TmdbExternalEpisodeId(TmdbEpisodeId(seasonId, episodeNumber))
+            val showId = show.baseShowData.key.id
+            val seasonId = TmdbSeasonId(showId, season.number)
+            val episodeId = TmdbExternalEpisodeId(TmdbEpisodeId(seasonId, episode.number))
+            val episodeNumberLabel = seasonEpisodeNumberToString(context, season.number, episode.number, episode.name)
+
             return UpNextListItemModel(
-                showId = TmdbExternalShowId(showId),
+                showId = showId.toExternalId(),
+                seasonId = seasonId.toExternalId(),
                 watchSession = watchSession,
+                showPreloadData = show.baseShowData,
                 episodeId = episodeId,
-                showName = showPreloadData.name,
-                showPreloadData = showPreloadData,
-                episodeLabel = seasonEpisodeNumberToString(context, seasonNumber, episodeNumber),
-                posterModel = showPreloadData.poster?.toImageModel(),
+                posterModel = show.baseShowData.poster?.toImageModel(),
+                showName = show.baseShowData.name,
+                episodeLabel = episodeNumberLabel,
+                episodeAirDate = episode.airDate,
+                showOriginalLanguage = show.originalLanguage,
+                episodeRuntime = episode.runtime,
             )
         }
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
@@ -118,7 +118,7 @@ fun ShowSection(
 
 @Composable
 private fun BookmarkedShowGrid(
-    shows: Loadable<List<ShowSectionViewModel.MaybeBookmarkedShowData>>,
+    shows: Loadable<List<ShowSectionViewModel.BookmarkedShow>>,
     emptyMessage: String,
     emptyDescription: String,
 ) {
@@ -182,13 +182,17 @@ private fun UpNext(
                 details = R.string.tab_shows_up_next_empty_description.str(),
             )
         } else {
+            // TODO: after marking an episode as watched, this should scroll to it
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(8.dp) + PaddingValues(bottom = OverviewScreenComponents.LIST_BOTTOM_SPACE),
                 verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                itemsWithPosition(entries) { position, upNextEntry ->
-                    UpNextListItem(upNextEntry.model, position)
+                itemsWithPosition(
+                    items = entries,
+                    key = { _, upNextEntry -> upNextEntry.itemKey },
+                ) { position, upNextEntry ->
+                    UpNextListItem(upNextEntry.model, position, modifier = Modifier.animateItem())
                 }
             }
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
 import io.github.couchtracker.db.app.ProfilesInfo
-import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalShowId
 import io.github.couchtracker.db.profile.externalids.UnknownExternalShowId
@@ -19,6 +19,8 @@ import io.github.couchtracker.tmdb.TmdbLanguages
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.details
+import io.github.couchtracker.tmdb.language
+import io.github.couchtracker.tmdb.runtime
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
 import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.components.ShowPortraitModel
@@ -56,7 +58,10 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.datetime.LocalDate
 import org.koin.mp.KoinPlatform
+import kotlin.time.Duration
+import kotlin.time.Instant
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ShowSectionViewModel(application: Application) : AndroidViewModel(application) {
@@ -70,11 +75,18 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         val watchedEpisodesBySession: Map<WatchedEpisodeSessionWrapper, List<WatchedItemWrapper.Episode>>,
     )
 
+    data class BookmarkedShow(
+        val showId: ExternalShowId,
+        val watchSessions: Map<WatchedEpisodeSessionWrapper, List<WatchedItemWrapper.Episode>>,
+        val data: CouchTrackerResult<BookmarkedShowData>,
+    )
+
     @Suppress("EqualsOrHashCode")
     data class BookmarkedShowData(
         val baseShowData: BaseTmdbShow,
         val portraitModel: ShowPortraitModel,
         val seasons: ApiLoadable<List<BookmarkedSeasonData>>,
+        val originalLanguage: Bcp47Language?,
     ) {
         // Computing the hashcode of this class is expensive.
         // Caching it, so it's computed on creation on a background thread
@@ -84,27 +96,27 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
 
     data class BookmarkedSeasonData(
         val id: TmdbSeasonId,
-        val seasonNumber: Int,
+        val number: Int,
         val episodes: List<BookmarkedEpisodeData>,
     )
 
     data class BookmarkedEpisodeData(
-        val episodeNumber: Int,
-    )
-
-    data class MaybeBookmarkedShowData(
-        val showId: ExternalShowId,
-        val watchSessions: Map<WatchedEpisodeSessionWrapper, Set<ExternalEpisodeId>>,
-        val data: CouchTrackerResult<BookmarkedShowData>,
+        val number: Int,
+        val name: String?,
+        val airDate: LocalDate?,
+        val runtime: Duration?,
     )
 
     data class UpNextEntry(
+        // A unique key for this entry
+        val itemKey: Any,
         val showId: ExternalShowId,
         val watchSession: WatchedEpisodeSessionWrapper?,
+        val lastWatchedEpisode: Instant?,
         val model: UpNextListItemModel,
     )
 
-    private val bookmarks: Flow<Loadable<List<MaybeBookmarkedShowData>>> =
+    private val bookmarks: Flow<Loadable<List<BookmarkedShow>>> =
         KoinPlatform.getKoin().get<Flow<ProfilesInfo>>()
             .mapNotNull { profilesInfo ->
                 val fullData = profilesInfo.currentFullData.resultValueOrNull()
@@ -123,20 +135,20 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
             .distinctUntilChanged()
             .shareIn(viewModelScope + Dispatchers.Default, SharingStarted.Eagerly, 1)
 
-    val watchlist: Loadable<List<MaybeBookmarkedShowData>> by bookmarks.mapLatest { bookmarks ->
+    val watchlist: Loadable<List<BookmarkedShow>> by bookmarks.mapLatest { bookmarks ->
         bookmarks.map { bookmarks ->
             bookmarks.filter { bookmarkedShowData -> bookmarkedShowData.watchSessions.none { it.key.isActive } }
         }
     }.collectAsLoadable("shows-watchlist")
 
-    val following: Loadable<List<MaybeBookmarkedShowData>> by bookmarks.mapLatest { bookmarks ->
+    val following: Loadable<List<BookmarkedShow>> by bookmarks.mapLatest { bookmarks ->
         bookmarks.map { bookmarks ->
             bookmarks.filter { bookmarkedShowData -> bookmarkedShowData.watchSessions.any { it.key.isActive } }
         }
     }.collectAsLoadable("shows-following")
 
     val upNext: CouchTrackerLoadable<List<UpNextEntry>> by bookmarks
-        .collectWithPrevious { previous: Loadable<Map<MaybeBookmarkedShowData, CouchTrackerLoadable<List<UpNextEntry>>>>?, bookmarks ->
+        .collectWithPrevious { previous: Loadable<Map<BookmarkedShow, CouchTrackerLoadable<List<UpNextEntry>>>>?, bookmarks ->
             bookmarks.map { bookmarks ->
                 bookmarks.associateWith { bookmarkedShowData ->
                     val old = previous?.valueOrNull()?.get(bookmarkedShowData)
@@ -166,7 +178,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
-    private fun Flow<BookmarkedShows>.withShowData(): Flow<Loadable<List<MaybeBookmarkedShowData>>> {
+    private fun Flow<BookmarkedShows>.withShowData(): Flow<Loadable<List<BookmarkedShow>>> {
         return retryContext { languages ->
             rememberingCombined(
                 keys = { it.bookmarkedShows },
@@ -177,10 +189,10 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                 } else {
                     bookmarkedData.bookmarkedShows.map { showId ->
                         val watchSessions = bookmarkedData.watchSessions[showId].orEmpty()
-                        MaybeBookmarkedShowData(
+                        BookmarkedShow(
                             showId = showId,
                             watchSessions = watchSessions.associateWith { watchSession ->
-                                bookmarkedData.watchedEpisodesBySession[watchSession].orEmpty().mapTo(HashSet()) { it.itemId }
+                                bookmarkedData.watchedEpisodesBySession[watchSession].orEmpty()
                             },
                             data = showDataCache.getValue(showId),
                         )
@@ -194,7 +206,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         showId: ExternalShowId,
         languages: TmdbLanguages,
     ): Flow<CouchTrackerResult<BookmarkedShowData>> {
-        Log.d("flowDetailForShow", "showId: $showId")
+        Log.d("ShowSectionViewModel", "Computing flowDetailForShow for showId: $showId")
         val tmdbShowId: TmdbShowId = when (showId) {
             is TmdbExternalShowId -> showId.id
             is UnknownExternalShowId -> return flowOf(
@@ -214,6 +226,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                     baseShowData = details.toBaseShow(languages.apiLanguage),
                     portraitModel = details.toShowPortraitModels(application, languages.apiLanguage),
                     seasons = Loadable.Loading,
+                    originalLanguage = details.language(),
                 ),
             )
             emit(bookmarkedShow)
@@ -229,10 +242,13 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                             val seasonId = TmdbSeasonId(tmdbShowId, season.seasonNumber)
                             BookmarkedSeasonData(
                                 id = seasonId,
-                                seasonNumber = season.seasonNumber,
+                                number = season.seasonNumber,
                                 episodes = season.episodes.orEmpty().map { episode ->
                                     BookmarkedEpisodeData(
-                                        episodeNumber = episode.episodeNumber,
+                                        number = episode.episodeNumber,
+                                        name = episode.name,
+                                        airDate = episode.airDate,
+                                        runtime = episode.runtime(),
                                     )
                                 },
                             )
@@ -248,7 +264,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
-    private fun MaybeBookmarkedShowData.upNextEntries(): CouchTrackerLoadable<List<UpNextEntry>> {
+    private fun BookmarkedShow.upNextEntries(): CouchTrackerLoadable<List<UpNextEntry>> {
         val (showData, seasons) = when (this.data) {
             is Result.Error -> return Loadable.Loaded(data)
             is Result.Value -> {
@@ -261,41 +277,63 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                 }
             }
         }
-        Log.d("upNextEntries", "showId: $showId")
+        Log.d("ShowSectionViewModel", "Computing upNextEntries for showId: $showId")
+        val watchSessionsToDisplay = if (watchSessions.isEmpty()) {
+            // No watch sessions => a single entry for a new watch session
+            mapOf(null to emptyList())
+        } else {
+            // Has watch sessions => one entry for each active watch session
+            watchSessions.filter { it.key.isActive }
+        }
         return Loadable.value(
-            if (watchSessions.isEmpty()) {
-                listOfNotNull(upNextEntry(showId, null, emptySet(), showData, seasons))
-            } else {
-                // Has watch sessions => one entry for each watch session
-                watchSessions.filter { it.key.isActive }.mapNotNull { watchSession ->
-                    upNextEntry(showId, watchSession.key, watchSession.value, showData, seasons)
-                }
+            watchSessionsToDisplay.mapNotNull { (watchSession, episodes) ->
+                upNextEntry(
+                    showId,
+                    watchSession,
+                    episodes,
+                    showData,
+                    seasons,
+                    hasMultipleWatchSessions = watchSessionsToDisplay.size > 1,
+                )
             },
         )
     }
 
+    @Suppress("LongParameterList", "NestedBlockDepth")
     private fun upNextEntry(
         showId: ExternalShowId,
         watchSession: WatchedEpisodeSessionWrapper?,
-        watchedEpisodes: Set<ExternalEpisodeId>,
+        watchedEpisodes: List<WatchedItemWrapper.Episode>,
         showData: BookmarkedShowData,
         seasons: List<BookmarkedSeasonData>,
+        hasMultipleWatchSessions: Boolean,
     ): UpNextEntry? {
+        val watchedEpisodesIds = watchedEpisodes.mapTo(HashSet()) { it.itemId }
         for (season in seasons) {
-            if (season.seasonNumber > 0) {
+            if (season.number > 0) {
                 for (episode in season.episodes) {
-                    val episodeId = TmdbEpisodeId(season.id, episode.episodeNumber).toExternalId()
-                    if (episodeId !in watchedEpisodes) {
+                    val episodeId = TmdbEpisodeId(season.id, episode.number).toExternalId()
+                    if (episodeId !in watchedEpisodesIds) {
+                        // Note the item key is the same with 0 or 1 watch sessions.
+                        // That's so creating the first watch session won't change the entry's key.
+                        // Note: the type should be savable via Bundle
+                        val itemKey = if (hasMultipleWatchSessions) {
+                            showId.serialize() to watchSession?.id
+                        } else {
+                            showId.serialize()
+                        }
                         return UpNextEntry(
+                            itemKey = itemKey,
                             showId = showId,
                             watchSession = watchSession,
                             model = UpNextListItemModel.withShowData(
                                 context = application,
-                                showPreloadData = showData.baseShowData,
                                 watchSession = watchSession,
-                                seasonNumber = season.seasonNumber,
-                                episodeNumber = episode.episodeNumber,
+                                show = showData,
+                                season = season,
+                                episode = episode,
                             ),
+                            lastWatchedEpisode = watchedEpisodes.maxOfOrNull { it.addedAt },
                         )
                     }
                 }
@@ -310,7 +348,9 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         } else if (any { it is Loadable.Loading }) {
             Loadable.Loading
         } else {
-            val loaded = mapNotNull { it.resultValueOrNull() }.flatten()
+            val loaded = mapNotNull { it.resultValueOrNull() }
+                .flatten()
+                .sortedByDescending { it.lastWatchedEpisode }
             if (loaded.isEmpty()) {
                 // Note: I'm just taking the first error; in principle they could be merged
                 Loadable.error(firstNotNullOf { it.resultErrorOrNull() })

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -147,7 +149,8 @@ private fun OverviewScreenComponents.SeasonPage(
     seasonBaseData: SeasonsScreenViewModelHelper.SeasonBaseDetails,
     showDetails: SeasonsScreenViewModelHelper.ShowDetails,
 ) {
-    val seasonModel = viewModel.viewModelForSeason(seasonBaseData.tmdbSeasonId, showOriginalLanguage = { showDetails.originalLanguage })
+    val originalLanguage by rememberUpdatedState(showDetails.originalLanguage)
+    val seasonModel = viewModel.viewModelForSeason(seasonBaseData.tmdbSeasonId, showOriginalLanguage = { originalLanguage })
     SeasonDetailsContent(
         innerPadding = innerPadding,
         viewModel = viewModel,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
@@ -132,6 +132,7 @@ private fun SeasonsScreenContent(
                 OverviewScreenComponents.SeasonPage(
                     innerPadding = innerPadding,
                     viewModel = viewModel,
+                    showDetails = showDetails,
                     seasonBaseData = seasonDetails,
                 )
             }
@@ -144,8 +145,9 @@ private fun OverviewScreenComponents.SeasonPage(
     innerPadding: PaddingValues,
     viewModel: SeasonsScreenViewModel,
     seasonBaseData: SeasonsScreenViewModelHelper.SeasonBaseDetails,
+    showDetails: SeasonsScreenViewModelHelper.ShowDetails,
 ) {
-    val seasonModel = viewModel.viewModelForSeason(seasonBaseData.tmdbSeasonId)
+    val seasonModel = viewModel.viewModelForSeason(seasonBaseData.tmdbSeasonId, showOriginalLanguage = { showDetails.originalLanguage })
     SeasonDetailsContent(
         innerPadding = innerPadding,
         viewModel = viewModel,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModel.kt
@@ -2,12 +2,14 @@ package io.github.couchtracker.ui.screens.seasons
 
 import android.app.Application
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.remember
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.tmdb.TmdbFlowRetryContext
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
@@ -17,7 +19,9 @@ import io.github.couchtracker.utils.allErrors
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.collectAsLoadableInScope
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlin.coroutines.EmptyCoroutineContext
 
 class SeasonsScreenViewModel(
     application: Application,
@@ -44,15 +48,19 @@ class SeasonsScreenViewModel(
 
     class SeasonViewModel(
         application: Application,
-        scope: CoroutineScope,
+        val scope: CoroutineScope,
         seasonId: TmdbSeasonId,
         retryContext: TmdbFlowRetryContext,
-    ) {
+        showOriginalLanguage: () -> Bcp47Language?,
+    ) : AndroidViewModel(application) {
+
         private val baseViewModel = SeasonsScreenViewModelHelper.SeasonViewModelHelper(
             application = application,
             seasonId = seasonId,
             retryContext = retryContext,
+            showOriginalLanguage = showOriginalLanguage,
         )
+
         val details by baseViewModel.details.collectAsLoadableInScope(scope, "details")
         val allErrors by derivedStateOf {
             listOf(details).allErrors()
@@ -60,13 +68,21 @@ class SeasonsScreenViewModel(
     }
 
     @Composable
-    fun viewModelForSeason(season: TmdbSeasonId): SeasonViewModel {
-        return SeasonViewModel(
-            application = application,
-            scope = rememberCoroutineScope(),
-            seasonId = season,
-            retryContext = retryContext,
-        ).also { childModels.put(it) }
+    fun viewModelForSeason(season: TmdbSeasonId, showOriginalLanguage: () -> Bcp47Language?): SeasonViewModel {
+        val model = remember(season) {
+            SeasonViewModel(
+                application = application,
+                scope = CoroutineScope(EmptyCoroutineContext),
+                seasonId = season,
+                retryContext = retryContext,
+                showOriginalLanguage = showOriginalLanguage,
+            )
+        }
+        DisposableEffect(model.scope) {
+            onDispose { model.scope.cancel() }
+        }
+        childModels.put(model)
+        return model
     }
 
     fun retryAll() {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModelHelper.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModelHelper.kt
@@ -2,6 +2,7 @@ package io.github.couchtracker.ui.screens.seasons
 
 import android.app.Application
 import androidx.compose.material3.ColorScheme
+import io.github.couchtracker.db.profile.Bcp47Language
 import io.github.couchtracker.db.profile.externalids.ExternalSeasonId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalSeasonId
 import io.github.couchtracker.tmdb.TmdbFlowRetryContext
@@ -9,6 +10,7 @@ import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.details
 import io.github.couchtracker.tmdb.extractColorScheme
+import io.github.couchtracker.tmdb.language
 import io.github.couchtracker.tmdb.toImageModelWithPlaceholder
 import io.github.couchtracker.ui.ImageModel
 import io.github.couchtracker.ui.components.EpisodeListItemModel
@@ -40,6 +42,7 @@ class SeasonsScreenViewModelHelper(
     class ShowDetails(
         val name: String?,
         val backdrop: ImageModel?,
+        val originalLanguage: Bcp47Language?,
         val seasons: List<SeasonBaseDetails>,
     )
 
@@ -63,6 +66,7 @@ class SeasonsScreenViewModelHelper(
                 ShowDetails(
                     name = details.name,
                     backdrop = details.backdropImage?.toImageModelWithPlaceholder(),
+                    originalLanguage = details.language(),
                     seasons = details.seasons.map { season ->
                         val tmdbSeasonId = TmdbSeasonId(showId, season.seasonNumber)
                         SeasonBaseDetails(
@@ -94,6 +98,7 @@ class SeasonsScreenViewModelHelper(
         val application: Application,
         val seasonId: TmdbSeasonId,
         val retryContext: TmdbFlowRetryContext,
+        val showOriginalLanguage: () -> Bcp47Language?,
     ) {
 
         val details: Flow<ApiLoadable<SeasonFullDetails>> = retryContext { languages ->
@@ -101,7 +106,12 @@ class SeasonsScreenViewModelHelper(
                 result.map { tmdbSeasonDetails ->
                     SeasonFullDetails(
                         episodes = tmdbSeasonDetails.episodes.orEmpty().map { tmdbEpisode ->
-                            EpisodeListItemModel.fromTmdbEpisode(application, seasonId.showId, tmdbEpisode)
+                            EpisodeListItemModel.fromTmdbEpisode(
+                                context = application,
+                                show = seasonId.showId,
+                                episode = tmdbEpisode,
+                                showOriginalLanguage = showOriginalLanguage,
+                            )
                         },
                     )
                 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
@@ -168,7 +168,7 @@ sealed interface WatchedItemsScreenViewModel {
 
             @Composable
             override fun markAsWatchedAction(): Action {
-                return markEpisodeAsWatchedAction(externalId.id.showId.toExternalId()) { watchedSession ->
+                return markEpisodeAsWatchedAction(externalId.id.showId.toExternalId(), externalId) { watchedSession ->
                     val showDetails = showBaseDetails.resultValueOrNull()
                     val seasonDetails = seasonDetails.resultValueOrNull()
                     val episodeDetails = seasonDetails?.findEpisode()

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
@@ -82,7 +82,7 @@ sealed interface WatchedItemsScreenViewModel {
 
             @Composable
             override fun markAsWatchedAction(): Action {
-                return markMovieAsWatchedAction {
+                return markMovieAsWatchedAction(externalId) {
                     val movieDetails = movieDetails.resultValueOrNull()
                     WatchedItemSheetMode.New.Movie(
                         itemId = externalId,


### PR DESCRIPTION
This commit improves the style of episodes in the up-next section, and in the list of episodes in a season.

The button to mark episodes as watched also works now; however, it has no visual indication about whether the episode is already watched or not.

This commit also implements minor improvements to the up-next section, such as sorting by last show marked as watched.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/a1d0193d-ed21-47ac-b0c7-969685a96a6b" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/e3c2578c-0eea-49cb-b6a4-34d48f63556a" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/03841bb5-8ebe-46e2-8df1-ef30fadaafbc" />


<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/70a78d24-1566-4972-be71-c809706fb36e" />
