### PR TITLE
Download 404

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
@@ -24,7 +24,6 @@ import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -109,7 +108,7 @@ fun <ID : TmdbId, L : Any, T : Any> tmdbLocalizedCachedDownload(
     val fullLogTag = "$id-$language-$logTag"
     val loadFromCacheQuery = loadFromCacheFn(cache)(id, language, ::TmdbTimestampedEntry)
     return tmdbGetOrDownload(
-        logTag = "$id-$fullLogTag",
+        logTag = fullLogTag,
         cacheKey = TmdbCacheKey(loadFromCacheQuery, listOf(id, language)),
         loadFromCache = { loadFromCacheQuery.executeAsOneOrNull() },
         putInCache = { data -> putInCacheFn(cache)(id, language, data.value, data.lastUpdate) },
@@ -156,7 +155,7 @@ fun <L : Any, T : Any> tmdbLocalizedCachedDownload(
  *
  * Handles caching, stale caching, reloads if cache changes.
  */
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 private fun <T : Any> tmdbGetOrDownload(
     logTag: String,
     cacheKey: TmdbCacheKey,
@@ -181,11 +180,22 @@ private fun <T : Any> tmdbGetOrDownload(
                     Log.d(LOG_TAG, "$logTag: Entry is old (age=$age), starting download")
                     when (val downloaded = downloadAndSave(cacheEvent, downloader, putInCache, coroutineContext)) {
                         is Result.Error -> {
-                            Log.w(
-                                LOG_TAG,
-                                "$logTag: Download failed, using a stale entry (${downloaded.error.debugMessage})",
-                                downloaded.error.cause,
-                            )
+                            if (downloaded.error.requiresUserAttention) {
+                                // Error is "important", let's emit it
+                                Log.e(
+                                    LOG_TAG,
+                                    "$logTag: Download failed in a way that requires the user's attention (${downloaded.error.debugMessage})",
+                                    downloaded.error.cause,
+                                )
+                                emit(downloaded)
+                            } else {
+                                // Error not important, let's emit nothing, and keep the stale data
+                                Log.w(
+                                    LOG_TAG,
+                                    "$logTag: Download failed, using a stale entry (${downloaded.error.debugMessage})",
+                                    downloaded.error.cause,
+                                )
+                            }
                         }
                         is Result.Value -> {
                             emit(downloaded)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/OverviewScreenComponents.kt
@@ -222,16 +222,16 @@ object OverviewScreenComponents {
     @Composable
     fun ShowSnackbarOnErrorEffect(
         snackbarHostState: SnackbarHostState,
-        errors: () -> List<CouchTrackerError>,
+        error: () -> CouchTrackerError?,
         onRetry: () -> Unit,
-        retryMessage: String = R.string.error_loading_data.str(),
-        retryAction: String = R.string.retry_action.str(),
     ) {
-        val inError = errors().isNotEmpty()
-        LaunchedEffect(snackbarHostState, inError, onRetry, retryMessage, retryAction) {
-            if (inError) {
+        val error = error()
+        val errorMessage = error?.title?.string()
+        val retryAction = if (error != null && error.isRetriable) R.string.retry_action.str() else null
+        LaunchedEffect(snackbarHostState, onRetry, errorMessage, retryAction) {
+            if (errorMessage != null) {
                 val result = snackbarHostState.showSnackbar(
-                    retryMessage,
+                    errorMessage,
                     actionLabel = retryAction,
                     duration = SnackbarDuration.Indefinite,
                     withDismissAction = true,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package io.github.couchtracker.ui.screens.episodes
 
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -124,7 +122,7 @@ private fun Content(initialEpisode: ExternalEpisodeId, viewModel: EpisodesScreen
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun EpisodesScreenContent(
     viewModel: EpisodesScreenViewModel,
@@ -137,7 +135,7 @@ private fun EpisodesScreenContent(
     val snackbarHostState = remember { SnackbarHostState() }
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { viewModel.allErrors },
+        error = { viewModel.aggregateError },
         onRetry = onRetry,
     )
     val pagerState = rememberPagerState(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/episodes/EpisodesScreenViewModel.kt
@@ -13,9 +13,10 @@ import io.github.couchtracker.tmdb.TmdbFlowRetryContext
 import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
 import io.github.couchtracker.utils.ComposableCache
-import io.github.couchtracker.utils.allErrors
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.collectAsLoadableInScope
+import io.github.couchtracker.utils.error.aggregateErrorOrNull
+import io.github.couchtracker.utils.resultErrorOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -42,9 +43,11 @@ class EpisodesScreenViewModel(
     val colorScheme by baseViewModel.showViewModel.colorScheme.collectAsLoadable("colorScheme")
     val seasonSubtitle get() = baseViewModel.subtitle(seasonDetails, showBaseDetails)
 
-    val allErrors by derivedStateOf {
-        listOf(seasonDetails, showBaseDetails, colorScheme).allErrors() +
-            childModels.elements.flatMap { it.allErrors }
+    val aggregateError by derivedStateOf {
+        listOf(seasonDetails, showBaseDetails, colorScheme)
+            .map { it.resultErrorOrNull() }
+            .plus(childModels.elements.mapNotNull { it.aggregateError })
+            .aggregateErrorOrNull()
     }
 
     class EpisodeViewModel(
@@ -60,8 +63,10 @@ class EpisodesScreenViewModel(
         )
         val details by baseViewModel.details.collectAsLoadableInScope(scope, "details")
         val images by baseViewModel.images.collectAsLoadableInScope(scope, "images")
-        val allErrors by derivedStateOf {
-            listOf(details, images).allErrors()
+        val aggregateError by derivedStateOf {
+            listOf(details, images)
+                .map { it.resultErrorOrNull() }
+                .aggregateErrorOrNull()
         }
     }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSection.kt
@@ -58,7 +58,7 @@ fun MoviesSection(
     val snackbarHostState = remember { SnackbarHostState() }
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { viewModel.allErrors },
+        error = { viewModel.aggregateError },
         onRetry = { viewModel.retryAll() },
     )
     MainSection(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MovieSectionViewModel.kt
@@ -22,6 +22,8 @@ import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.error.CouchTrackerError
 import io.github.couchtracker.utils.error.CouchTrackerResult
 import io.github.couchtracker.utils.error.UnsupportedItemError
+import io.github.couchtracker.utils.error.aggregateErrorOrNull
+import io.github.couchtracker.utils.errorOrNull
 import io.github.couchtracker.utils.injectBrokenItems
 import io.github.couchtracker.utils.map
 import io.github.couchtracker.utils.resultValueOrNull
@@ -54,8 +56,8 @@ class MovieSectionViewModel(application: Application) : AndroidViewModel(applica
             .distinctUntilChanged(),
     ).collectAsLoadable("movies-watchlist")
 
-    val allErrors: List<CouchTrackerError> by derivedStateOf {
-        watchlist.allErrors()
+    val aggregateError: CouchTrackerError? by derivedStateOf {
+        watchlist.aggregateError()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -94,15 +96,10 @@ class MovieSectionViewModel(application: Application) : AndroidViewModel(applica
         }
     }
 
-    private fun Loadable<List<Pair<ExternalMovieId, CouchTrackerResult<MoviePortraitModel>>>>.allErrors(): List<CouchTrackerError> {
+    private fun Loadable<List<Pair<ExternalMovieId, CouchTrackerResult<MoviePortraitModel>>>>.aggregateError(): CouchTrackerError? {
         return when (this) {
-            Loadable.Loading -> emptyList()
-            is Loadable.Loaded -> value.mapNotNull { (_, movie) ->
-                when (movie) {
-                    is Result.Error -> movie.error
-                    is Result.Value -> null
-                }
-            }
+            Loadable.Loading -> null
+            is Loadable.Loaded -> value.map { it.second.errorOrNull() }.aggregateErrorOrNull()
         }
     }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSection.kt
@@ -68,10 +68,10 @@ fun ShowSection(
     // TODO: open up next as a first tab
     val pagerState = rememberPagerState(initialPage = ShowTab.WATCHLIST.ordinal) { ShowTab.entries.size }
     val snackbarHostState = remember { SnackbarHostState() }
-    val modelErrors by viewModel.allErrors().collectAsStateWithLifecycle(emptyList())
+    val modelError by viewModel.aggregateError().collectAsStateWithLifecycle(null)
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { modelErrors },
+        error = { modelError },
         onRetry = { viewModel.retryAll() },
     )
     MainSection(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
@@ -30,32 +30,33 @@ import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.collectWithPrevious
-import io.github.couchtracker.utils.combineResults
 import io.github.couchtracker.utils.error.ApiLoadable
 import io.github.couchtracker.utils.error.CouchTrackerError
 import io.github.couchtracker.utils.error.CouchTrackerLoadable
 import io.github.couchtracker.utils.error.CouchTrackerResult
 import io.github.couchtracker.utils.error.UnsupportedItemError
+import io.github.couchtracker.utils.error.aggregateError
+import io.github.couchtracker.utils.error.aggregateErrorOrNull
+import io.github.couchtracker.utils.error.aggregateResults
 import io.github.couchtracker.utils.flatMap
 import io.github.couchtracker.utils.injectBrokenItems
 import io.github.couchtracker.utils.map
+import io.github.couchtracker.utils.mapResult
 import io.github.couchtracker.utils.rememberingCombined
 import io.github.couchtracker.utils.resultErrorOrNull
 import io.github.couchtracker.utils.resultValueOrNull
 import io.github.couchtracker.utils.valueOrNull
+import io.github.couchtracker.utils.withLoading
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.datetime.LocalDate
@@ -163,17 +164,17 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         }
         .collectAsLoadable("shows-up-next")
 
-    fun allErrors(): Flow<List<CouchTrackerError>> {
+    fun aggregateError(): Flow<CouchTrackerError?> {
         // Note: all errors in this model originate from `bookmarks`, so I don't need to check errors of individual fields
         return bookmarks.map { bookmarks ->
             when (bookmarks) {
-                Loadable.Loading -> emptyList()
+                Loadable.Loading -> null
                 is Loadable.Loaded -> bookmarks.value.mapNotNull { bookmarkedShowData ->
                     when (bookmarkedShowData.data) {
                         is Result.Error -> bookmarkedShowData.data.error
                         is Result.Value -> bookmarkedShowData.data.value.seasons.resultErrorOrNull()
                     }
-                }
+                }.aggregateErrorOrNull()
             }
         }
     }
@@ -213,37 +214,17 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                 Result.Error(UnsupportedItemError(showId)),
             )
         }
-        return tmdbShowId.details(languages.apiLanguage).transform { result ->
-            val details = when (result) {
-                is Result.Error -> {
-                    emit(result)
-                    return@transform
-                }
-                is Result.Value -> result.value
-            }
-            val bookmarkedShow = Result.Value(
-                value = BookmarkedShowData(
-                    baseShowData = details.toBaseShow(languages.apiLanguage),
-                    portraitModel = details.toShowPortraitModels(application, languages.apiLanguage),
-                    seasons = Loadable.Loading,
-                    originalLanguage = details.language(),
-                ),
-            )
-            emit(bookmarkedShow)
-            emitAll(
-                combine(
-                    details.seasons.map {
-                        val seasonId = TmdbSeasonId(tmdbShowId, it.seasonNumber)
-                        seasonId.details(languages.apiLanguage)
-                    },
-                ) { seasons ->
-                    val bookmarkedSeasonsData = seasons.asList().combineResults().map { season ->
-                        season.map { season ->
-                            val seasonId = TmdbSeasonId(tmdbShowId, season.seasonNumber)
+        return tmdbShowId.details(languages.apiLanguage)
+            .rememberingCombined(
+                keys = { showDetails -> showDetails.valueOrNull()?.seasons.orEmpty().map { it.seasonNumber }.toSet() },
+                flowToRemember = { seasonNumber ->
+                    val seasonId = TmdbSeasonId(tmdbShowId, seasonNumber)
+                    seasonId.details(languages.apiLanguage).withLoading().map { seasonResult ->
+                        seasonResult.mapResult { seasonDetails ->
                             BookmarkedSeasonData(
                                 id = seasonId,
-                                number = season.seasonNumber,
-                                episodes = season.episodes.orEmpty().map { episode ->
+                                number = seasonNumber,
+                                episodes = seasonDetails.episodes.orEmpty().map { episode ->
                                     BookmarkedEpisodeData(
                                         number = episode.episodeNumber,
                                         name = episode.name,
@@ -254,14 +235,24 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                             )
                         }
                     }
-                    Result.Value(
-                        value = bookmarkedShow.value.copy(
-                            seasons = Loadable.Loaded(bookmarkedSeasonsData),
-                        ),
-                    )
                 },
-            )
-        }
+            ) { showDetails, seasonsDataCache ->
+                val details = when (showDetails) {
+                    is Result.Error -> {
+                        return@rememberingCombined showDetails
+                    }
+                    is Result.Value -> showDetails.value
+                }
+                val seasons = details.seasons.map { seasonsDataCache.getValue(it.seasonNumber) }.aggregateResults()
+                Result.Value(
+                    value = BookmarkedShowData(
+                        baseShowData = details.toBaseShow(languages.apiLanguage),
+                        portraitModel = details.toShowPortraitModels(application, languages.apiLanguage),
+                        seasons = seasons,
+                        originalLanguage = details.language(),
+                    ),
+                )
+            }
     }
 
     private fun BookmarkedShow.upNextEntries(): CouchTrackerLoadable<List<UpNextEntry>> {
@@ -352,8 +343,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                 .flatten()
                 .sortedByDescending { it.lastWatchedEpisode }
             if (loaded.isEmpty()) {
-                // Note: I'm just taking the first error; in principle they could be merged
-                Loadable.error(firstNotNullOf { it.resultErrorOrNull() })
+                Loadable.error(mapNotNull { it.resultErrorOrNull() }.aggregateError())
             } else {
                 Loadable.value(loaded)
             }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreen.kt
@@ -1,9 +1,6 @@
-@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
-
 package io.github.couchtracker.ui.screens.movie
 
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -124,7 +121,7 @@ private fun Content(viewModel: MovieScreenViewModel, actions: Actions) {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun MovieScreenContent(
     viewModel: MovieScreenViewModel,
@@ -137,7 +134,7 @@ private fun MovieScreenContent(
 
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { viewModel.allErrors },
+        error = { viewModel.aggregateError },
         onRetry = reloadMovie,
     )
     logCompositions(LOG_TAG, "Recomposing MovieScreenContent")

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/movie/MovieScreenViewModel.kt
@@ -7,9 +7,10 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.couchtracker.tmdb.TmdbMovieId
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
-import io.github.couchtracker.utils.allErrors
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.error.CouchTrackerError
+import io.github.couchtracker.utils.error.aggregateErrorOrNull
+import io.github.couchtracker.utils.resultErrorOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -33,8 +34,10 @@ class MovieScreenViewModel(
     val images by baseViewModel.images.collectAsLoadable(debugLog = "images")
     val credits by baseViewModel.credits.collectAsLoadable(debugLog = "credits")
 
-    val allErrors: List<CouchTrackerError> by derivedStateOf {
-        listOf(baseDetails, fullDetails, colorScheme, images, credits).allErrors()
+    val aggregateError: CouchTrackerError? by derivedStateOf {
+        listOf(baseDetails, fullDetails, colorScheme, images, credits)
+            .map { it.resultErrorOrNull() }
+            .aggregateErrorOrNull()
     }
 
     fun retryAll() {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreen.kt
@@ -126,7 +126,7 @@ private fun SeasonsScreenContent(
     val snackbarHostState = remember { SnackbarHostState() }
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { viewModel.allErrors },
+        error = { viewModel.aggregateError },
         onRetry = reloadSeason,
     )
     val pagerState = rememberPagerState(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/seasons/SeasonsScreenViewModel.kt
@@ -16,9 +16,10 @@ import io.github.couchtracker.tmdb.TmdbSeasonId
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
 import io.github.couchtracker.utils.ComposableCache
-import io.github.couchtracker.utils.allErrors
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.collectAsLoadableInScope
+import io.github.couchtracker.utils.error.aggregateErrorOrNull
+import io.github.couchtracker.utils.resultErrorOrNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -43,9 +44,11 @@ class SeasonsScreenViewModel(
     val showDetails by baseViewModel.showDetails.collectAsLoadable("showDetails")
     val colorScheme by baseViewModel.colorScheme.collectAsLoadable("colorScheme")
 
-    val allErrors by derivedStateOf {
-        listOf(showDetails, colorScheme).allErrors() +
-            childModels.elements.flatMap { it.allErrors }
+    val aggregateError by derivedStateOf {
+        listOf(showDetails, colorScheme)
+            .map { it.resultErrorOrNull() }
+            .plus(childModels.elements.mapNotNull { it.aggregateError })
+            .aggregateErrorOrNull()
     }
 
     class SeasonViewModel(
@@ -64,8 +67,8 @@ class SeasonsScreenViewModel(
         )
 
         val details by baseViewModel.details.collectAsLoadableInScope(scope, "details")
-        val allErrors by derivedStateOf {
-            listOf(details).allErrors()
+        val aggregateError by derivedStateOf {
+            details.resultErrorOrNull()
         }
     }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -125,7 +124,6 @@ private fun TmdbShowContent(viewModel: ShowScreenViewModel, actions: Actions) {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun ShowScreenContent(
     viewModel: ShowScreenViewModel,
@@ -141,7 +139,7 @@ private fun ShowScreenContent(
     val snackbarHostState = remember { SnackbarHostState() }
     OverviewScreenComponents.ShowSnackbarOnErrorEffect(
         snackbarHostState = snackbarHostState,
-        errors = { viewModel.allErrors },
+        error = { viewModel.aggregateError },
         onRetry = reloadShow,
     )
     logCompositions(LOG_TAG, "Recomposing ShowScreenContent")

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/show/ShowScreenViewModel.kt
@@ -7,9 +7,10 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.couchtracker.tmdb.TmdbShowId
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
-import io.github.couchtracker.utils.allErrors
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.error.CouchTrackerError
+import io.github.couchtracker.utils.error.aggregateErrorOrNull
+import io.github.couchtracker.utils.resultErrorOrNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -33,8 +34,10 @@ class ShowScreenViewModel(
     val images by baseViewModel.images.collectAsLoadable("images")
     val credits by baseViewModel.credits.collectAsLoadable("credits")
 
-    val allErrors: List<CouchTrackerError> by derivedStateOf {
-        listOf(baseDetails, fullDetails, colorScheme, images, credits).allErrors()
+    val aggregateError: CouchTrackerError? by derivedStateOf {
+        listOf(baseDetails, fullDetails, colorScheme, images, credits)
+            .map { it.resultErrorOrNull() }
+            .aggregateErrorOrNull()
     }
 
     fun retryAll() {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Flow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Flow.kt
@@ -1,6 +1,5 @@
 package io.github.couchtracker.utils
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -9,7 +8,9 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combineTransform
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 fun <T, R> Flow<T>.collectWithPrevious(operation: suspend (previous: R?, value: T) -> R): Flow<R> = flow {
@@ -26,7 +27,6 @@ fun <T, R> Flow<T>.collectWithPrevious(operation: suspend (previous: R?, value: 
  *
  * As a design decision, only the latest value of all involved Flows is used.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 fun <I : Any, P1, P2, O> Flow<I>.biFork(
     fork1: (Flow<I>) -> Flow<P1>,
     fork2: (Flow<I>) -> Flow<P2>,
@@ -66,7 +66,7 @@ private sealed interface RememberingCombinedEvent<I : Any, K, C> {
 fun <I : Any, K, C, O> Flow<I>.rememberingCombined(
     keys: (I) -> Set<K>,
     flowToRemember: (K) -> Flow<C>,
-    f: (I, Map<K, C>) -> O,
+    f: suspend (I, Map<K, C>) -> O,
 ): Flow<O> = channelFlow {
     val jobs = mutableMapOf<K, Job>()
     val events = Channel<RememberingCombinedEvent<I, K, C>>()
@@ -131,5 +131,13 @@ fun <I : Any, K, C, O> Flow<I>.rememberingCombined(
         if (latestItem != null && latestValues.size == keysCount) {
             send(f(latestItem, latestValues))
         }
+    }
+}
+
+fun <T> Flow<T>.withLoading(): Flow<Loadable<T>> {
+    val original = this
+    return flow {
+        emit(Loadable.Loading)
+        emitAll(original.map { Loadable.Loaded(it) })
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Loadable.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Loadable.kt
@@ -83,14 +83,6 @@ inline fun <T> Loadable<T>.onValue(f: (T) -> Unit): Loadable<T> {
     return this
 }
 
-fun <T> List<Loadable<T>>.allLoaded(): List<T> {
-    return filterIsInstance<Loadable.Loaded<T>>().map { it.value }
-}
-
-fun <E> List<Loadable<Result<*, E>>>.allErrors(): List<E> {
-    return allLoaded().allErrors()
-}
-
 @Composable
 fun <T> Flow<T>.collectAsLoadableWithLifecycle(): State<Loadable<T>> {
     return remember(this) { map { Loadable.Loaded(it) } }.collectAsStateWithLifecycle(Loadable.Loading)

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/Result.kt
@@ -125,22 +125,3 @@ inline fun <T : R, E, R> Result<T, E>.ifError(block: (E) -> R): R {
         is Result.Error -> block(this.error)
     }
 }
-
-fun <E> List<Result<*, E>>.allErrors(): List<E> {
-    return filterIsInstance<Result.Error<E>>().map { it.error }
-}
-
-/**
- * Returns the list of all values, or the first error
- */
-fun <T, E> List<Result<T, E>>.combineResults(): Result<List<T>, E> {
-    val values = buildList {
-        for (result in this@combineResults) {
-            when (result) {
-                is Result.Value -> add(result.value)
-                is Result.Error -> return Result.Error(result.error)
-            }
-        }
-    }
-    return Result.Value(values)
-}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/ApiError.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/ApiError.kt
@@ -14,6 +14,8 @@ typealias ApiLoadable<T> = Loadable<ApiResult<T>>
 
 sealed interface ApiError : CouchTrackerError {
 
+    override val requiresUserAttention: Boolean get() = false
+
     data class ClientError(override val cause: ClientRequestException) : ApiError {
         override val debugMessage = cause.message
         override val title = Text.Resource(R.string.api_exception_client_error)
@@ -51,6 +53,7 @@ sealed interface ApiError : CouchTrackerError {
             null
         }
         override val isRetriable = false
+        override val requiresUserAttention = true
     }
 
     data class Simulated(override val cause: SimulatedException? = null) : ApiError {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/CouchTrackerError.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/CouchTrackerError.kt
@@ -16,6 +16,12 @@ interface CouchTrackerError {
     val title: Text
     val details: Text?
     val isRetriable: Boolean
+
+    /**
+     * Whether the issue is not transitory, and generally required explicit action from the user to be solved,
+     * for example, by removing a show that no longer exists from the bookmarks
+     **/
+    val requiresUserAttention: Boolean
 }
 
 /**

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/CouchTrackerErrorAggregate.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/CouchTrackerErrorAggregate.kt
@@ -1,0 +1,94 @@
+package io.github.couchtracker.utils.error
+
+import io.github.couchtracker.utils.Loadable
+import io.github.couchtracker.utils.Result
+import io.github.couchtracker.utils.Text
+
+/**
+ * This class aggregates a set of errors.
+ * It is biased towards returning the information of an error that `requiresUserAttention`.
+ */
+data class CouchTrackerErrorAggregate(
+    val errors: Set<CouchTrackerError>,
+) : CouchTrackerError {
+
+    init {
+        require(errors.size > 1)
+        require(errors.none { it is CouchTrackerErrorAggregate })
+    }
+
+    private val mainError = errors.maxBy { it.requiresUserAttention }
+
+    override val debugMessage: String
+        get() = errors.joinToString { it.debugMessage }
+
+    override val cause: Exception?
+        get() = mainError.cause
+
+    override val title: Text
+        get() = mainError.title
+
+    override val details: Text?
+        get() = mainError.details
+
+    override val isRetriable: Boolean
+        get() = errors.any { it.isRetriable }
+
+    override val requiresUserAttention: Boolean
+        get() = errors.any { it.requiresUserAttention }
+}
+
+private fun Collection<CouchTrackerError?>.flattenInto(list: MutableCollection<CouchTrackerError>) {
+    for (error in this) {
+        when (error) {
+            null -> {}
+            is CouchTrackerErrorAggregate -> error.errors.flattenInto(list)
+            else -> list.add(error)
+        }
+    }
+}
+
+fun Collection<CouchTrackerError?>.aggregateErrorOrNull(): CouchTrackerError? {
+    val uniqueErrors = mutableSetOf<CouchTrackerError>()
+    this.flattenInto(uniqueErrors)
+    return when (uniqueErrors.size) {
+        0 -> null
+        1 -> uniqueErrors.single()
+        else -> CouchTrackerErrorAggregate(uniqueErrors)
+    }
+}
+
+fun Collection<CouchTrackerError>.aggregateError(): CouchTrackerError {
+    return aggregateErrorOrNull() ?: error("No errors found")
+}
+
+/**
+ * Transforms a list of results to a result of list.
+ * Returns the list of all loaded values, the aggregated error, or Loading.
+ */
+fun <T> Collection<CouchTrackerLoadable<T>>.aggregateResults(): CouchTrackerLoadable<List<T>> {
+    // Function optimized for iterating elements once
+    val loaded = mutableListOf<T>()
+    val errors = mutableListOf<CouchTrackerError>()
+    var hasLoadings = false
+    for (result in this) {
+        when (result) {
+            is Loadable.Loaded -> when (result.value) {
+                is Result.Value -> {
+                    if (errors.isEmpty() && !hasLoadings) {
+                        loaded.add(result.value.value)
+                    }
+                }
+                is Result.Error -> errors.add(result.value.error)
+            }
+            Loadable.Loading -> hasLoadings = true
+        }
+    }
+    return if (errors.isNotEmpty()) {
+        Loadable.error(errors.aggregateError())
+    } else if (hasLoadings) {
+        Loadable.Loading
+    } else {
+        Loadable.value(loaded)
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/UnsupportedItemError.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/error/UnsupportedItemError.kt
@@ -11,4 +11,5 @@ data class UnsupportedItemError(val unsupportedItem: ExternalId) : CouchTrackerE
     override val title = Text.Resource(R.string.unsupported_item_id)
     override val details = Text.Lambda { R.string.unsupported_item_id_description.str(unsupportedItem.serialize()) }
     override val isRetriable = false
+    override val requiresUserAttention = true
 }

--- a/composeApp/src/test/kotlin/io/github/couchtracker/utils/error/AggregateResultsTest.kt
+++ b/composeApp/src/test/kotlin/io/github/couchtracker/utils/error/AggregateResultsTest.kt
@@ -1,0 +1,97 @@
+package io.github.couchtracker.utils.error
+
+import io.github.couchtracker.utils.Loadable
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class AggregateResultsTest : FunSpec(
+    {
+
+        val error1 = ApiError.Simulated()
+        val error2 = ApiError.ItemNotFound(RuntimeException(), itemIdentifier = null)
+
+        test("returns all values when every result is loaded successfully") {
+            val results = listOf(
+                Loadable.value("one"),
+                Loadable.value("two"),
+                Loadable.value("three"),
+            )
+
+            results.aggregateResults() shouldBe
+                Loadable.value(listOf("one", "two", "three"))
+        }
+
+        test("returns an empty list when the collection is empty") {
+            emptyList<CouchTrackerLoadable<String>>().aggregateResults() shouldBe Loadable.value(emptyList())
+        }
+
+        test("returns Loading when any result is loading and there are no errors") {
+            val results = listOf(
+                Loadable.value("one"),
+                Loadable.Loading,
+                Loadable.value("three"),
+            )
+
+            results.aggregateResults() shouldBe Loadable.Loading
+        }
+
+        test("returns Loading when all results are loading") {
+            val results = listOf(Loadable.Loading, Loadable.Loading)
+
+            results.aggregateResults<Int>() shouldBe Loadable.Loading
+        }
+
+        test("returns the single error when there is one error") {
+            val results = listOf(
+                Loadable.value("one"),
+                Loadable.error(error1),
+                Loadable.value("three"),
+            )
+            results.aggregateResults() shouldBe Loadable.error(error1)
+        }
+
+        test("aggregates multiple errors") {
+            val results = listOf(
+                Loadable.error(error1),
+                Loadable.error(error2),
+            )
+
+            results.aggregateResults() shouldBe
+                Loadable.error(listOf(error1, error2).aggregateError())
+        }
+
+        test("errors take precedence over Loading") {
+            val results = listOf(
+                Loadable.value("one"),
+                Loadable.Loading,
+                Loadable.error(error1),
+                Loadable.Loading,
+            )
+
+            results.aggregateResults() shouldBe
+                Loadable.error(error1)
+        }
+
+        test("errors take precedence over successfully loaded values") {
+            val results = listOf(
+                Loadable.value("one"),
+                Loadable.error(error1),
+                Loadable.value("three"),
+            )
+
+            results.aggregateResults() shouldBe
+                Loadable.error(error1)
+        }
+
+        test("preserves the order of loaded values") {
+            val results = listOf(
+                Loadable.value("first"),
+                Loadable.value("second"),
+                Loadable.value("third"),
+            )
+
+            results.aggregateResults() shouldBe
+                Loadable.value(listOf("first", "second", "third"))
+        }
+    },
+)


### PR DESCRIPTION
This commit implements three improvements:
1. some errors are preferred over stale data (e.g. an item not found)
2. errors are always aggregated using `CouchTrackerErrorAggregate`
3. bugfix on the main related to refreshing the information when the show detail changes

Note 1: I feel like there's still room for improvements: for example, looking at the screenshot below, it's hard for the user to know which TV show it was originally; technically we could somehow display some stale local data (e.g. show name, poster, etc.).  

Note 2: The error message in the snackbar is right, but it's still pretty generic. The user has to scroll through the TV shows to find the one in error. Ideally there could be a button to open the show, or to explain to the user how to solve the issue (i.e. remove it from bookmarks).

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/10c5307b-b643-46d2-8d0b-5fb57d7986f5" />
