### PR TITLE
Open the episodes list from up-next

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/AnimationDefaults.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/AnimationDefaults.kt
@@ -1,8 +1,29 @@
 package io.github.couchtracker.ui
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.tween
 
 object AnimationDefaults {
     const val ANIMATION_DURATION_MS = 350
     val NAV_HOST_FADE_ANIMATION_SPEC = tween<Float>(ANIMATION_DURATION_MS)
+
+    object PulseAnimation {
+        const val DURATION_MS = 150
+        const val REPETITIONS = 2
+        const val ALPHA = 0.3f
+
+        suspend fun run(pulseAlpha: Animatable<Float, AnimationVector1D>) {
+            repeat(REPETITIONS) {
+                pulseAlpha.animateTo(
+                    ALPHA,
+                    animationSpec = tween(DURATION_MS),
+                )
+                pulseAlpha.animateTo(
+                    0f,
+                    animationSpec = tween(DURATION_MS),
+                )
+            }
+        }
+    }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CouchTrackerScreenScaffold.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/CouchTrackerScreenScaffold.kt
@@ -4,12 +4,12 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -23,7 +23,6 @@ import io.github.couchtracker.ui.LocalBackgroundColor
 /**
  * A scaffold that applies correct background/content colors when used inside [io.github.couchtracker.ui.Screen]
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun BaseCouchTrackerScreenScaffold(
     modifier: Modifier = Modifier,
@@ -51,7 +50,7 @@ fun BaseCouchTrackerScreenScaffold(
  * A scaffold that applies correct background/content colors when used inside [io.github.couchtracker.ui.Screen].
  * This also applies a default top bar and scroll behavior.
  */
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CouchTrackerScreenScaffold(
     title: () -> String,
@@ -62,9 +61,9 @@ fun CouchTrackerScreenScaffold(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     floatingActionButton: @Composable () -> Unit = {},
     scaffoldContainer: @Composable (scaffold: @Composable () -> Unit) -> Unit = { it() },
+    scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState()),
     content: @Composable (PaddingValues) -> Unit,
 ) {
-    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     scaffoldContainer {
         BaseCouchTrackerScreenScaffold(
             modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/EpisodeListItem.kt
@@ -3,7 +3,8 @@ package io.github.couchtracker.ui.components
 import android.content.Context
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -47,11 +48,11 @@ import kotlin.time.Duration
 private val STILL_WIDTH = 112.dp
 private val STILL_HEIGHT = 64.dp
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun EpisodeListItem(
     episode: EpisodeListItemModel,
     position: ItemPosition,
+    colors: ListItemColors = ListItemDefaults.colors(),
 ) {
     val navController = LocalNavController.current
 
@@ -93,6 +94,7 @@ fun EpisodeListItem(
                 )
             }
         },
+        colors = colors,
     ) {
         Column {
             if (episode.name != null) {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ListItemWithAction.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/ListItemWithAction.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -33,6 +35,7 @@ fun ListItemWithAction(
     position: ItemPosition,
     modifier: Modifier = Modifier,
     leadingContent: @Composable (() -> Unit)? = null,
+    colors: ListItemColors = ListItemDefaults.colors(),
     content: @Composable () -> Unit,
 ) {
     ListItem(
@@ -75,5 +78,6 @@ fun ListItemWithAction(
         },
         contentPadding = PaddingValues(),
         shapes = ListItemShapes(position),
+        colors = colors,
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
@@ -18,8 +18,10 @@ import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -249,12 +251,14 @@ object OverviewScreenComponents {
         innerPadding: PaddingValues,
         modifier: Modifier = Modifier,
         verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(4.dp),
+        state: LazyListState = rememberLazyListState(),
         content: LazyListScope.() -> Unit,
     ) {
         LazyColumn(
             contentPadding = innerPadding + PaddingValues(bottom = LIST_BOTTOM_SPACE),
             modifier = modifier.fillMaxSize(),
             verticalArrangement = verticalArrangement,
+            state = state,
         ) {
             content()
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
@@ -34,8 +34,8 @@ import io.github.couchtracker.ui.ItemPosition
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.actions.markEpisodeAsWatchedAction
 import io.github.couchtracker.ui.rememberPlaceholderPainter
-import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
 import io.github.couchtracker.ui.screens.main.ShowSectionViewModel
+import io.github.couchtracker.ui.screens.seasons.navigateToSeason
 import io.github.couchtracker.ui.screens.show.navigateToShow
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetMode
 import io.github.couchtracker.ui.seasonEpisodeNumberToString
@@ -76,7 +76,7 @@ fun UpNextListItem(
         modifier = modifier,
         action = markEpisodeAsWatchedAction,
         onClick = {
-            navController.navigateToEpisode(upNext.episodeId)
+            navController.navigateToSeason(upNext.seasonId, upNext.episodeId)
         },
         leadingContentHeight = POSTER_HEIGHT,
         position = position,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
@@ -1,28 +1,38 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package io.github.couchtracker.ui.screens.seasons
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.plus
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.ExternalSeasonId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalSeasonId
 import io.github.couchtracker.db.profile.externalids.UnknownExternalSeasonId
+import io.github.couchtracker.ui.AnimationDefaults
 import io.github.couchtracker.ui.ColorSchemes
 import io.github.couchtracker.ui.Screen
 import io.github.couchtracker.ui.components.CouchTrackerScreenScaffold
@@ -37,11 +47,12 @@ import io.github.couchtracker.utils.resultValueOrNull
 import io.github.couchtracker.utils.viewModelApplication
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import kotlin.math.roundToInt
 
 private const val LOG_TAG = "SeasonsScreen"
 
 @Serializable
-data class SeasonsScreen(val seasonId: String) : Screen() {
+data class SeasonsScreen(val seasonId: String, val episodeId: String?) : Screen() {
 
     @Composable
     override fun Content() {
@@ -50,11 +61,15 @@ data class SeasonsScreen(val seasonId: String) : Screen() {
             is TmdbExternalSeasonId -> externalSeasonId.id
             is UnknownExternalSeasonId -> TODO()
         }
+        val externalEpisodeId = this@SeasonsScreen.episodeId?.let {
+            ExternalEpisodeId.parse(it)
+        }
 
         val viewModel = viewModel {
             SeasonsScreenViewModel(
                 application = viewModelApplication(),
                 showId = seasonId.showId,
+                pendingPulseAnimation = externalEpisodeId,
             )
         }
         val colorScheme = viewModel.colorScheme.resultValueOrNull() ?: ColorSchemes.Show
@@ -67,12 +82,20 @@ data class SeasonsScreen(val seasonId: String) : Screen() {
     }
 }
 
-fun NavController.navigateToSeason(id: ExternalSeasonId) {
-    navigate(SeasonsScreen(ExternalSeasonId.serialize(id)))
+fun NavController.navigateToSeason(id: ExternalSeasonId, episodeId: ExternalEpisodeId? = null) {
+    navigate(
+        SeasonsScreen(
+            seasonId = ExternalSeasonId.serialize(id),
+            episodeId = episodeId?.let { ExternalEpisodeId.serialize(it) },
+        ),
+    )
 }
 
 @Composable
-private fun Content(viewModel: SeasonsScreenViewModel, initialSeason: ExternalSeasonId) {
+private fun Content(
+    viewModel: SeasonsScreenViewModel,
+    initialSeason: ExternalSeasonId,
+) {
     LoadableScreen(
         data = viewModel.showDetails,
         onError = { apiError ->
@@ -91,7 +114,7 @@ private fun Content(viewModel: SeasonsScreenViewModel, initialSeason: ExternalSe
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SeasonsScreenContent(
     viewModel: SeasonsScreenViewModel,
@@ -112,6 +135,7 @@ private fun SeasonsScreenContent(
     )
     val selectedSeason = showDetails.seasons[pagerState.currentPage]
     logCompositions(LOG_TAG, "Recomposing SeasonsScreenContent")
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     CouchTrackerScreenScaffold(
         title = { selectedSeason.name ?: selectedSeason.defaultName },
         subtitle = { showDetails.name },
@@ -128,6 +152,7 @@ private fun SeasonsScreenContent(
             )
         },
         snackbarHostState = snackbarHostState,
+        scrollBehavior = scrollBehavior,
         content = { innerPadding ->
             HorizontalPager(pagerState, modifier = Modifier.fillMaxSize(), beyondViewportPageCount = 1) { page ->
                 val seasonDetails = showDetails.seasons[page]
@@ -136,18 +161,21 @@ private fun SeasonsScreenContent(
                     viewModel = viewModel,
                     showDetails = showDetails,
                     seasonBaseData = seasonDetails,
+                    nestedScrollBehavior = scrollBehavior,
                 )
             }
         },
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun OverviewScreenComponents.SeasonPage(
     innerPadding: PaddingValues,
     viewModel: SeasonsScreenViewModel,
     seasonBaseData: SeasonsScreenViewModelHelper.SeasonBaseDetails,
     showDetails: SeasonsScreenViewModelHelper.ShowDetails,
+    nestedScrollBehavior: TopAppBarScrollBehavior,
 ) {
     val originalLanguage by rememberUpdatedState(showDetails.originalLanguage)
     val seasonModel = viewModel.viewModelForSeason(seasonBaseData.tmdbSeasonId, showOriginalLanguage = { originalLanguage })
@@ -155,14 +183,17 @@ private fun OverviewScreenComponents.SeasonPage(
         innerPadding = innerPadding,
         viewModel = viewModel,
         seasonModel = seasonModel,
+        nestedScrollBehavior = nestedScrollBehavior,
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun OverviewScreenComponents.SeasonDetailsContent(
     innerPadding: PaddingValues,
     viewModel: SeasonsScreenViewModel,
     seasonModel: SeasonsScreenViewModel.SeasonViewModel,
+    nestedScrollBehavior: TopAppBarScrollBehavior,
 ) {
     val episodes = seasonModel.details.mapResult { it.episodes }
     LoadableScreen(
@@ -174,14 +205,53 @@ private fun OverviewScreenComponents.SeasonDetailsContent(
             )
         },
     ) { episodes ->
+        val indexToPulse = episodes.indexOfFirst { it.episodeId == viewModel.pendingPulseAnimation }
+        val listState = rememberLazyListState(
+            initialFirstVisibleItemIndex = indexToPulse.coerceAtLeast(0),
+            // Scrolling dow to give some "breathing room"
+            initialFirstVisibleItemScrollOffset = -with(LocalDensity.current) { 200.dp.toPx() }.roundToInt(),
+        )
+        LaunchedEffect(Unit) {
+            // Since I might have scrolled, I need to collapse the header if the first item has been scrolled up
+            val firstItemMeasurementInfo = listState.layoutInfo.visibleItemsInfo.find { it.index == 0 }
+            if (viewModel.pendingPulseAnimation != null && (firstItemMeasurementInfo == null || firstItemMeasurementInfo.offset != 0)) {
+                // Collapse the header
+                nestedScrollBehavior.state.apply {
+                    heightOffset = heightOffsetLimit
+                    contentOffset = -heightOffsetLimit
+                }
+            }
+        }
         ContentList(
             innerPadding.plus(PaddingValues(vertical = 16.dp, horizontal = 8.dp)),
             verticalArrangement = Arrangement.spacedBy(2.dp),
+            state = listState,
         ) {
             itemsWithPosition(episodes) { position, episode ->
+                val defaultListItemColors = ListItemDefaults.colors()
+                val colors = if (episode.episodeId == viewModel.pendingPulseAnimation) {
+                    val pulseInterpolation = remember { Animatable(0f) }
+                    LaunchedEffect(Unit) {
+                        AnimationDefaults.PulseAnimation.run(pulseInterpolation)
+                        viewModel.pendingPulseAnimation = null
+                    }
+                    val pulseColor = lerp(
+                        start = defaultListItemColors.containerColor,
+                        stop = MaterialTheme.colorScheme.onSurface,
+                        fraction = pulseInterpolation.value,
+                    )
+                    defaultListItemColors.copy(
+                        containerColor = pulseColor,
+                        // Note: parameter necessary to use non-deprecated copy function
+                        selectedContainerColor = Color.Unspecified,
+                    )
+                } else {
+                    defaultListItemColors
+                }
                 EpisodeListItem(
                     episode = episode,
                     position = position,
+                    colors = colors,
                 )
             }
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
 import io.github.couchtracker.db.profile.Bcp47Language
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.tmdb.TmdbFlowRetryContext
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
@@ -26,6 +27,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 class SeasonsScreenViewModel(
     application: Application,
     showId: TmdbShowId,
+    var pendingPulseAnimation: ExternalEpisodeId?,
 ) : AndroidViewModel(
     application = application,
 ) {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/WatchedEpisodeSessionsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/WatchedEpisodeSessionsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.Layers
 import androidx.compose.material.icons.outlined.LayersClear
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -102,6 +103,7 @@ private fun Content(viewModel: WatchedEpisodeSessionsScreenViewModel) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun WatchedEpisodeSessionList(
     viewModel: WatchedEpisodeSessionsScreenViewModel,


### PR DESCRIPTION
Instead of going to the screen of the episodes, with this change clicking an episodes from the up-next section will redirect to the list of all episodes in the season, with an animation to indicate which episodes we clicked.

The list of episodes is more useful to get a "sense" of where the episode is in the season, and which other episodes come next.


[Screen_recording_20260803_132324.webm](https://github.com/user-attachments/assets/f98a873e-ffd9-49b4-8c75-0413a80c4390)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>