### PR TITLE
Bugfix: color scheme was incorrectly remembered

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
@@ -77,8 +77,8 @@ sealed interface WatchedItemsScreenViewModel {
                     backdrop = movieDetails?.baseDetails?.backdrop,
                 )
             }
-            override val colorScheme = baseViewModel.colorScheme.collectAsLoadable("colorScheme").value.resultValueOrNull()
-                ?: ColorSchemes.Movie
+            val colorSchemeResult by baseViewModel.colorScheme.collectAsLoadable("colorScheme")
+            override val colorScheme get() = colorSchemeResult.resultValueOrNull() ?: ColorSchemes.Movie
 
             @Composable
             override fun markAsWatchedAction(): Action {
@@ -144,8 +144,8 @@ sealed interface WatchedItemsScreenViewModel {
             private val showBaseDetails by showBaseModel.baseDetails.collectAsLoadable("showBaseDetails")
             private val seasonDetails by seasonModel.seasonDetails.collectAsLoadable("seasonDetails")
 
-            override val colorScheme = showBaseModel.colorScheme.collectAsLoadable("colorScheme").value.resultValueOrNull()
-                ?: ColorSchemes.Show
+            val colorSchemeResult by showBaseModel.colorScheme.collectAsLoadable("colorScheme")
+            override val colorScheme get() = colorSchemeResult.resultValueOrNull() ?: ColorSchemes.Show
 
             override val details by derivedStateOf {
                 val showBaseDetails = showBaseDetails.resultValueOrNull()


### PR DESCRIPTION
Before, the color scheme was immediately read and saved on the field.
Now, the "color transformations" are done every time on top of the latest value.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/f77d8d3f-a934-4b86-9d36-c66de5916c7a" />


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>