### PR TITLE
Add style and behavior settings

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/settings/AppSettings.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/settings/AppSettings.kt
@@ -12,15 +12,17 @@ import io.github.couchtracker.utils.settings.LoadedSettingsFlow
 import io.github.couchtracker.utils.settings.LoadedSettingsGetter
 import kotlinx.coroutines.flow.flowOf
 import org.koin.compose.koinInject
+import org.koin.core.Koin
 import org.koin.mp.KoinPlatform
 
 val LocalAppSettingsContext = compositionLocalOf<LoadedSettings<AppSettings>> { error("no default app settings context") }
 
 object AppSettings : AbstractAppSettings(), LoadedSettingsGetter<AppSettings> {
 
-    override val loadedSettingsFlow by KoinPlatform.getKoin().inject<LoadedSettingsFlow<AppSettings>>()
+    override val loadedSettingsFlow by KoinPlatform.getKoin().injectAppSettings()
 
     val Tmdb = settings(TmdbSettings)
+    val StyleAndBehavior = settings(StyleAndBehaviorSettings)
 
     val CurrentProfileId = setting(
         key = longPreferencesKey("currentProfileId"),
@@ -43,3 +45,6 @@ fun AppSettingsContext(content: @Composable () -> Unit) {
 fun appSettings(): LoadedSettings<AppSettings> {
     return LocalAppSettingsContext.current
 }
+
+fun Koin.injectAppSettings() = inject<LoadedSettingsFlow<AppSettings>>()
+fun Koin.getAppSettings() = get<LoadedSettingsFlow<AppSettings>>().settings

--- a/composeApp/src/main/kotlin/io/github/couchtracker/settings/StyleAndBehaviorSettings.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/settings/StyleAndBehaviorSettings.kt
@@ -1,0 +1,37 @@
+package io.github.couchtracker.settings
+
+import org.koin.core.component.KoinComponent
+import java.util.Locale
+
+object StyleAndBehaviorSettings : AbstractAppSettings(), KoinComponent {
+
+    @Suppress("EnumNaming", "EnumEntryNameCase")
+    enum class EpisodeNumberFormattingOption(
+        private val template: String,
+    ) {
+        S01E02($$"S%1$02dE%2$02d"),
+        sXXeYY($$"s%1$02de%2$02d"),
+        XXxYY($$"%1$02dx%2$02d"),
+        XxY($$"%1$dx%2$d"),
+        ;
+
+        fun format(seasonNumber: Int, episodeNumber: Int): String {
+            return template.format(locale = Locale.ROOT, seasonNumber, episodeNumber)
+        }
+    }
+
+    val EpisodeNumberFormatting = setting<EpisodeNumberFormattingOption>(
+        key = "episodeNumberFormatting",
+        default = EpisodeNumberFormattingOption.S01E02,
+    )
+
+    enum class OpenEpisodeBehaviorOption {
+        HIGHLIGHT_IN_SEASON,
+        OPEN_EPISODE_DETAILS,
+    }
+
+    val OpenEpisodeBehavior = setting<OpenEpisodeBehaviorOption>(
+        key = "openEpisodeBehavior",
+        default = OpenEpisodeBehaviorOption.HIGHLIGHT_IN_SEASON,
+    )
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/EpisodeUtils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/EpisodeUtils.kt
@@ -1,0 +1,44 @@
+package io.github.couchtracker.ui
+
+import android.content.Context
+import io.github.couchtracker.R
+import io.github.couchtracker.settings.StyleAndBehaviorSettings
+
+fun seasonEpisodeNumberToString(
+    context: Context,
+    formatting: StyleAndBehaviorSettings.EpisodeNumberFormattingOption,
+    seasonNumber: Int,
+    episodeNumber: Int,
+    episodeName: String? = null,
+): String {
+    return if (seasonNumber == 0) {
+        if (episodeName == null) {
+            context.getString(R.string.season_special_episode, episodeNumber)
+        } else {
+            context.getString(R.string.season_special_episode_with_name, episodeNumber, episodeName)
+        }
+    } else {
+        val episodeFormatted = formatting.format(seasonNumber, episodeNumber)
+        if (episodeName == null) {
+            episodeFormatted
+        } else {
+            context.getString(R.string.season_episode_with_name, episodeFormatted, episodeName)
+        }
+    }
+}
+
+fun showSeasonEpisodeNumberToString(
+    context: Context,
+    formatting: StyleAndBehaviorSettings.EpisodeNumberFormattingOption,
+    showName: String?,
+    seasonNumber: Int,
+    episodeNumber: Int,
+    episodeName: String? = null,
+): String {
+    val seasonEpisodeString = seasonEpisodeNumberToString(context, formatting, seasonNumber, episodeNumber, episodeName)
+    return if (showName == null) {
+        seasonEpisodeString
+    } else {
+        context.getString(R.string.show_dash_x, showName, seasonEpisodeString)
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/SeasonUtils.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/SeasonUtils.kt
@@ -12,37 +12,6 @@ fun seasonNumberToString(context: Context, seasonNumber: Int): String {
     }
 }
 
-fun seasonEpisodeNumberToString(context: Context, seasonNumber: Int, episodeNumber: Int, episodeName: String? = null): String {
-    return if (seasonNumber == 0) {
-        if (episodeName == null) {
-            context.getString(R.string.season_special_episode, episodeNumber)
-        } else {
-            context.getString(R.string.season_special_episode_with_name, episodeNumber, episodeName)
-        }
-    } else {
-        if (episodeName == null) {
-            context.getString(R.string.season_episode, seasonNumber, episodeNumber)
-        } else {
-            context.getString(R.string.season_episode_with_name, seasonNumber, episodeNumber, episodeName)
-        }
-    }
-}
-
-fun showSeasonEpisodeNumberToString(
-    context: Context,
-    showName: String?,
-    seasonNumber: Int,
-    episodeNumber: Int,
-    episodeName: String? = null,
-): String {
-    val seasonEpisodeString = seasonEpisodeNumberToString(context, seasonNumber, episodeNumber, episodeName)
-    return if (showName == null) {
-        seasonEpisodeString
-    } else {
-        context.getString(R.string.show_dash_x, showName, seasonEpisodeString)
-    }
-}
-
 data class SeasonNames(
     val mainName: String,
     val secondaryName: String?,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
@@ -26,6 +26,10 @@ import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
 import io.github.couchtracker.intl.datetime.EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS
 import io.github.couchtracker.intl.datetime.rememberLocalizer
+import io.github.couchtracker.settings.StyleAndBehaviorSettings
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.OpenEpisodeBehaviorOption.HIGHLIGHT_IN_SEASON
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.OpenEpisodeBehaviorOption.OPEN_EPISODE_DETAILS
+import io.github.couchtracker.settings.appSettings
 import io.github.couchtracker.tmdb.BaseTmdbShow
 import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbSeasonId
@@ -34,6 +38,7 @@ import io.github.couchtracker.ui.ItemPosition
 import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.actions.markEpisodeAsWatchedAction
 import io.github.couchtracker.ui.rememberPlaceholderPainter
+import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
 import io.github.couchtracker.ui.screens.main.ShowSectionViewModel
 import io.github.couchtracker.ui.screens.seasons.navigateToSeason
 import io.github.couchtracker.ui.screens.show.navigateToShow
@@ -54,6 +59,7 @@ fun UpNextListItem(
     modifier: Modifier = Modifier,
 ) {
     val navController = LocalNavController.current
+    val openEpisodeBehavior = appSettings().get { StyleAndBehavior.OpenEpisodeBehavior }
 
     val dateTimeLocalizer = rememberLocalizer(EPISODE_FIRST_AIRDATE_LOCALIZER_OPTIONS, ::DynamicLocalDateLocalizer)
     val dateTimeText = rememberTickingValue(dateTimeLocalizer, upNext.episodeAirDate) {
@@ -76,7 +82,10 @@ fun UpNextListItem(
         modifier = modifier,
         action = markEpisodeAsWatchedAction,
         onClick = {
-            navController.navigateToSeason(upNext.seasonId, upNext.episodeId)
+            when (openEpisodeBehavior.current) {
+                HIGHLIGHT_IN_SEASON -> navController.navigateToSeason(upNext.seasonId, upNext.episodeId)
+                OPEN_EPISODE_DETAILS -> navController.navigateToEpisode(upNext.episodeId)
+            }
         },
         leadingContentHeight = POSTER_HEIGHT,
         position = position,
@@ -128,8 +137,10 @@ data class UpNextListItemModel(
 
     companion object {
 
+        @Suppress("LongParameterList")
         fun withShowData(
             context: Context,
+            episodeFormatting: StyleAndBehaviorSettings.EpisodeNumberFormattingOption,
             watchSession: WatchedEpisodeSessionWrapper?,
             show: ShowSectionViewModel.BookmarkedShowData,
             season: ShowSectionViewModel.BookmarkedSeasonData,
@@ -138,7 +149,13 @@ data class UpNextListItemModel(
             val showId = show.baseShowData.key.id
             val seasonId = TmdbSeasonId(showId, season.number)
             val episodeId = TmdbExternalEpisodeId(TmdbEpisodeId(seasonId, episode.number))
-            val episodeNumberLabel = seasonEpisodeNumberToString(context, season.number, episode.number, episode.name)
+            val episodeNumberLabel = seasonEpisodeNumberToString(
+                context = context,
+                formatting = episodeFormatting,
+                seasonNumber = season.number,
+                episodeNumber = episode.number,
+                episodeName = episode.name,
+            )
 
             return UpNextListItemModel(
                 showId = showId.toExternalId(),

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
@@ -13,6 +13,8 @@ import io.github.couchtracker.db.profile.externalids.TmdbExternalShowId
 import io.github.couchtracker.db.profile.externalids.UnknownExternalShowId
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemWrapper
+import io.github.couchtracker.settings.AppSettings
+import io.github.couchtracker.settings.StyleAndBehaviorSettings
 import io.github.couchtracker.tmdb.BaseTmdbShow
 import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbLanguages
@@ -45,6 +47,7 @@ import io.github.couchtracker.utils.mapResult
 import io.github.couchtracker.utils.rememberingCombined
 import io.github.couchtracker.utils.resultErrorOrNull
 import io.github.couchtracker.utils.resultValueOrNull
+import io.github.couchtracker.utils.settings.get
 import io.github.couchtracker.utils.valueOrNull
 import io.github.couchtracker.utils.withLoading
 import kotlinx.coroutines.Dispatchers
@@ -52,6 +55,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
@@ -148,12 +152,14 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         }
     }.collectAsLoadable("shows-following")
 
-    val upNext: CouchTrackerLoadable<List<UpNextEntry>> by bookmarks
-        .collectWithPrevious { previous: Loadable<Map<BookmarkedShow, CouchTrackerLoadable<List<UpNextEntry>>>>?, bookmarks ->
-            bookmarks.map { bookmarks ->
-                bookmarks.associateWith { bookmarkedShowData ->
-                    val old = previous?.valueOrNull()?.get(bookmarkedShowData)
-                    old ?: bookmarkedShowData.upNextEntries()
+    val upNext: CouchTrackerLoadable<List<UpNextEntry>> by AppSettings.get { StyleAndBehavior.EpisodeNumberFormatting }
+        .flatMapLatest { episodeFormatting ->
+            bookmarks.collectWithPrevious { previous: Loadable<Map<BookmarkedShow, CouchTrackerLoadable<List<UpNextEntry>>>>?, bookmarks ->
+                bookmarks.map { bookmarks ->
+                    bookmarks.associateWith { bookmarkedShowData ->
+                        val old = previous?.valueOrNull()?.get(bookmarkedShowData)
+                        old ?: bookmarkedShowData.upNextEntries(episodeFormatting.current)
+                    }
                 }
             }
         }
@@ -255,7 +261,9 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
             }
     }
 
-    private fun BookmarkedShow.upNextEntries(): CouchTrackerLoadable<List<UpNextEntry>> {
+    private fun BookmarkedShow.upNextEntries(
+        episodeFormatting: StyleAndBehaviorSettings.EpisodeNumberFormattingOption,
+    ): CouchTrackerLoadable<List<UpNextEntry>> {
         val (showData, seasons) = when (this.data) {
             is Result.Error -> return Loadable.Loaded(data)
             is Result.Value -> {
@@ -279,12 +287,13 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         return Loadable.value(
             watchSessionsToDisplay.mapNotNull { (watchSession, episodes) ->
                 upNextEntry(
-                    showId,
-                    watchSession,
-                    episodes,
-                    showData,
-                    seasons,
+                    showId = showId,
+                    watchSession = watchSession,
+                    watchedEpisodes = episodes,
+                    showData = showData,
+                    seasons = seasons,
                     hasMultipleWatchSessions = watchSessionsToDisplay.size > 1,
+                    episodeFormatting = episodeFormatting,
                 )
             },
         )
@@ -298,6 +307,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         showData: BookmarkedShowData,
         seasons: List<BookmarkedSeasonData>,
         hasMultipleWatchSessions: Boolean,
+        episodeFormatting: StyleAndBehaviorSettings.EpisodeNumberFormattingOption,
     ): UpNextEntry? {
         val watchedEpisodesIds = watchedEpisodes.mapTo(HashSet()) { it.itemId }
         for (season in seasons) {
@@ -319,6 +329,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                             watchSession = watchSession,
                             model = UpNextListItemModel.withShowData(
                                 context = application,
+                                episodeFormatting = episodeFormatting,
                                 watchSession = watchSession,
                                 show = showData,
                                 season = season,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/MainSettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/MainSettingsScreen.kt
@@ -3,6 +3,7 @@ package io.github.couchtracker.ui.screens.settings
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.ManageAccounts
+import androidx.compose.material.icons.filled.Style
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -37,6 +38,12 @@ private fun MainSettingsScreenContent() {
                 Icon(Icons.Filled.ManageAccounts, contentDescription = null)
             },
             onClick = { navController.navigate(ProfilesSettingsScreen) },
+        )
+        preference(
+            key = "ux",
+            icon = { Icon(Icons.Default.Style, contentDescription = null) },
+            title = { Text(R.string.style_and_behavior.str()) },
+            onClick = { navController.navigate(StyleAndBehaviorSettingsScreen) },
         )
         // TODO move to appropriate section
         preference(

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ fun NavGraphBuilder.settings() {
         composable<MainSettingsScreen>()
         composable<ProfilesSettingsScreen>()
         composable<ProfileSettingsScreen>()
+        composable<StyleAndBehaviorSettingsScreen>()
         composable<TmdbLanguagesSettingsScreen>()
     }
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/StyleAndBehaviorSettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/StyleAndBehaviorSettingsScreen.kt
@@ -1,0 +1,116 @@
+package io.github.couchtracker.ui.screens.settings
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import io.github.couchtracker.R
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.EpisodeNumberFormattingOption
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.OpenEpisodeBehaviorOption
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.OpenEpisodeBehaviorOption.HIGHLIGHT_IN_SEASON
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.OpenEpisodeBehaviorOption.OPEN_EPISODE_DETAILS
+import io.github.couchtracker.settings.appSettings
+import io.github.couchtracker.ui.Screen
+import io.github.couchtracker.utils.str
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import me.zhanghai.compose.preference.ListPreference
+import me.zhanghai.compose.preference.ListPreferenceType
+import me.zhanghai.compose.preference.PreferenceCategory
+
+@Serializable
+data object StyleAndBehaviorSettingsScreen : Screen() {
+
+    override fun profileDataContext() = false
+
+    @Composable
+    override fun Content() {
+        ScreenContainer { SettingsContent() }
+    }
+}
+
+private const val EXAMPLE_SEASON = 1
+private const val EXAMPLE_EPISODE = 2
+
+@Composable
+private fun SettingsContent() {
+    val settings = appSettings()
+    val cs = rememberCoroutineScope()
+    val openEpisodeBehavior by settings.get { StyleAndBehavior.OpenEpisodeBehavior }
+    val episodeFormatting by settings.get { StyleAndBehavior.EpisodeNumberFormatting }
+    BaseSettings(
+        title = R.string.style_and_behavior.str(),
+        header = null,
+        footer = null,
+    ) {
+        item("style-category") { PreferenceCategory(title = { Text(R.string.style.str()) }) }
+        item("abbreviated-episode-format") {
+            ListPreference(
+                value = episodeFormatting,
+                onValueChange = {
+                    cs.launch {
+                        settings.getSetting { StyleAndBehavior.EpisodeNumberFormatting }.set(it)
+                    }
+                },
+                values = EpisodeNumberFormattingOption.entries.toList(),
+                title = {
+                    Text(R.string.episode_number_formatting.str())
+                },
+                summary = {
+                    val example = episodeFormatting.format(EXAMPLE_SEASON, EXAMPLE_EPISODE)
+                    Text(R.string.episode_number_formatting_summary.str(example))
+                },
+                icon = {
+                    Text(
+                        "SxE",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontFamily = FontFamily.Monospace,
+                        color = LocalContentColor.current,
+                    )
+                },
+                type = ListPreferenceType.ALERT_DIALOG,
+                valueToText = {
+                    val example = it.format(EXAMPLE_SEASON, EXAMPLE_EPISODE)
+                    AnnotatedString(example)
+                },
+            )
+        }
+        item("behavior-category") { PreferenceCategory(title = { Text(R.string.behavior.str()) }) }
+        item("open-episode-behavior") {
+            val nameStrings = OpenEpisodeBehaviorOption.entries.associateWith {
+                when (it) {
+                    HIGHLIGHT_IN_SEASON -> R.string.open_episode_behavior_highlight_in_season.str()
+                    OPEN_EPISODE_DETAILS -> R.string.open_episode_behavior_episode_details.str()
+                }
+            }
+            ListPreference(
+                value = openEpisodeBehavior,
+                onValueChange = {
+                    cs.launch {
+                        settings.getSetting { StyleAndBehavior.OpenEpisodeBehavior }.set(it)
+                    }
+                },
+                values = OpenEpisodeBehaviorOption.entries.toList(),
+                title = {
+                    Text(R.string.open_episode_behavior.str())
+                },
+                summary = {
+                    Text(nameStrings.getValue(openEpisodeBehavior))
+                },
+                icon = {
+                    Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
+                },
+                type = ListPreferenceType.ALERT_DIALOG,
+                valueToText = {
+                    AnnotatedString(nameStrings.getValue(it))
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/TmdbLanguagesSettingsScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/settings/TmdbLanguagesSettingsScreen.kt
@@ -75,7 +75,7 @@ data object TmdbLanguagesSettingsScreen : Screen() {
 
     @Composable
     override fun Content() {
-        ScreenContainer { io.github.couchtracker.ui.screens.settings.Content() }
+        ScreenContainer { SettingsContent() }
     }
 }
 
@@ -83,7 +83,7 @@ data object TmdbLanguagesSettingsScreen : Screen() {
 private const val NUMBER_OF_ITEMS_BEFORE_LANGUAGE_LIST = 3
 
 @Composable
-private fun Content() {
+private fun SettingsContent() {
     val settingsTmdbLanguages by appSettings().loadWithDefault { Tmdb.Languages }
     val coroutineScope = rememberCoroutineScope()
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/watchedItem/WatchedItemsScreenViewModel.kt
@@ -14,6 +14,7 @@ import io.github.couchtracker.db.profile.externalids.ExternalMovieId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalMovieId
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemType
+import io.github.couchtracker.settings.getAppSettings
 import io.github.couchtracker.tmdb.TmdbMovieId
 import io.github.couchtracker.tmdb.tmdbFlowRetryContext
 import io.github.couchtracker.ui.ColorSchemes
@@ -25,9 +26,13 @@ import io.github.couchtracker.ui.screens.episodes.EpisodesScreenViewModelHelper
 import io.github.couchtracker.ui.screens.movie.MovieScreenViewModelHelper
 import io.github.couchtracker.ui.screens.show.ShowScreenViewModelHelper
 import io.github.couchtracker.ui.showSeasonEpisodeNumberToString
+import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.collectAsLoadable
 import io.github.couchtracker.utils.resultValueOrNull
+import io.github.couchtracker.utils.valueOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatform
 import kotlin.time.Duration
 
 sealed interface WatchedItemsScreenViewModel {
@@ -141,6 +146,11 @@ sealed interface WatchedItemsScreenViewModel {
                 retryContext = retryContext,
             )
 
+            private val settings by KoinPlatform.getKoin()
+                .getAppSettings()
+                .map { Loadable.Loaded(it) }
+                .collectAsLoadable("settings")
+
             private val showBaseDetails by showBaseModel.baseDetails.collectAsLoadable("showBaseDetails")
             private val seasonDetails by seasonModel.seasonDetails.collectAsLoadable("seasonDetails")
 
@@ -153,13 +163,17 @@ sealed interface WatchedItemsScreenViewModel {
                 val episodeDetails = seasonDetails?.findEpisode()
 
                 Details(
-                    subtitle = showSeasonEpisodeNumberToString(
-                        context = application,
-                        showName = showBaseDetails?.name ?: externalId.id.showId.toExternalId().serialize(),
-                        seasonNumber = externalId.id.seasonId.number,
-                        episodeNumber = externalId.id.number,
-                        episodeName = episodeDetails?.name,
-                    ),
+                    subtitle = settings.valueOrNull()?.let { settings ->
+                        val formatting = settings.get { StyleAndBehavior.EpisodeNumberFormatting }.current
+                        showSeasonEpisodeNumberToString(
+                            context = application,
+                            formatting = formatting,
+                            showName = showBaseDetails?.name ?: externalId.id.showId.toExternalId().serialize(),
+                            seasonNumber = externalId.id.seasonId.number,
+                            episodeNumber = externalId.id.number,
+                            episodeName = episodeDetails?.name,
+                        )
+                    }.orEmpty(),
                     runtime = episodeDetails?.runtime,
                     originalLanguage = showBaseDetails?.originalLanguage,
                     backdrop = showBaseDetails?.backdrop,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/AbstractPreferencesSettings.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/AbstractPreferencesSettings.kt
@@ -2,7 +2,10 @@ package io.github.couchtracker.utils.settings
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlin.enums.enumEntries
 
 /**
  * Specialization of [AbstractSettings] that holds [PreferencesSetting].
@@ -27,6 +30,19 @@ abstract class AbstractPreferencesSettings : AbstractSettings() {
             serialize = serialize,
         ),
     )
+
+    protected inline fun <reified E : Enum<E>> setting(
+        key: String,
+        default: E,
+    ): PreferencesSetting<String, E, E> {
+        val entries = enumEntries<E>()
+        return setting(
+            key = stringPreferencesKey(key),
+            default = flowOf(default),
+            serialize = { it.name },
+            parse = { entries.single { entry -> entry.name == it } },
+        )
+    }
 
     protected fun <V : D, D> setting(
         key: Preferences.Key<V>,

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettingsFlow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettingsFlow.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
@@ -31,7 +32,7 @@ interface LoadedSettingsGetter<S : AbstractSettings> {
 inline fun <S : AbstractSettings, reified V : D, reified D> LoadedSettingsGetter<S>.get(
     crossinline setting: S.() -> Setting<*, *, V, D>,
 ): Flow<LoadedSetting<V, D>> {
-    return loadedSettingsFlow.settings.map { it.get(setting) }
+    return loadedSettingsFlow.settings.map { it.get(setting) }.distinctUntilChanged()
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/composeApp/src/main/res/values-it/settings.xml
+++ b/composeApp/src/main/res/values-it/settings.xml
@@ -50,4 +50,13 @@
     <string name="tmdb_languages_settings_footer">I contenuti localizzati verranno mostrati con la prima lingua disponibile</string>
     <string name="tmdb_languages_limit_reached">Hai raggiunto il numero massimo di lingue impostabili</string>
     <string name="use_system_languages">Usa lingue di sistema</string>
+
+    <string name="style_and_behavior">Stile e comportamento</string>
+    <string name="style">Stile</string>
+    <string name="behavior">Comportamento</string>
+    <string name="episode_number_formatting">"Formato del numero dell'episodio"</string>
+    <string name="episode_number_formatting_summary">I numeri degli episodi sono nel formato %1$s</string>
+    <string name="open_episode_behavior">"All'apertura di un episodio"</string>
+    <string name="open_episode_behavior_highlight_in_season">"Apri la stagione ed evidenzia l'episodio"</string>
+    <string name="open_episode_behavior_episode_details">"Apri i dettagli dell'episodio"</string>
 </resources>

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -135,8 +135,7 @@
     <string name="show_dash_x">%1$s - %2$s</string>
     <string name="season_special_episode_with_name">Speciale %1$d: %2$s</string>
     <string name="season_special_episode">Speciale %1$d</string>
-    <string name="season_episode_with_name">S%1$02dE%2$02d: %3$s</string>
-    <string name="season_episode">S%1$02dE%2$02d</string>
+    <string name="season_episode_with_name">%1$s: %2$s</string>
     <string name="season_name_parenthesis_default_name">%1$s (%2$s)</string>
 
     <string name="mark_movie_as_watched">Segna come visto</string>

--- a/composeApp/src/main/res/values/settings.xml
+++ b/composeApp/src/main/res/values/settings.xml
@@ -50,4 +50,13 @@
     <string name="tmdb_languages_settings_footer">Localized content will be displayed in the first language that is available</string>
     <string name="tmdb_languages_limit_reached">You\'ve reached the maximum number of languages that can be set</string>
     <string name="use_system_languages">Use system languages</string>
+
+    <string name="style_and_behavior">Style and behavior</string>
+    <string name="style">Style</string>
+    <string name="behavior">Behavior</string>
+    <string name="episode_number_formatting">Episode number format</string>
+    <string name="episode_number_formatting_summary">Episode numbers are in the format %1$s</string>
+    <string name="open_episode_behavior">When opening an episode</string>
+    <string name="open_episode_behavior_highlight_in_season">Open the season and highlight the episode</string>
+    <string name="open_episode_behavior_episode_details">Open the episode details</string>
 </resources>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -132,8 +132,7 @@
     <string name="show_dash_x">%1$s - %2$s</string>
     <string name="season_special_episode_with_name">Special %1$d: %2$s</string>
     <string name="season_special_episode">Special %1$d</string>
-    <string name="season_episode_with_name">S%1$02dE%2$02d: %3$s</string>
-    <string name="season_episode">S%1$02dE%2$02d</string>
+    <string name="season_episode_with_name">%1$s: %2$s</string>
     <string name="season_name_parenthesis_default_name">%1$s (%2$s)</string>
 
     <string name="mark_movie_as_watched">Mark as watched</string>


### PR DESCRIPTION
This commit adds settings to customize the behavior when clicking an episode, and the episode formatting.

Partially solves #246.

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/e9d78776-5b9d-4d50-aa00-32007deddeb0" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/ec38c6d7-fea2-47ef-9c8e-fc128c9ece53" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/2e6856e5-3a0e-4411-a178-c85184311779" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/68fe1140-361a-4b24-a364-7316f371903d" />
