### PR TITLE
Up next sort

### DIFF
--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/app/AppDataModule.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/app/AppDataModule.kt
@@ -10,6 +10,7 @@ import io.github.couchtracker.db.common.adapters.URIColumnAdapter
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.utils.lazyEagerModule
 import io.github.couchtracker.utils.settings.get
+import io.github.couchtracker.utils.settings.getCurrent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
@@ -35,7 +36,7 @@ val AppDataModule = lazyEagerModule {
 
     single<Flow<ProfilesInfo>> {
         val profiles = get<AppData>().profileQueries.selectAll().asFlow().map { it.executeAsList() }
-        val profileId = AppSettings.get { CurrentProfileId }.map { it.current }
+        val profileId = AppSettings.getCurrent { CurrentProfileId }
         profilesInfoFlow(profiles, profileId)
             .shareIn(get<AppCoroutineScope>(), SharingStarted.Eagerly, 1)
     }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTime.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/db/profile/model/partialtime/PartialDateTime.kt
@@ -23,7 +23,6 @@ import kotlinx.datetime.format.char
 import kotlinx.datetime.format.format
 import kotlinx.datetime.number
 import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.yearMonth
 import kotlin.time.Instant
 
@@ -528,6 +527,6 @@ fun PartialDateTime?.group(): PartialDateTimeGroup = when (this) {
 /**
  * Sorts the given list of [PartialDateTime]. See [PartialDateTime.sort].
  */
-fun List<PartialDateTime>.sort(): List<PartialDateTime> {
+fun <PDT : PartialDateTime?> List<PDT>.sort(): List<PDT> {
     return PartialDateTime.sort(items = this, getPartialDateTime = { this })
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/settings/StyleAndBehaviorSettings.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/settings/StyleAndBehaviorSettings.kt
@@ -1,5 +1,11 @@
 package io.github.couchtracker.settings
 
+import androidx.annotation.StringRes
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import io.github.couchtracker.R
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.UpNextSortOrderOption
+import io.github.couchtracker.utils.settings.LoadedSettings
+import kotlinx.coroutines.flow.flowOf
 import org.koin.core.component.KoinComponent
 import java.util.Locale
 
@@ -33,5 +39,40 @@ object StyleAndBehaviorSettings : AbstractAppSettings(), KoinComponent {
     val OpenEpisodeBehavior = setting<OpenEpisodeBehaviorOption>(
         key = "openEpisodeBehavior",
         default = OpenEpisodeBehaviorOption.HIGHLIGHT_IN_SEASON,
+    )
+
+    enum class UpNextSortOrderOption(@StringRes val stringRes: Int) {
+        LAST_WATCHED_FIRST(R.string.up_next_sort_option_last_watched_first),
+        SAME_AS_SHOWS(R.string.up_next_sort_option_same_as_shows),
+        NEWEST_FIRST(R.string.up_next_sort_option_newest_first),
+        OLDEST_FIRST(R.string.up_next_sort_option_oldest_first),
+    }
+
+    val UpNextEnableSuggestions = setting(
+        key = booleanPreferencesKey("up-next-enable-suggestions"),
+        default = flowOf(true),
+    )
+    val UpNextDivideAired = setting(
+        key = booleanPreferencesKey("up-next-divide-aired"),
+        default = flowOf(true),
+    )
+    val UpNextSortOrder = setting(
+        key = "up-next-sort-order",
+        default = UpNextSortOrderOption.LAST_WATCHED_FIRST,
+    )
+}
+
+data class UpNextOptions(
+    val enableSmartSuggestions: Boolean,
+    val divideAired: Boolean,
+    val sortOrder: UpNextSortOrderOption,
+)
+
+fun LoadedSettings<AppSettings>.upNextOptions(): UpNextOptions {
+    val loaded = this
+    return UpNextOptions(
+        enableSmartSuggestions = loaded.get { StyleAndBehavior.UpNextEnableSuggestions }.current,
+        divideAired = loaded.get { StyleAndBehavior.UpNextDivideAired }.current,
+        sortOrder = loaded.get { StyleAndBehavior.UpNextSortOrder }.current,
     )
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/tmdb/TmdbDownload.kt
@@ -18,7 +18,7 @@ import io.github.couchtracker.utils.error.SimulatedException
 import io.github.couchtracker.utils.injectApiError
 import io.github.couchtracker.utils.injectCacheMiss
 import io.github.couchtracker.utils.logExecutionTime
-import io.github.couchtracker.utils.settings.get
+import io.github.couchtracker.utils.settings.getCurrent
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.withContext
 import kotlinx.io.IOException
@@ -62,7 +61,7 @@ private val tmdbCacheEvents = EventBus<TmdbCacheEvent>()
 
 fun tmdbFlowRetryContext(
     retryToken: FlowRetryToken = FlowRetryToken(),
-    languages: Flow<TmdbLanguages> = AppSettings.get { Tmdb.Languages }.map { it.current },
+    languages: Flow<TmdbLanguages> = AppSettings.getCurrent { Tmdb.Languages },
 ): TmdbFlowRetryContext {
     return FlowRetryContext(retryToken, languages)
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/components/UpNextListItem.kt
@@ -38,7 +38,7 @@ import io.github.couchtracker.ui.PlaceholdersDefaults
 import io.github.couchtracker.ui.actions.markEpisodeAsWatchedAction
 import io.github.couchtracker.ui.rememberPlaceholderPainter
 import io.github.couchtracker.ui.screens.episodes.navigateToEpisode
-import io.github.couchtracker.ui.screens.main.ShowSectionViewModel
+import io.github.couchtracker.ui.screens.main.show.ShowSectionViewModel
 import io.github.couchtracker.ui.screens.seasons.navigateToSeason
 import io.github.couchtracker.ui.screens.show.navigateToShow
 import io.github.couchtracker.ui.screens.watchedItem.WatchedItemSheetMode

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/MainScreen.kt
@@ -38,6 +38,7 @@ import io.github.couchtracker.ui.generateColorScheme
 import io.github.couchtracker.ui.screens.main.search.SEARCH_SCREEN_EVENT_BUS
 import io.github.couchtracker.ui.screens.main.search.SearchScreenEvent
 import io.github.couchtracker.ui.screens.main.search.SearchSection
+import io.github.couchtracker.ui.screens.main.show.ShowSection
 import io.github.couchtracker.utils.str
 import kotlinx.serialization.Serializable
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/ShowSectionViewModel.kt
@@ -28,6 +28,7 @@ import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.components.ShowPortraitModel
 import io.github.couchtracker.ui.components.UpNextListItemModel
 import io.github.couchtracker.ui.components.toShowPortraitModels
+import io.github.couchtracker.ui.screens.main.show.ShowExploreTabState
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.collectAsLoadable

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/search/SearchViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/search/SearchViewModel.kt
@@ -40,6 +40,7 @@ import io.github.couchtracker.utils.error.ApiResult
 import io.github.couchtracker.utils.flatMap
 import io.github.couchtracker.utils.map
 import io.github.couchtracker.utils.settings.get
+import io.github.couchtracker.utils.settings.getCurrent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -82,11 +83,11 @@ class SearchViewModel(
         .debounce { (prevId, params) -> if (prevId == params.searchRequestId) 300.milliseconds else 0.milliseconds }
         .map { (_, params) -> params.query to params.filters }
         .distinctUntilChanged()
-        .combine(AppSettings.get { Tmdb.Languages }) { searchParameters, tmdbLanguages ->
+        .combine(AppSettings.getCurrent { Tmdb.Languages }) { searchParameters, tmdbLanguages ->
             SearchInstance(
                 query = searchParameters.first,
                 filters = searchParameters.second,
-                tmdbLanguage = tmdbLanguages.current.apiLanguage,
+                tmdbLanguage = tmdbLanguages.apiLanguage,
                 lazyGridState = LazyGridState(0, 0),
             )
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/ShowSection.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.flow.map
 @Composable
 fun ShowSection(
     innerPadding: PaddingValues,
-    viewModel: io.github.couchtracker.ui.screens.main.ShowSectionViewModel = viewModel(),
+    viewModel: ShowSectionViewModel = viewModel(),
 ) {
     // TODO: open up next as a first tab
     val pagerState = rememberPagerState(initialPage = ShowTab.WATCHLIST.ordinal) { ShowTab.entries.size }
@@ -73,6 +73,9 @@ fun ShowSection(
         imageModel = R.drawable.sunset,
         title = R.string.main_section_shows.str(),
         actions = {
+            if (ShowTab.entries[pagerState.currentPage] == ShowTab.UP_NEXT) {
+                UpNextAppBarActions()
+            }
             MainSectionDefaults.DefaultAppBarActions()
         },
         tabText = { page -> Text(text = ShowTab.entries[page].displayName.str()) },
@@ -95,7 +98,7 @@ fun ShowSection(
                         emptyDescription = R.string.tab_shows_following_empty_description.str(),
                     )
                     ShowTab.UP_NEXT -> UpNextTab(
-                        entries = viewModel.upNext,
+                        upNextModel = viewModel.upNext,
                         onRetry = { viewModel.retryAll() },
                     )
                     ShowTab.EXPLORE -> ShowListComposable(viewModel.exploreState)
@@ -111,7 +114,7 @@ fun ShowSection(
 
 @Composable
 private fun BookmarkedShowGrid(
-    shows: Loadable<List<io.github.couchtracker.ui.screens.main.ShowSectionViewModel.BookmarkedShow>>,
+    shows: Loadable<List<ShowSectionViewModel.BookmarkedShow>>,
     emptyMessage: String,
     emptyDescription: String,
 ) {

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/ShowSection.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/ShowSection.kt
@@ -1,17 +1,13 @@
-@file:OptIn(ExperimentalFoundationApi::class)
-
-package io.github.couchtracker.ui.screens.main
+package io.github.couchtracker.ui.screens.main.show
 
 import android.app.Application
 import androidx.annotation.StringRes
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.plus
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -34,7 +30,6 @@ import app.moviebase.tmdb.model.TmdbTimeWindow
 import io.github.couchtracker.R
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.tmdb.tmdbPager
-import io.github.couchtracker.ui.components.DefaultErrorScreen
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.ui.components.MessageComposable
 import io.github.couchtracker.ui.components.OverviewScreenComponents
@@ -42,14 +37,12 @@ import io.github.couchtracker.ui.components.PaginatedGrid
 import io.github.couchtracker.ui.components.PortraitComposableDefaults
 import io.github.couchtracker.ui.components.ShowPortrait
 import io.github.couchtracker.ui.components.ShowPortraitModel
-import io.github.couchtracker.ui.components.UpNextListItem
 import io.github.couchtracker.ui.components.WipMessageComposable
 import io.github.couchtracker.ui.components.toShowPortraitModels
-import io.github.couchtracker.ui.itemsWithPosition
-import io.github.couchtracker.ui.screens.main.ShowSectionViewModel.UpNextEntry
+import io.github.couchtracker.ui.screens.main.MainSection
+import io.github.couchtracker.ui.screens.main.MainSectionDefaults
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
-import io.github.couchtracker.utils.error.CouchTrackerLoadable
 import io.github.couchtracker.utils.map
 import io.github.couchtracker.utils.removeDuplicates
 import io.github.couchtracker.utils.settings.get
@@ -63,7 +56,7 @@ import kotlinx.coroutines.flow.map
 @Composable
 fun ShowSection(
     innerPadding: PaddingValues,
-    viewModel: ShowSectionViewModel = viewModel(),
+    viewModel: io.github.couchtracker.ui.screens.main.ShowSectionViewModel = viewModel(),
 ) {
     // TODO: open up next as a first tab
     val pagerState = rememberPagerState(initialPage = ShowTab.WATCHLIST.ordinal) { ShowTab.entries.size }
@@ -101,7 +94,7 @@ fun ShowSection(
                         emptyMessage = R.string.tab_shows_following_empty.str(),
                         emptyDescription = R.string.tab_shows_following_empty_description.str(),
                     )
-                    ShowTab.UP_NEXT -> UpNext(
+                    ShowTab.UP_NEXT -> UpNextTab(
                         entries = viewModel.upNext,
                         onRetry = { viewModel.retryAll() },
                     )
@@ -118,7 +111,7 @@ fun ShowSection(
 
 @Composable
 private fun BookmarkedShowGrid(
-    shows: Loadable<List<ShowSectionViewModel.BookmarkedShow>>,
+    shows: Loadable<List<io.github.couchtracker.ui.screens.main.ShowSectionViewModel.BookmarkedShow>>,
     emptyMessage: String,
     emptyDescription: String,
 ) {
@@ -154,45 +147,6 @@ private fun BookmarkedShowGrid(
                             )
                         },
                     )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun UpNext(
-    entries: CouchTrackerLoadable<List<UpNextEntry>>,
-    onRetry: () -> Unit,
-) {
-    LoadableScreen(
-        entries,
-        onError = { apiError ->
-            DefaultErrorScreen(
-                error = apiError,
-                retry = onRetry,
-            )
-        },
-    ) { entries ->
-        if (entries.isEmpty()) {
-            MessageComposable(
-                modifier = Modifier.fillMaxSize(),
-                icon = Icons.Default.BookmarkBorder,
-                message = R.string.tab_shows_up_next_empty.str(),
-                details = R.string.tab_shows_up_next_empty_description.str(),
-            )
-        } else {
-            // TODO: after marking an episode as watched, this should scroll to it
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(8.dp) + PaddingValues(bottom = OverviewScreenComponents.LIST_BOTTOM_SPACE),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                itemsWithPosition(
-                    items = entries,
-                    key = { _, upNextEntry -> upNextEntry.itemKey },
-                ) { position, upNextEntry ->
-                    UpNextListItem(upNextEntry.model, position, modifier = Modifier.animateItem())
                 }
             }
         }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/ShowSectionViewModel.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/ShowSectionViewModel.kt
@@ -1,20 +1,30 @@
-package io.github.couchtracker.ui.screens.main
+package io.github.couchtracker.ui.screens.main.show
 
 import android.app.Application
 import android.util.Log
+import androidx.annotation.StringRes
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
+import io.github.couchtracker.R
 import io.github.couchtracker.db.app.ProfilesInfo
 import io.github.couchtracker.db.profile.Bcp47Language
+import io.github.couchtracker.db.profile.externalids.ExternalEpisodeId
 import io.github.couchtracker.db.profile.externalids.ExternalShowId
 import io.github.couchtracker.db.profile.externalids.TmdbExternalShowId
 import io.github.couchtracker.db.profile.externalids.UnknownExternalShowId
+import io.github.couchtracker.db.profile.model.partialtime.PartialDateTime
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedEpisodeSessionWrapper
 import io.github.couchtracker.db.profile.model.watchedItem.WatchedItemWrapper
 import io.github.couchtracker.settings.AppSettings
 import io.github.couchtracker.settings.StyleAndBehaviorSettings
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.UpNextSortOrderOption.LAST_WATCHED_FIRST
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.UpNextSortOrderOption.NEWEST_FIRST
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.UpNextSortOrderOption.OLDEST_FIRST
+import io.github.couchtracker.settings.StyleAndBehaviorSettings.UpNextSortOrderOption.SAME_AS_SHOWS
+import io.github.couchtracker.settings.UpNextOptions
+import io.github.couchtracker.settings.upNextOptions
 import io.github.couchtracker.tmdb.BaseTmdbShow
 import io.github.couchtracker.tmdb.TmdbEpisodeId
 import io.github.couchtracker.tmdb.TmdbLanguages
@@ -28,7 +38,6 @@ import io.github.couchtracker.tmdb.toBaseShow
 import io.github.couchtracker.ui.components.ShowPortraitModel
 import io.github.couchtracker.ui.components.UpNextListItemModel
 import io.github.couchtracker.ui.components.toShowPortraitModels
-import io.github.couchtracker.ui.screens.main.show.ShowExploreTabState
 import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.Result
 import io.github.couchtracker.utils.collectAsLoadable
@@ -48,13 +57,14 @@ import io.github.couchtracker.utils.mapResult
 import io.github.couchtracker.utils.rememberingCombined
 import io.github.couchtracker.utils.resultErrorOrNull
 import io.github.couchtracker.utils.resultValueOrNull
-import io.github.couchtracker.utils.settings.get
+import io.github.couchtracker.utils.settings.getCurrent
 import io.github.couchtracker.utils.valueOrNull
 import io.github.couchtracker.utils.withLoading
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -64,10 +74,21 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
 import org.koin.mp.KoinPlatform
+import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.Instant
+
+private val UP_NEXT_MARKED_WATCHED_RECENTLY_THRESHOLD = DatePeriod(days = 1)
+private val UP_NEXT_WATCHED_RECENTLY_THRESHOLD = DatePeriod(days = 14)
+private val UP_NEXT_AIRED_RECENTLY_THRESHOLD = DatePeriod(days = 14)
+private val UP_NEXT_AIRING_SOON_THRESHOLD = DatePeriod(days = 7)
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ShowSectionViewModel(application: Application) : AndroidViewModel(application) {
@@ -118,9 +139,27 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         val itemKey: Any,
         val showId: ExternalShowId,
         val watchSession: WatchedEpisodeSessionWrapper?,
-        val lastWatchedEpisode: Instant?,
+        val episodeId: ExternalEpisodeId,
+        val previousViewings: List<WatchedItemWrapper.Episode>,
+        val airDate: LocalDate?,
         val model: UpNextListItemModel,
     )
+
+    data class UpNextModel(
+        val options: UpNextOptions,
+        val sections: Map<UpNextSection, List<UpNextEntry>>,
+    )
+
+    enum class UpNextSection(@StringRes val stringRes: Int) {
+        SUGGESTED(R.string.up_next_section_suggested),
+        AIRING_TODAY(R.string.up_next_section_airing_today),
+        AIRED_RECENTLY(R.string.up_next_section_aired_recently),
+        AIRING_SOON(R.string.up_next_section_airing_soon),
+        AIRED(R.string.up_next_section_aired),
+        UNKNOWN_AIR_DATE(R.string.up_next_section_unknown_air_date),
+        NOT_AIRED(R.string.up_next_section_not_aired),
+        OTHER(R.string.up_next_section_other),
+    }
 
     private val bookmarks: Flow<Loadable<List<BookmarkedShow>>> =
         KoinPlatform.getKoin().get<Flow<ProfilesInfo>>()
@@ -153,20 +192,24 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         }
     }.collectAsLoadable("shows-following")
 
-    val upNext: CouchTrackerLoadable<List<UpNextEntry>> by AppSettings.get { StyleAndBehavior.EpisodeNumberFormatting }
+    val upNext: CouchTrackerLoadable<UpNextModel> by AppSettings.getCurrent { StyleAndBehavior.EpisodeNumberFormatting }
         .flatMapLatest { episodeFormatting ->
             bookmarks.collectWithPrevious { previous: Loadable<Map<BookmarkedShow, CouchTrackerLoadable<List<UpNextEntry>>>>?, bookmarks ->
                 bookmarks.map { bookmarks ->
                     bookmarks.associateWith { bookmarkedShowData ->
                         val old = previous?.valueOrNull()?.get(bookmarkedShowData)
-                        old ?: bookmarkedShowData.upNextEntries(episodeFormatting.current)
+                        old ?: bookmarkedShowData.upNextEntries(episodeFormatting)
                     }
                 }
             }
         }
-        .mapLatest { bookmarksWithUpNext ->
+        .combine(
+            AppSettings.loadedSettingsFlow.settings.map { it.upNextOptions() }.distinctUntilChanged(),
+        ) { bookmarksWithUpNext, upNextOptions ->
             bookmarksWithUpNext.flatMap { bookmarksWithUpNext ->
-                bookmarksWithUpNext.values.mergeUpNextEntries()
+                bookmarksWithUpNext.values.mergeUpNextEntries(upNextOptions).mapResult { sections ->
+                    UpNextModel(upNextOptions, sections)
+                }
             }
         }
         .collectAsLoadable("shows-up-next")
@@ -311,6 +354,7 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
         episodeFormatting: StyleAndBehaviorSettings.EpisodeNumberFormattingOption,
     ): UpNextEntry? {
         val watchedEpisodesIds = watchedEpisodes.mapTo(HashSet()) { it.itemId }
+        var previousEpisodeId: ExternalEpisodeId? = null
         for (season in seasons) {
             if (season.number > 0) {
                 for (episode in season.episodes) {
@@ -324,10 +368,18 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                         } else {
                             showId.serialize()
                         }
+                        val previousViewings = if (previousEpisodeId == null) {
+                            emptyList()
+                        } else {
+                            watchedEpisodes.filter { it.itemId == previousEpisodeId }.also {
+                                check(it.isNotEmpty())
+                            }
+                        }
                         return UpNextEntry(
                             itemKey = itemKey,
                             showId = showId,
                             watchSession = watchSession,
+                            episodeId = episodeId,
                             model = UpNextListItemModel.withShowData(
                                 context = application,
                                 episodeFormatting = episodeFormatting,
@@ -336,29 +388,103 @@ class ShowSectionViewModel(application: Application) : AndroidViewModel(applicat
                                 season = season,
                                 episode = episode,
                             ),
-                            lastWatchedEpisode = watchedEpisodes.maxOfOrNull { it.addedAt },
+                            previousViewings = previousViewings,
+                            airDate = episode.airDate,
                         )
                     }
+                    previousEpisodeId = episodeId
                 }
             }
         }
         return null
     }
 
-    private fun Collection<CouchTrackerLoadable<List<UpNextEntry>>>.mergeUpNextEntries(): CouchTrackerLoadable<List<UpNextEntry>> {
+    private fun Collection<CouchTrackerLoadable<List<UpNextEntry>>>.mergeUpNextEntries(
+        options: UpNextOptions,
+    ): CouchTrackerLoadable<Map<UpNextSection, List<UpNextEntry>>> {
         return if (isEmpty()) {
-            Loadable.value(emptyList())
+            Loadable.value(emptyMap())
         } else if (any { it is Loadable.Loading }) {
             Loadable.Loading
         } else {
-            val loaded = mapNotNull { it.resultValueOrNull() }
-                .flatten()
-                .sortedByDescending { it.lastWatchedEpisode }
+            val loaded = mapNotNull { it.resultValueOrNull() }.flatten()
             if (loaded.isEmpty()) {
                 Loadable.error(mapNotNull { it.resultErrorOrNull() }.aggregateError())
             } else {
-                Loadable.value(loaded)
+                Loadable.value(loaded.groupedAndSorted(options))
             }
+        }
+    }
+
+    private fun List<UpNextEntry>.groupedAndSorted(options: UpNextOptions): Map<UpNextSection, List<UpNextEntry>> {
+        val upNextEntries = this
+        // TODO: today/timezone should recompute
+        val timeZone = TimeZone.currentSystemDefault()
+        val today = Clock.System.now().toLocalDateTime(timeZone).date
+        val recentlyWatchedBound = (today - UP_NEXT_WATCHED_RECENTLY_THRESHOLD).atStartOfDayIn(timeZone)
+        val recentlyMarkedAsWatchedBound = (today - UP_NEXT_MARKED_WATCHED_RECENTLY_THRESHOLD).atStartOfDayIn(timeZone)
+
+        val groupedEntries = upNextEntries.groupBy { entry ->
+            val isSuggested = when {
+                !options.enableSmartSuggestions -> false
+                // Not aired
+                entry.airDate == null || entry.airDate > today -> false
+                // Recently aired
+                entry.airDate >= today - UP_NEXT_AIRED_RECENTLY_THRESHOLD -> true
+                // Recently (marked as) watched
+                else -> {
+                    entry.previousViewings.any { previousViewing ->
+                        val watchedRecently = when (val watchedAt = previousViewing.watchAt) {
+                            null -> false
+                            is PartialDateTime.Local -> watchedAt.toInstant(timeZone) >= recentlyWatchedBound
+                            is PartialDateTime.Zoned -> watchedAt.toInstant() >= recentlyWatchedBound
+                        }
+                        val markedAsWatchedRecently = previousViewing.addedAt >= recentlyMarkedAsWatchedBound
+                        watchedRecently || markedAsWatchedRecently
+                    }
+                }
+            }
+            if (isSuggested) {
+                return@groupBy UpNextSection.SUGGESTED
+            }
+            when {
+                !options.divideAired -> UpNextSection.OTHER
+                entry.airDate == null -> UpNextSection.UNKNOWN_AIR_DATE
+                entry.airDate < today - UP_NEXT_AIRED_RECENTLY_THRESHOLD -> UpNextSection.AIRED
+                entry.airDate < today -> UpNextSection.AIRED_RECENTLY
+                entry.airDate == today -> UpNextSection.AIRING_TODAY
+                entry.airDate <= today + UP_NEXT_AIRING_SOON_THRESHOLD -> UpNextSection.AIRING_SOON
+                else -> UpNextSection.NOT_AIRED
+            }
+        }
+        return groupedEntries
+            .mapValues { it.value.sorted(options) }
+            .toSortedMap()
+    }
+
+    private fun List<UpNextEntry>.sorted(options: UpNextOptions): List<UpNextEntry> {
+        val upNextEntries = this
+        return when (options.sortOrder) {
+            LAST_WATCHED_FIRST -> {
+                val entriesWithTime = upNextEntries.flatMap { upNextEntry ->
+                    if (upNextEntry.previousViewings.isEmpty()) {
+                        listOf(upNextEntry to null)
+                    } else {
+                        upNextEntry.previousViewings.map { previousViewing ->
+                            upNextEntry to previousViewing.watchAt
+                        }
+                    }
+                }
+                PartialDateTime
+                    .sort(entriesWithTime, { second })
+                    .reversed()
+                    .mapTo(mutableSetOf()) { it.first }
+                    .toList()
+            }
+            // TODO: implement same as show
+            SAME_AS_SHOWS -> upNextEntries
+            NEWEST_FIRST -> upNextEntries.sortedByDescending { it.airDate }
+            OLDEST_FIRST -> upNextEntries.sortedBy { it.airDate }
         }
     }
 

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/UpNextTab.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/UpNextTab.kt
@@ -1,0 +1,61 @@
+package io.github.couchtracker.ui.screens.main.show
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.plus
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.couchtracker.R
+import io.github.couchtracker.ui.components.DefaultErrorScreen
+import io.github.couchtracker.ui.components.LoadableScreen
+import io.github.couchtracker.ui.components.MessageComposable
+import io.github.couchtracker.ui.components.OverviewScreenComponents
+import io.github.couchtracker.ui.components.UpNextListItem
+import io.github.couchtracker.ui.itemsWithPosition
+import io.github.couchtracker.ui.screens.main.ShowSectionViewModel.UpNextEntry
+import io.github.couchtracker.utils.error.CouchTrackerLoadable
+import io.github.couchtracker.utils.str
+
+@Composable
+fun UpNextTab(
+    entries: CouchTrackerLoadable<List<UpNextEntry>>,
+    onRetry: () -> Unit,
+) {
+    LoadableScreen(
+        entries,
+        onError = { apiError ->
+            DefaultErrorScreen(
+                error = apiError,
+                retry = onRetry,
+            )
+        },
+    ) { entries ->
+        if (entries.isEmpty()) {
+            MessageComposable(
+                modifier = Modifier.fillMaxSize(),
+                icon = Icons.Default.BookmarkBorder,
+                message = R.string.tab_shows_up_next_empty.str(),
+                details = R.string.tab_shows_up_next_empty_description.str(),
+            )
+        } else {
+            // TODO: after marking an episode as watched, this should scroll to it
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(8.dp) + PaddingValues(bottom = OverviewScreenComponents.LIST_BOTTOM_SPACE),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                itemsWithPosition(
+                    items = entries,
+                    key = { _, upNextEntry -> upNextEntry.itemKey },
+                ) { position, upNextEntry ->
+                    UpNextListItem(upNextEntry.model, position, modifier = Modifier.animateItem())
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/UpNextTab.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/ui/screens/main/show/UpNextTab.kt
@@ -1,41 +1,142 @@
 package io.github.couchtracker.ui.screens.main.show
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.plus
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.Assistant
 import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.filled.CheckBoxOutlineBlank
+import androidx.compose.material.icons.filled.RadioButtonChecked
+import androidx.compose.material.icons.filled.RadioButtonUnchecked
+import androidx.compose.material.icons.filled.Today
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import io.github.couchtracker.R
+import io.github.couchtracker.settings.StyleAndBehaviorSettings
+import io.github.couchtracker.settings.appSettings
+import io.github.couchtracker.settings.upNextOptions
 import io.github.couchtracker.ui.components.DefaultErrorScreen
 import io.github.couchtracker.ui.components.LoadableScreen
 import io.github.couchtracker.ui.components.MessageComposable
 import io.github.couchtracker.ui.components.OverviewScreenComponents
 import io.github.couchtracker.ui.components.UpNextListItem
 import io.github.couchtracker.ui.itemsWithPosition
-import io.github.couchtracker.ui.screens.main.ShowSectionViewModel.UpNextEntry
+import io.github.couchtracker.ui.screens.main.show.ShowSectionViewModel.UpNextEntry
+import io.github.couchtracker.ui.screens.main.show.ShowSectionViewModel.UpNextModel
+import io.github.couchtracker.ui.screens.main.show.ShowSectionViewModel.UpNextSection
 import io.github.couchtracker.utils.error.CouchTrackerLoadable
 import io.github.couchtracker.utils.str
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+@Composable
+fun UpNextAppBarActions() {
+    val cs = rememberCoroutineScope()
+    val settings = appSettings()
+    val current = settings.upNextOptions()
+    var expanded by remember { mutableStateOf(false) }
+    IconButton({ expanded = !expanded }) {
+        Icon(Icons.AutoMirrored.Default.Sort, contentDescription = R.string.settings.str())
+    }
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+    ) {
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(Icons.Default.Assistant, contentDescription = null)
+            },
+            text = { Text(R.string.up_next_enable_suggested_section.str()) },
+            onClick = {
+                cs.launch {
+                    settings.get { StyleAndBehavior.UpNextEnableSuggestions }.setting.set(!current.enableSmartSuggestions)
+                }
+            },
+            trailingIcon = {
+                if (current.enableSmartSuggestions) {
+                    Icon(Icons.Default.CheckBox, contentDescription = null)
+                } else {
+                    Icon(Icons.Default.CheckBoxOutlineBlank, contentDescription = null)
+                }
+            },
+        )
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(Icons.Default.Today, contentDescription = null)
+            },
+            text = { Text(R.string.up_next_group_by_airing_status.str()) },
+            onClick = {
+                cs.launch {
+                    settings.get { StyleAndBehavior.UpNextDivideAired }.setting.set(!current.divideAired)
+                }
+            },
+            trailingIcon = {
+                if (current.divideAired) {
+                    Icon(Icons.Default.CheckBox, contentDescription = null)
+                } else {
+                    Icon(Icons.Default.CheckBoxOutlineBlank, contentDescription = null)
+                }
+            },
+        )
+        HorizontalDivider()
+        for (sortOrder in StyleAndBehaviorSettings.UpNextSortOrderOption.entries) {
+            DropdownMenuItem(
+                text = { Text(sortOrder.stringRes.str()) },
+                onClick = {
+                    cs.launch {
+                        settings.get { StyleAndBehavior.UpNextSortOrder }.setting.set(sortOrder)
+                    }
+                },
+                trailingIcon = {
+                    if (current.sortOrder == sortOrder) {
+                        Icon(Icons.Default.RadioButtonChecked, contentDescription = null)
+                    } else {
+                        Icon(Icons.Default.RadioButtonUnchecked, contentDescription = null)
+                    }
+                },
+            )
+        }
+    }
+}
 
 @Composable
 fun UpNextTab(
-    entries: CouchTrackerLoadable<List<UpNextEntry>>,
+    upNextModel: CouchTrackerLoadable<UpNextModel>,
     onRetry: () -> Unit,
 ) {
     LoadableScreen(
-        entries,
+        upNextModel,
         onError = { apiError ->
             DefaultErrorScreen(
                 error = apiError,
                 retry = onRetry,
             )
         },
-    ) { entries ->
-        if (entries.isEmpty()) {
+    ) { (upNextOptions, sections) ->
+        if (sections.isEmpty()) {
             MessageComposable(
                 modifier = Modifier.fillMaxSize(),
                 icon = Icons.Default.BookmarkBorder,
@@ -43,19 +144,98 @@ fun UpNextTab(
                 details = R.string.tab_shows_up_next_empty_description.str(),
             )
         } else {
-            // TODO: after marking an episode as watched, this should scroll to it
+            val listState = rememberLazyListState()
+            var previousSections = remember { sections }
+            var previousUpNextOptions = remember { upNextOptions }
+            val scrollOffset = with(LocalDensity.current) { 200.dp.toPx().roundToInt() }
+            // This effect will scroll the list to items that change
+            LaunchedEffect(sections) {
+                if (sections != previousSections) {
+                    val changed = findChangedUpNextEntry(previousSections, sections)
+                    if (changed != null) {
+                        val index = findIndex(sections, changed)
+                        val item = listState.layoutInfo.visibleItemsInfo.singleOrNull { it.index == index }
+                        if (item == null || item.offset < 0) {
+                            // Scroll only if it's not visible
+                            listState.animateScrollToItem(index, -scrollOffset)
+                        }
+                    }
+                    previousSections = sections
+                }
+            }
+            // This effect will scroll to the top when up-next options change
+            LaunchedEffect(upNextOptions) {
+                if (upNextOptions != previousUpNextOptions) {
+                    listState.scrollToItem(0)
+                }
+                previousUpNextOptions = upNextOptions
+            }
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(8.dp) + PaddingValues(bottom = OverviewScreenComponents.LIST_BOTTOM_SPACE),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
+                state = listState,
             ) {
-                itemsWithPosition(
-                    items = entries,
-                    key = { _, upNextEntry -> upNextEntry.itemKey },
-                ) { position, upNextEntry ->
-                    UpNextListItem(upNextEntry.model, position, modifier = Modifier.animateItem())
+                // Note: when changing the items in this lazy column, please also update `findChangedUpNextEntry` function
+                for ((section, entries) in sections) {
+                    item {
+                        // Note: I'm keeping an empty item to help the lazy column retain the scroll position
+                        // when the section title appears/disappears
+                        if (sections.size > 1 || section != UpNextSection.OTHER) {
+                            Text(
+                                text = section.stringRes.str(),
+                                modifier = Modifier
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 4.dp),
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+                        }
+                    }
+                    itemsWithPosition(
+                        items = entries,
+                        key = { _, upNextEntry -> upNextEntry.itemKey },
+                    ) { position, upNextEntry ->
+                        UpNextListItem(upNextEntry.model, position, modifier = Modifier.animateItem())
+                        Spacer(Modifier.height(2.dp))
+                    }
+                    item { Spacer(Modifier.height(24.dp)) }
                 }
             }
         }
     }
+}
+
+/** Finds the first up-next entry that changed */
+private fun findChangedUpNextEntry(
+    previousSections: Map<UpNextSection, List<UpNextEntry>>,
+    sections: Map<UpNextSection, List<UpNextEntry>>,
+): UpNextEntry? {
+    val previousByKey = previousSections.values.flatten().associateBy { it.itemKey }
+    for (entry in sections.values.flatten()) {
+        val previous = previousByKey[entry.itemKey]
+        // New or changed
+        if (previous == null || previous.episodeId != entry.episodeId) {
+            return entry
+        }
+    }
+    return null
+}
+
+/** The index of this up-nexty entry in the lazy column */
+private fun findIndex(
+    sections: Map<UpNextSection, List<UpNextEntry>>,
+    entry: UpNextEntry,
+): Int {
+    var index = 0
+    for ((_, entries) in sections) {
+        // Section title
+        index++
+        val iof = entries.indexOf(entry)
+        if (iof >= 0) {
+            return index + iof
+        }
+        index += entries.size
+        // Spacer
+        index++
+    }
+    error("Entry not found")
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettings.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettings.kt
@@ -7,6 +7,7 @@ import io.github.couchtracker.utils.Loadable
 import io.github.couchtracker.utils.collectAsLoadableWithLifecycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 private typealias SettingGetter<S, V, D> = S.() -> Setting<*, *, V, D>
@@ -66,4 +67,10 @@ fun <S : AbstractSettings> S.loaded(): Flow<LoadedSettings<S>> {
             values = flowsMap.keys.zip(loadedSettings).toMap(),
         )
     }
+}
+
+inline fun <S : AbstractSettings, reified V : D, reified D> Flow<LoadedSettings<S>>.getCurrentSetting(
+    crossinline setting: SettingGetter<S, V, D>,
+): Flow<D> {
+    return this.map { it.get(setting).current }.distinctUntilChanged()
 }

--- a/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettingsFlow.kt
+++ b/composeApp/src/main/kotlin/io/github/couchtracker/utils/settings/LoadedSettingsFlow.kt
@@ -35,9 +35,15 @@ inline fun <S : AbstractSettings, reified V : D, reified D> LoadedSettingsGetter
     return loadedSettingsFlow.settings.map { it.get(setting) }.distinctUntilChanged()
 }
 
+inline fun <S : AbstractSettings, reified V : D, reified D> LoadedSettingsGetter<S>.getCurrent(
+    crossinline setting: S.() -> Setting<*, *, V, D>,
+): Flow<D> {
+    return get(setting).map { it.current }.distinctUntilChanged()
+}
+
 @OptIn(ExperimentalCoroutinesApi::class)
 inline fun <S : AbstractSettings, reified V : D, reified D> LoadedSettingsGetter<S>.getWithDefault(
     crossinline setting: S.() -> Setting<*, *, V, D>,
 ): Flow<LoadedSettingWithDefault<V, D>> {
-    return loadedSettingsFlow.settings.flatMapLatest { it.getWithDefault(setting) }
+    return loadedSettingsFlow.settings.flatMapLatest { it.getWithDefault(setting) }.distinctUntilChanged()
 }

--- a/composeApp/src/main/res/values-it/settings.xml
+++ b/composeApp/src/main/res/values-it/settings.xml
@@ -59,4 +59,11 @@
     <string name="open_episode_behavior">"All'apertura di un episodio"</string>
     <string name="open_episode_behavior_highlight_in_season">"Apri la stagione ed evidenzia l'episodio"</string>
     <string name="open_episode_behavior_episode_details">"Apri i dettagli dell'episodio"</string>
+
+    <string name="up_next_enable_suggested_section">Mostra sezione suggeriti</string>
+    <string name="up_next_group_by_airing_status">Raggruppa per stato di trasmissione</string>
+    <string name="up_next_sort_option_last_watched_first">Visti più di recente per primi</string>
+    <string name="up_next_sort_option_same_as_shows">Come per le serie</string>
+    <string name="up_next_sort_option_newest_first">Più recenti per primi</string>
+    <string name="up_next_sort_option_oldest_first">Più vecchi per primi</string>
 </resources>

--- a/composeApp/src/main/res/values-it/strings.xml
+++ b/composeApp/src/main/res/values-it/strings.xml
@@ -220,4 +220,13 @@
     <string name="unsupported_item_id">Id non supportato</string>
     <string name="unsupported_item_id_description">"L'elemento con id '%1$s' non è supportato da quest'app"</string>
     <string name="manage_item">Gestisci elemento</string>
+
+    <string name="up_next_section_suggested">Suggeriti</string>
+    <string name="up_next_section_airing_today">In onda oggi</string>
+    <string name="up_next_section_aired_recently">Trasmessi di recente</string>
+    <string name="up_next_section_airing_soon">In onda prossimamente</string>
+    <string name="up_next_section_aired">Trasmessi</string>
+    <string name="up_next_section_unknown_air_date">Data di trasmissione sconosciuta</string>
+    <string name="up_next_section_not_aired">Non ancora trasmessi</string>
+    <string name="up_next_section_other">Altro</string>
 </resources>

--- a/composeApp/src/main/res/values/settings.xml
+++ b/composeApp/src/main/res/values/settings.xml
@@ -59,4 +59,11 @@
     <string name="open_episode_behavior">When opening an episode</string>
     <string name="open_episode_behavior_highlight_in_season">Open the season and highlight the episode</string>
     <string name="open_episode_behavior_episode_details">Open the episode details</string>
+
+    <string name="up_next_enable_suggested_section">Enable suggested section</string>
+    <string name="up_next_group_by_airing_status">Group by airing status</string>
+    <string name="up_next_sort_option_last_watched_first">Last watched first</string>
+    <string name="up_next_sort_option_same_as_shows">Same as shows</string>
+    <string name="up_next_sort_option_newest_first">Newest first</string>
+    <string name="up_next_sort_option_oldest_first">Oldest first</string>
 </resources>

--- a/composeApp/src/main/res/values/strings.xml
+++ b/composeApp/src/main/res/values/strings.xml
@@ -215,4 +215,13 @@
     <string name="unsupported_item_id">Unsupported item id</string>
     <string name="unsupported_item_id_description">"The item with id '%1$s' is not supported by this app"</string>
     <string name="manage_item">Manage item</string>
+
+    <string name="up_next_section_suggested">Suggested</string>
+    <string name="up_next_section_airing_today">Airing today</string>
+    <string name="up_next_section_aired_recently">Aired recently</string>
+    <string name="up_next_section_airing_soon">Airing soon</string>
+    <string name="up_next_section_aired">Aired</string>
+    <string name="up_next_section_unknown_air_date">Unknown air date</string>
+    <string name="up_next_section_not_aired">Not aired</string>
+    <string name="up_next_section_other">Other</string>
 </resources>


### PR DESCRIPTION
This is heavily inspired by SeriesFad, however the `watchedAt` and `addedAt` are no longer conflated: 
 - Sorting by "last watched" and "last marked as watched" is split
 - Suggested section includes episodes where the previous one was either _watched_ in the last two weeks, or _marked as watched_ in the last day

Other sorting and grouping options and more or less the same.

This PR also implements automatic-scrolling of up-next: when an episode is marked as watched, if not already in the screen, the list is scrolled so the entry for the watch session is visible.  
When Sorting/grouping options change, the list remains scrolled at the top (this avoids for the lazy-column to automatically scroll around).

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/48200aab-054e-43a8-afec-7fcb12c250e6" />

[Screen_recording_20260811_213127.webm](https://github.com/user-attachments/assets/dff51fac-33a5-46f3-b2eb-d8937980da3d)

[Screen_recording_20260811_214701.webm](https://github.com/user-attachments/assets/6b3eb881-6eab-4566-bd1f-28c2af281955)