### PR TITLE
Rename viewings list to viewings history

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/EpisodeActions.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/EpisodeActions.kt
@@ -14,7 +14,7 @@ fun episodeActions(
     return Actions(
         mainAction = showId?.let { markEpisodeAsWatchedAction(it, episodeId, watchedItemSheetModel) },
         otherActions = listOf(
-            ViewingsListAction(episodeId),
+            ViewingsHistoryAction(episodeId),
         ),
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/MovieActions.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/MovieActions.kt
@@ -14,7 +14,7 @@ fun movieActions(movieId: ExternalMovieId, watchedItemSheetModel: () -> WatchedI
         mainAction = markMovieAsWatchedAction(movieId, watchedItemSheetModel),
         otherActions = listOf(
             Action(R.string.action_lists.str(), Icons.AutoMirrored.Default.List) { /* TODO */ },
-            ViewingsListAction(movieId),
+            ViewingsHistoryAction(movieId),
             BookmarkAction(movieId),
         ),
     )

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/ViewingsHistoryAction.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/actions/ViewingsHistoryAction.kt
@@ -1,24 +1,33 @@
 package io.github.couchtracker.ui.actions
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Checklist
+import androidx.compose.material.icons.filled.History
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import io.github.couchtracker.LocalFullProfileDataContext
 import io.github.couchtracker.LocalNavController
 import io.github.couchtracker.R
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
+import io.github.couchtracker.db.profile.externalids.ExternalMovieId
 import io.github.couchtracker.db.profile.externalids.WatchableExternalId
 import io.github.couchtracker.ui.screens.watchedItem.navigateToWatchedItems
 
 @Composable
-fun ViewingsListAction(id: WatchableExternalId): Action {
+fun ViewingsHistoryAction(id: WatchableExternalId): Action {
     val navController = LocalNavController.current
     val fullProfileData = LocalFullProfileDataContext.current
-    val watchCount = fullProfileData.watchedItems.count { it.itemId == id }
+    val watchCount = when (id) {
+        is ExternalMovieId -> {
+            fullProfileData.watchedItemsByMovie[id].orEmpty().size
+        }
+        is ExternalEpisodeId -> {
+            fullProfileData.watchedItemsByEpisode[id].orEmpty().size
+        }
+    }
 
     return Action(
-        name = stringResource(R.string.viewings_list),
-        icon = Icons.Default.Checklist,
+        name = stringResource(R.string.viewings_history),
+        icon = Icons.Default.History,
         badgeLabel = if (watchCount > 0) watchCount.toString() else null,
         onClick = {
             navController.navigateToWatchedItems(id)

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -184,7 +184,7 @@
     <string name="action_bookmark_add">Aggiungi agli elementi salvati</string>
     <string name="action_bookmark_remove">Rimuovi dagli elementi salvati</string>
 
-    <string name="viewings_list">Lista di visioni</string>
+    <string name="viewings_history">Cronologia delle visioni</string>
     <string name="watch_sessions">Sessioni di visioni</string>
     <string name="watch_session_info">Ogni episodio che guardi appartiene a una sessione di visioni, che ti permette di raggruppare le visioni in modo logico. Se ricominci una serie dall’inizio, puoi creare una nuova sessione di visione. I tuoi progressi, il prossimo episodio da guardare e le informazioni correlate sono tutti collegati alle sessioni di visione attive.</string>
     <string name="add_watch_session">Aggiungi sessione di visioni</string>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -179,7 +179,7 @@
     <string name="action_bookmark_add">Add to bookmarks</string>
     <string name="action_bookmark_remove">Remove form bookmarks</string>
 
-    <string name="viewings_list">Viewings list</string>
+    <string name="viewings_history">Viewings history</string>
     <string name="watch_sessions">Watch sessions</string>
     <string name="watch_session_info">Each episode you watch belongs to a watch session, which lets you group your viewings together logically. If you rewatch a show from the beginning, you can create a new watch session. Your progress, next episode to watch, and related information are all tied to active watch sessions.</string>
     <string name="add_watch_session">Add watch session</string>


### PR DESCRIPTION
According to early alpha testers (Valeria), calling the section (and actions) "viewings history" is clearer.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>